### PR TITLE
Change: Show CNS and OTU values a bit more pronounced in the deco plan

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasDisplay.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasDisplay.kt
@@ -42,18 +42,21 @@ fun BigNumberDisplay(
 ) {
 
     val style = when (size) {
+        BigNumberSize.EXTRA_SMALL -> MaterialTheme.typography.headlineSmall
         BigNumberSize.SMALL -> MaterialTheme.typography.headlineMedium
         BigNumberSize.MEDIUM -> MaterialTheme.typography.displayMedium
         BigNumberSize.LARGE -> MaterialTheme.typography.displayLarge
     }
 
     val paddingHorizontal = when (size) {
+        BigNumberSize.EXTRA_SMALL -> 16.dp
         BigNumberSize.SMALL -> 16.dp
         BigNumberSize.MEDIUM -> 16.dp
         BigNumberSize.LARGE -> 16.dp
     }
 
     val paddingVertical = when (size) {
+        BigNumberSize.EXTRA_SMALL -> 8.dp
         BigNumberSize.SMALL -> 8.dp
         BigNumberSize.MEDIUM -> 16.dp
         BigNumberSize.LARGE -> 16.dp
@@ -118,6 +121,7 @@ fun BigNumberDisplay(
 }
 
 enum class BigNumberSize {
+    EXTRA_SMALL,
     SMALL,
     MEDIUM,
     LARGE

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/ShareImage.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/ShareImage.kt
@@ -52,6 +52,7 @@ import org.neotech.app.abysner.presentation.component.BigNumberDisplay
 import org.neotech.app.abysner.presentation.component.BigNumberSize
 import org.neotech.app.abysner.presentation.component.appendBold
 import org.neotech.app.abysner.presentation.preview.PreviewData
+import org.neotech.app.abysner.presentation.screens.planner.decoplan.DecoPlanOxygenToxicityDisplay
 import org.neotech.app.abysner.presentation.screens.planner.decoplan.DecoPlanTable
 import org.neotech.app.abysner.presentation.screens.planner.gasplan.CylindersTable
 import org.neotech.app.abysner.presentation.screens.planner.gasplan.GasLimitsTable
@@ -100,26 +101,11 @@ fun ShareImage(
                         settings = settingsModel
                     )
 
-                    Row(
+                    DecoPlanOxygenToxicityDisplay(
                         modifier = Modifier.padding(top = 16.dp).fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(
-                            16.dp,
-                            Alignment.CenterHorizontally
-                        ),
-                    ) {
-                        BigNumberDisplay(
-                            modifier = Modifier.width(96.dp),
-                            size = BigNumberSize.SMALL,
-                            value = "${divePlan.base.totalCns.format(0)}%",
-                            label = "CNS"
-                        )
-                        BigNumberDisplay(
-                            modifier = Modifier.width(96.dp),
-                            size = BigNumberSize.SMALL,
-                            value = divePlan.base.totalOtu.format(0),
-                            label = "OTU"
-                        )
-                    }
+                        cns = divePlan.base.totalCns,
+                        otu = divePlan.base.totalOtu
+                    )
 
                     // DecoPlanExtraInfo(
                     //     modifier = Modifier.padding(horizontal = 16.dp).padding(top = 16.dp),

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
@@ -19,6 +19,7 @@ import abysner.composeapp.generated.resources.ic_outline_trending_down_24
 import abysner.composeapp.generated.resources.ic_outline_trending_flat_24
 import abysner.composeapp.generated.resources.ic_outline_trending_up_24
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -27,6 +28,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
@@ -66,6 +68,9 @@ import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.settings.model.SettingsModel
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
 import org.neotech.app.abysner.domain.utilities.DecimalFormatter
+import org.neotech.app.abysner.domain.utilities.format
+import org.neotech.app.abysner.presentation.component.BigNumberDisplay
+import org.neotech.app.abysner.presentation.component.BigNumberSize
 import org.neotech.app.abysner.presentation.component.SingleChoiceSegmentedButtonRow
 import org.neotech.app.abysner.presentation.component.Table
 import org.neotech.app.abysner.presentation.component.TextWithStartIcon
@@ -155,6 +160,12 @@ fun DecoPlanCardComponent(
                         settings = settings
                     )
 
+                    DecoPlanOxygenToxicityDisplay(
+                        modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 16.dp).fillMaxWidth(),
+                        cns = planToShow.totalCns,
+                        otu = planToShow.totalOtu
+                    )
+
                     Row(
                         verticalAlignment = Alignment.Bottom
                     ) {
@@ -185,6 +196,31 @@ fun DecoPlanCardComponent(
                 }
             }
         }
+    }
+}
+
+@Composable
+fun DecoPlanOxygenToxicityDisplay(
+    cns: Double,
+    otu: Double,
+    modifier: Modifier
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        BigNumberDisplay(
+            modifier = Modifier.width(96.dp),
+            size = BigNumberSize.EXTRA_SMALL,
+            value = "${ceil(cns).format(0)}%",
+            label = "CNS"
+        )
+        BigNumberDisplay(
+            modifier = Modifier.width(96.dp),
+            size = BigNumberSize.EXTRA_SMALL,
+            value = ceil(otu).format(0),
+            label = "OTU"
+        )
     }
 }
 
@@ -239,20 +275,6 @@ fun DecoPlanExtraInfo(
                 style = MaterialTheme.typography.bodyMedium
             )
         }
-        Text(
-            text = buildAnnotatedString {
-                appendBold("CNS: ")
-                append("${DecimalFormat.format(0, ceil(divePlan.totalCns))}%")
-            },
-            style = MaterialTheme.typography.bodyMedium
-        )
-        Text(
-            text = buildAnnotatedString {
-                appendBold("OTU: ")
-                append(DecimalFormat.format(0, ceil(divePlan.totalOtu)))
-            },
-            style = MaterialTheme.typography.bodyMedium
-        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
@@ -50,7 +50,6 @@ import org.neotech.app.abysner.presentation.component.TextAlert
 import org.neotech.app.abysner.presentation.component.textfield.ExpandableText
 import org.neotech.app.abysner.presentation.screens.planner.decoplan.LoadingBoxWithBlur
 
-@OptIn(ExperimentalTextApi::class)
 @Composable
 fun GasPlanCardComponent(
     modifier: Modifier = Modifier,
@@ -109,7 +108,6 @@ fun GasPlanCardComponent(
                             gasRequirement = gasRequirements
                         )
                     }
-
 
                     Text(
                         modifier = Modifier.padding(top = 16.dp, bottom = 4.dp)


### PR DESCRIPTION
This also changes the CNS and OTU display in shared images (most notably the font size has slightly decreased).

Fixes: #11