### PR TITLE
Release: 1.0.1-alpha

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -21,10 +21,10 @@ import java.io.ByteArrayOutputStream
 import java.util.Properties
 
 // DMG distribution does not support "-alpha", MSI requires at least MAJOR.MINOR.BUILD
-val abysnerVersionBase = "1.0.0"
-val abysnerVersion = "$abysnerVersionBase-alpha02"
+val abysnerVersionBase = "1.0.1"
+val abysnerVersion = "$abysnerVersionBase-alpha"
 // iOS supports a String here, but Android only an integer
-val abysnerBuildNumber = 2
+val abysnerBuildNumber = 3
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Apple does not allow the usage of 'alpha' in the app version, thus we have to use the patch section of the app version. So to keep things consistent I'm also changing this for Android.