### PR TITLE
Refactor: offload bitmap and file handling to a background dispatcher

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/utilities/ShareExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/utilities/ShareExtensions.kt
@@ -14,4 +14,4 @@ package org.neotech.app.abysner.presentation.utilities
 
 import androidx.compose.ui.graphics.ImageBitmap
 
-expect fun shareImageBitmap(image: ImageBitmap)
+expect suspend fun shareImageBitmap(image: ImageBitmap)

--- a/composeApp/src/desktopMain/kotlin/org/neotech/app/abysner/presentation/utilities/ShareExtensions.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/org/neotech/app/abysner/presentation/utilities/ShareExtensions.desktop.kt
@@ -14,6 +14,6 @@ package org.neotech.app.abysner.presentation.utilities
 
 import androidx.compose.ui.graphics.ImageBitmap
 
-actual fun shareImageBitmap(image: ImageBitmap) {
+actual suspend fun shareImageBitmap(image: ImageBitmap) {
     TODO("Not yet implemented")
 }


### PR DESCRIPTION
This mostly seems to improve sharing on iOS (since the ViewController is now also created on the background dispatcher)