### PR TITLE
Release: 1.0.4-beta

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -20,11 +20,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.ByteArrayOutputStream
 import java.util.Properties
 
-// DMG distribution does not support "-alpha", MSI requires at least MAJOR.MINOR.BUILD
-val abysnerVersionBase = "1.0.3"
-val abysnerVersion = "$abysnerVersionBase-alpha"
+// DMG distribution does not support "-beta", MSI requires at least MAJOR.MINOR.BUILD
+val abysnerVersionBase = "1.0.4"
+val abysnerVersion = "$abysnerVersionBase-beta"
 // iOS supports a String here, but Android only an integer
-val abysnerBuildNumber = 5
+val abysnerBuildNumber = 6
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
This release does not contain any changes (compared to 1.0.3-alpha), except for dependency updates.