### PR TITLE
Release: 1.0.0-alpha02

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -22,9 +22,9 @@ import java.util.Properties
 
 // DMG distribution does not support "-alpha", MSI requires at least MAJOR.MINOR.BUILD
 val abysnerVersionBase = "1.0.0"
-val abysnerVersion = "$abysnerVersionBase-alpha"
+val abysnerVersion = "$abysnerVersionBase-alpha02"
 // iOS supports a String here, but Android only an integer
-val abysnerBuildNumber = 1
+val abysnerBuildNumber = 2
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)


### PR DESCRIPTION
**Compared to release 1.0.0-alpha(01):**

- Added: Cylinder planning
- Changed: warnings and critical warnings are displayed a bit nicer
- Added: Option to share plan as image