### PR TITLE
Refactor: Contingency planning

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/MultiChoiceSegmentedButtonRowComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/MultiChoiceSegmentedButtonRowComponent.kt
@@ -13,50 +13,51 @@
 package org.neotech.app.abysner.presentation.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 
 @Stable
-class SingleChoiceSegmentedButtonRowState(initialSelectedIndex: Int) {
-    var selectedIndex: Int by mutableIntStateOf(initialSelectedIndex)
+class MultiChoiceSegmentedButtonRowState(initialCheckedItemIndexes: Array<Int>) {
+    var checkedItemIndexes: SnapshotStateList<Int> = mutableStateListOf(*initialCheckedItemIndexes)
 }
 
 @Composable
-fun rememberSingleChoiceSegmentedButtonRowState(initialSelectedIndex: Int): SingleChoiceSegmentedButtonRowState {
+fun rememberMultiChoiceSegmentedButtonRowState(initialCheckedItemIndexes: Array<Int> = emptyArray()): MultiChoiceSegmentedButtonRowState {
     return remember {
-        SingleChoiceSegmentedButtonRowState(initialSelectedIndex)
+        MultiChoiceSegmentedButtonRowState(initialCheckedItemIndexes)
     }
 }
 
 @Composable
-fun <T> SingleChoiceSegmentedButtonRow(
+fun <T> MultiChoiceSegmentedButtonRow(
     modifier: Modifier = Modifier,
     items: List<T>,
-    singleChoiceSegmentedButtonRowState: SingleChoiceSegmentedButtonRowState = rememberSingleChoiceSegmentedButtonRowState(0),
-    onClick: (item: T, index: Int) -> Unit =  { _, _ -> },
+    multiChoiceSegmentedButtonRowState: MultiChoiceSegmentedButtonRowState = rememberMultiChoiceSegmentedButtonRowState(emptyArray()),
+    onChecked: (item: T, index: Int, checked: Boolean) -> Unit =  { _, _, _ -> },
     label: @Composable (item: T, index: Int) -> Unit = { item, _ ->
         Text(text = item.toString(), maxLines = 1)
     }
 ) {
-    androidx.compose.material3.SingleChoiceSegmentedButtonRow(
+    androidx.compose.material3.MultiChoiceSegmentedButtonRow(
         modifier = modifier
     ) {
         items.forEachIndexed { index, item ->
             SegmentedButton(
-                selected = index == singleChoiceSegmentedButtonRowState.selectedIndex,
-                onClick = {
-                    singleChoiceSegmentedButtonRowState.selectedIndex = index
-                    onClick(item, index)
+                checked = index in multiChoiceSegmentedButtonRowState.checkedItemIndexes,
+                onCheckedChange = {
+                    if (it) {
+                        multiChoiceSegmentedButtonRowState.checkedItemIndexes.add(index)
+                    } else {
+                        multiChoiceSegmentedButtonRowState.checkedItemIndexes.remove(index)
+                    }
+                    onChecked(item, index, it)
                 },
                 shape = SegmentedButtonDefaults.itemShape(index = index, count = items.size)
             ) {
@@ -68,10 +69,10 @@ fun <T> SingleChoiceSegmentedButtonRow(
 
 @Preview
 @Composable
-fun SingleChoiceSegmentedButtonRowPreview() {
-    SingleChoiceSegmentedButtonRow(
-        items = listOf("All", "Basics"),
-        onClick = { _, _ ->
+private fun MultiChoiceSegmentedButtonRowPreview() {
+    MultiChoiceSegmentedButtonRow(
+        items = listOf("+3min", "+3m"),
+        onChecked = { _, _, _ ->
 
         }
     ) { item, _ ->

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/SingleChoiceSegmentedButtonRowComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/SingleChoiceSegmentedButtonRowComponent.kt
@@ -1,0 +1,78 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2024 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.presentation.component
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+@Stable
+class SingleChoiceSegmentedButtonRowState(initialSelectedIndex: Int) {
+    var selectedIndex: Int by mutableIntStateOf(initialSelectedIndex)
+}
+
+@Composable
+fun rememberSingleChoiceSegmentedButtonRowState(initialSelectedIndex: Int): SingleChoiceSegmentedButtonRowState {
+    return remember {
+        SingleChoiceSegmentedButtonRowState(initialSelectedIndex)
+    }
+}
+
+@Composable
+fun <T> SingleChoiceSegmentedButtonRow(
+    modifier: Modifier = Modifier,
+    items: List<T>,
+    singleChoiceSegmentedButtonRowState: SingleChoiceSegmentedButtonRowState = rememberSingleChoiceSegmentedButtonRowState(0),
+    onClick: (item: T, index: Int) -> Unit =  { _, _ -> },
+    label: @Composable (item: T, index: Int) -> Unit = { item, _ ->
+        Text(text = item.toString(), maxLines = 1)
+    }
+) {
+    androidx.compose.material3.SingleChoiceSegmentedButtonRow(
+        modifier = modifier
+    ) {
+        items.forEachIndexed { index, item ->
+            SegmentedButton(
+                selected = index == singleChoiceSegmentedButtonRowState.selectedIndex,
+                onClick = {
+                    singleChoiceSegmentedButtonRowState.selectedIndex = index
+                    onClick(item, index)
+                },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = items.size)
+            ) {
+                label(item, index)
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SingleChoiceSegmentedButtonRowPreview() {
+    SingleChoiceSegmentedButtonRow(
+        items = listOf("All", "Basics"),
+        onClick = { _, _ ->
+
+        }
+    ) { item, _ ->
+        Text(text = item)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
@@ -37,7 +37,8 @@ object PreviewData {
             )
             return DivePlanSet(
                 base = divePlan,
-                deeperAndLonger = divePlan,
+                deeper = null,
+                longer = null,
                 gasPlan = gasPlan
             )
         }

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/ConfigurationSummeryDialog.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/ConfigurationSummeryDialog.kt
@@ -37,7 +37,7 @@ fun ConfigurationSummeryDialog(
         text = {
             Column {
                 Text(
-                    text = "Algorithm: ${configuration.algorithm.name}",
+                    text = "Algorithm: ${configuration.algorithm.shortName}",
                     style = MaterialTheme.typography.bodySmall
                 )
                 Text(

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
@@ -238,7 +238,10 @@ fun PlannerScreen(
                     divePlanSet = viewState.divePlanSet.getOrNull(),
                     settings = settings,
                     planningException = viewState.divePlanSet.exceptionOrNull(),
-                    isLoading = viewState.isLoading
+                    isLoading = viewState.isLoading,
+                    onContingencyInputChanged = { deeper, longer ->
+                        viewModel.setContingency(deeper, longer)
+                    }
                 )
                 GasPlanCardComponent(
                     isLoading = viewState.isLoading,

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraph.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraph.kt
@@ -117,7 +117,7 @@ fun DecoPlanGraph(
                 val label = when(it) {
                     0 -> "Depth"
                     1 -> "GF ceiling"
-                    2 -> "Avg. depth (running)"
+                    2 -> "Avg. depth"
                     else -> error("Unknown legend index")
                 }
                 Text(text = label, style = MaterialTheme.typography.bodySmall)

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/GasPieChart.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/GasPieChart.kt
@@ -130,8 +130,8 @@ fun GasPieChart(
             itemCount = arrayOf(emergencyExtra.isNotEmpty(), base.isNotEmpty()).count { it },
             label = {
                 val label = when(it) {
-                    0 -> "Baseline*"
-                    1 -> "Lost gas extra*"
+                    0 -> "Base*"
+                    1 -> "(Out-of-air)*"
                     else -> error("Unknown legend index")
                 }
                 Text(text = label, style = MaterialTheme.typography.bodyMedium)

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
@@ -12,6 +12,8 @@
 
 package org.neotech.app.abysner.presentation.screens.planner.gasplan
 
+import IconFont
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,24 +25,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import appendIcon
-import org.jetbrains.compose.ui.tooling.preview.Preview
-import org.neotech.app.abysner.domain.core.model.Cylinder
-import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
-import org.neotech.app.abysner.domain.core.model.Configuration
-import org.neotech.app.abysner.domain.diveplanning.DivePlanner
-import org.neotech.app.abysner.domain.gasplanning.GasPlanner
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanSet
-import org.neotech.app.abysner.presentation.screens.planner.decoplan.GasPieChart
-import org.neotech.app.abysner.presentation.getUserReadableMessage
-import org.neotech.app.abysner.presentation.theme.AbysnerTheme
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
 import org.neotech.app.abysner.domain.utilities.format
 import org.neotech.app.abysner.domain.utilities.higherThenDelta
@@ -48,7 +41,11 @@ import org.neotech.app.abysner.presentation.component.AlertSeverity
 import org.neotech.app.abysner.presentation.component.Table
 import org.neotech.app.abysner.presentation.component.TextAlert
 import org.neotech.app.abysner.presentation.component.textfield.ExpandableText
+import org.neotech.app.abysner.presentation.getUserReadableMessage
+import org.neotech.app.abysner.presentation.preview.PreviewData
+import org.neotech.app.abysner.presentation.screens.planner.decoplan.GasPieChart
 import org.neotech.app.abysner.presentation.screens.planner.decoplan.LoadingBoxWithBlur
+import org.neotech.app.abysner.presentation.theme.AbysnerTheme
 
 @Composable
 fun GasPlanCardComponent(
@@ -72,7 +69,17 @@ fun GasPlanCardComponent(
                 Text(
                     modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 16.dp),
                     style = MaterialTheme.typography.titleLarge,
-                    text = "Gas plan"
+                    text = buildAnnotatedString {
+                        append("Gas plan")
+                        withStyle(MaterialTheme.typography.titleSmall.toSpanStyle()) {
+                            if(divePlanSet?.isDeeper == true) {
+                                append(" +${divePlanSet.deeper}m")
+                            }
+                            if(divePlanSet?.isLonger == true) {
+                                append(" +${divePlanSet.longer}min")
+                            }
+                        }
+                    }
                 )
 
                 if (divePlanSet == null || divePlanSet.isEmpty) {
@@ -136,9 +143,10 @@ fun GasPlanCardComponent(
 
                     ExpandableText(
                         modifier = Modifier.padding(horizontal = 16.dp),
-                        text = "Note: All gas information is calculated based on the contingency (deeper & longer) plan:\n\n - 'Baseline' represents the gas requirement for a single diver to normally complete the contingency plan.\n\n - 'Lost gas extra' represents the extra gas that is needed for a safe ascent (including deco) should a buddy lose one or more gas mixes at the worst possible time during the dive (calculated using the out-of-air SAC rate). This lost-gas calculation assumes buddy breathing is possible, however with deco gasses this may not always be the case and you may have to take turns using the deco gas. No extra (bottom) gas is accounted for those situations! Also keep in mind that you need to plan your tanks carefully taking into account 'minimum functional pressure' of your regulators.",
+                        text = "Note: 'Base' represents the gas requirement for a single diver to normally complete the plan. 'Out-of-air' represents the extra gas that is needed for a safe ascent (including deco) should a buddy lose one or more gas mixes at the worst possible time during the dive (calculated using the out-of-air SAC rate). This out-of-air calculation assumes buddy breathing is possible, however with deco gasses this may not always be the case and you may have to take turns using the deco gas. No extra (bottom) gas is accounted for those situations! Also keep in mind that you need to plan your tanks carefully taking into account 'minimum functional pressure' of your regulators.",
                         style = MaterialTheme.typography.bodySmall.copy(fontStyle = FontStyle.Italic)
                     )
+
                 }
             }
         }
@@ -249,7 +257,7 @@ fun GasLimitsTable(
         }
     ) {
 
-        (divePlanSet.deeperAndLonger.maximumGasDensities + divePlanSet.base.maximumGasDensities)
+        (divePlanSet.base.maximumGasDensities)
             .distinct().sortedBy { it.gas.oxygenFraction }.forEach {
 
                 row {
@@ -302,21 +310,8 @@ fun GasLimitsTable(
 @Composable
 private fun GasPlanCardComponentPreview() {
     AbysnerTheme {
-
-        val divePlan = DivePlanner().apply {
-            configuration = Configuration()
-        }.getDecoPlan(
-            plan = listOf(
-                DiveProfileSection(16, 45, Cylinder.steel12Liter(Gas.Air)),
-                DiveProfileSection(16, 35, Cylinder.steel12Liter(Gas(0.28, 0.0))),
-            ),
-            decoGases = listOf(Cylinder.aluminium80Cuft(Gas.Oxygen50)),
-        )
-
-        val gasPlan = GasPlanner().calculateGasPlan(divePlan)
-
         GasPlanCardComponent(
-            divePlanSet = DivePlanSet(divePlan, divePlan, gasPlan),
+            divePlanSet = PreviewData.divePlan,
             planningException = null,
             isLoading = false
         )

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanSet.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanSet.kt
@@ -17,9 +17,14 @@ import org.neotech.app.abysner.domain.gasplanning.model.GasPlan
 
 data class DivePlanSet(
     val base: DivePlan,
-    val deeperAndLonger: DivePlan,
+    val deeper: Int?,
+    val longer: Int?,
     val gasPlan: GasPlan,
 ) {
+
+    val isDeeper = deeper != null
+    val isLonger = longer != null
+
     val configuration: Configuration = base.configuration
     val isEmpty: Boolean = base.isEmpty
 }


### PR DESCRIPTION
Instead of calculating 2 plans: 'base' and 'contingency' (a plan that is both deeper and longer). Now only 1 plan is calculated, this plan can however be adjusted by the user: the user can choose to either make the plan deeper or longer or both.

Now that there is essentially 1 plan (that may or may not be adjusted), the gas plan makes a bit more sense: as it always shows the amount of gas you need for this 1 plan (adjusted for deeper, longer, or both). The gas plan used to be always based on the deeper and longer plan, which could be confusing to users.