### PR TITLE
Fix: Show both normal and deco PPO2 MOD

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPropertiesComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPropertiesComponent.kt
@@ -12,23 +12,30 @@
 
 package org.neotech.app.abysner.presentation.component
 
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.core.model.Salinity
+import org.neotech.app.abysner.domain.core.physics.ATMOSPHERIC_PRESSURE_AT_SEA_LEVEL
+import org.neotech.app.abysner.domain.utilities.format
+import org.neotech.app.abysner.presentation.theme.AbysnerTheme
 import kotlin.math.round
 
 @Composable
 fun GasPropertiesComponent(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     gas: Gas?,
     maxPPO2: Double,
+    maxPPO2Secondary: Double?,
     maxDensity: Double,
     environment: Environment,
     showTopRow: Boolean = true,
@@ -46,14 +53,16 @@ fun GasPropertiesComponent(
         nitrogenPercentage = EMPTY_PLACEHOLDER
     }
 
+    val showSecondaryPPO2 = maxPPO2Secondary != null && maxPPO2Secondary != maxPPO2
+
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         if(showTopRow) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 BigNumberDisplay(
@@ -72,7 +81,8 @@ fun GasPropertiesComponent(
                 )
             }
         }
-        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Row(modifier = Modifier.wrapContentHeight(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)) {
 
             val mod = gas?.let {
                 "${round(it.oxygenMod(maxPPO2, environment)).toInt()}m"
@@ -85,7 +95,7 @@ fun GasPropertiesComponent(
                         modifier = it,
                         size = BigNumberSize.SMALL,
                         value = mod,
-                        label = "Oxygen MOD"
+                        label = "O2 MOD (${maxPPO2.format(1)})",
                     )
                 },
                 back = {
@@ -97,6 +107,33 @@ fun GasPropertiesComponent(
                     )
                 }
             )
+
+            if(showSecondaryPPO2) {
+
+                val modSecondary = gas?.let {
+                    "${round(it.oxygenMod(maxPPO2Secondary!!, environment)).toInt()}m"
+                } ?: EMPTY_PLACEHOLDER
+
+                FlipCardComponent(
+                    modifier = Modifier.weight(0.3f),
+                    front = {
+                        BigNumberDisplay(
+                            modifier = it,
+                            size = BigNumberSize.SMALL,
+                            value = modSecondary,
+                            label = "O2 MOD (${maxPPO2Secondary!!.format(1)})",
+                        )
+                    },
+                    back = {
+                        BigNumberDisplay(
+                            modifier = it,
+                            size = BigNumberSize.SMALL,
+                            value = maxPPO2Secondary.toString(),
+                            label = "at PPO2",
+                        )
+                    }
+                )
+            }
 
             val densityMod = gas?.let {
                 "${round(it.densityMod(maxAllowedDensity = maxDensity, environment = environment)).toInt()}m"
@@ -122,27 +159,45 @@ fun GasPropertiesComponent(
                 }
             )
 
-            FlipCardComponent(
-                modifier = Modifier.weight(0.3f),
-                front = {
-                    BigNumberDisplay(
-                        modifier = it,
-                        size = BigNumberSize.SMALL,
-                        value = nitrogenPercentage,
-                        label = "Nitrogen"
-                    )
-                },
-                back = {
-                    BigNumberDisplay(
-                        modifier = it,
-                        size = BigNumberSize.SMALL,
-                        value = "\uD83E\uDD24",
-                        label = "Nitrogen"
-                    )
-                }
-            )
+            if(!showSecondaryPPO2) {
+                FlipCardComponent(
+                    modifier = Modifier.weight(0.3f),
+                    front = {
+                        BigNumberDisplay(
+                            modifier = it,
+                            size = BigNumberSize.SMALL,
+                            value = nitrogenPercentage,
+                            label = "Nitrogen"
+                        )
+                    },
+                    back = {
+                        BigNumberDisplay(
+                            modifier = it,
+                            size = BigNumberSize.SMALL,
+                            value = "\uD83E\uDD24",
+                            label = "Nitrogen"
+                        )
+                    }
+                )
+            }
         }
     }
 }
 
 private const val EMPTY_PLACEHOLDER = "…"
+
+@Preview
+@Composable
+private fun GasPropertiesComponentPreview() {
+    AbysnerTheme {
+        GasPropertiesComponent(
+            modifier = Modifier.wrapContentHeight(),
+            gas = Gas.Air,
+            maxPPO2 = 1.4,
+            maxPPO2Secondary = 1.6,
+            maxDensity = 6.8,
+            environment = Environment(Salinity.WATER_FRESH, ATMOSPHERIC_PRESSURE_AT_SEA_LEVEL),
+            showTopRow = true
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/SegmentedButtonRowComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/SegmentedButtonRowComponent.kt
@@ -13,6 +13,7 @@
 package org.neotech.app.abysner.presentation.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -43,7 +44,9 @@ fun <T> SingleChoiceSegmentedButtonRow(
     items: List<T>,
     singleChoiceSegmentedButtonRowState: SingleChoiceSegmentedButtonRowState = rememberSingleChoiceSegmentedButtonRowState(0),
     onClick: (item: T, index: Int) -> Unit =  { _, _ -> },
-    label: @Composable (item: T, index: Int) -> Unit
+    label: @Composable (item: T, index: Int) -> Unit = { item, _ ->
+        Text(text = item.toString(), maxLines = 1)
+    }
 ) {
     androidx.compose.material3.SingleChoiceSegmentedButtonRow(
         modifier = modifier

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
@@ -254,7 +254,8 @@ fun PlannerScreen(
                 isAdd = cylinderBeingEdited == null,
                 initialValue = cylinderBeingEdited,
                 environment = configuration.environment,
-                maxPPO2 = configuration.maxPPO2Deco,
+                maxPPO2 = configuration.maxPPO2,
+                maxPPO2Secondary = configuration.maxPPO2Deco,
                 onAddOrUpdateCylinder = {
                     if(cylinderBeingEdited != null) {
                         viewModel.updateCylinder(it)

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentPickerBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentPickerBottomSheet.kt
@@ -132,9 +132,10 @@ fun SegmentPickerBottomSheet(
 
                 GasPropertiesComponent(
                     modifier = Modifier.padding(vertical = 16.dp),
-                    gas = cylinder?.gas,
+                    gas = cylinder.gas,
                     maxDensity = maxDensity,
                     maxPPO2 = maxPPO2,
+                    maxPPO2Secondary = null,
                     environment = environment,
                     showTopRow = false,
                 )


### PR DESCRIPTION
When selecting a cylinder only the deco MOD was being shown, while it is not yet clear what this cylinder is going to be used for. So instead as kinda of a quick fix, the app now shows both MODs.

This also improves the gas properties display a bit, especially on smaller screens.

Fixes: #23