### PR TITLE
Release: 1.0.3-alpha

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -21,10 +21,10 @@ import java.io.ByteArrayOutputStream
 import java.util.Properties
 
 // DMG distribution does not support "-alpha", MSI requires at least MAJOR.MINOR.BUILD
-val abysnerVersionBase = "1.0.2"
+val abysnerVersionBase = "1.0.3"
 val abysnerVersion = "$abysnerVersionBase-alpha"
 // iOS supports a String here, but Android only an integer
-val abysnerBuildNumber = 4
+val abysnerBuildNumber = 5
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
- Changed: SAC rate is now increased to 20 l/min (#6)
- Changed: Contingency planning is now more flexible (#35)
  - Contingency plan can be chosen as a combination added depth, and/or added time.
  - Gas plan is now based on selected contingency options.
- Changed: CNS and OTU values displayed with more emphasis (#11)
- New: Option to easily pick standard gases (#8)
- New: Planned dive is now persisted (#2)
- New: 'Travel time' hint when editing a dive segment (#9)
- Fixed: Cylinder/gas picker now shows both deco and non-deco PPO2 (#23)
- Fixed: Cylinder dropdown showing all cylinders as the same size (#26)
- Improved: Empty cylinder alert and warning colors (#28)
- Improved: Share performance (#37)
