### PR TITLE
Fix: Incorrect numbers displayed for cylinder pressures

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
@@ -418,7 +418,7 @@ fun DecoPlanCardComponentPreview() {
         )
 
         DecoPlanCardComponent(
-            divePlanSet = DivePlanSet(base = divePlan, deeper = null, longer = null, gasPlan = GasPlan(emptyMap(), emptyMap())),
+            divePlanSet = DivePlanSet(base = divePlan, deeper = null, longer = null, gasPlan = emptyList()),
             settings = SettingsModel(),
             planningException = null,
             isLoading = false,

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/GasPieChart.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/GasPieChart.kt
@@ -52,9 +52,14 @@ fun GasPieChart(
     modifier: Modifier,
     gasRequirement: GasPlan
 ) {
-
-    val emergencyExtra = gasRequirement.extraRequiredForWorstCaseOutOfAirSorted
-    val base = gasRequirement.sortedBase
+    val emergencyExtra = gasRequirement.map {
+        it.gas to it.amountEmergencyExtra
+    }.sortedByDescending {
+        it.second
+    }
+    val base = gasRequirement.map {
+        it.gas to it.amount
+    }.sortedByDescending { it.second }
 
     val gas = base + emergencyExtra
 

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
@@ -181,7 +181,7 @@ fun CylindersTable(
     ) {
 
         val gasRequirements = divePlanSet.gasPlan
-        gasRequirements.total.forEachIndexed { index, (gas, volume) ->
+        gasRequirements.forEachIndexed { index, usage ->
             row {
                 Text(
                     modifier = Modifier.weight(0.1f),
@@ -189,19 +189,19 @@ fun CylindersTable(
                 )
                 Text(
                     modifier = Modifier.weight(0.2f),
-                    text = gas.gas.toString(),
+                    text = usage.gas.gas.toString(),
                 )
-                val size = DecimalFormat.format(1, gas.waterVolume)
+                val size = DecimalFormat.format(1, usage.gas.waterVolume)
                 Text(
                     modifier = Modifier.weight(0.2f),
                     text = size,
                 )
 
                 // TODO extract these values to a CylinderUsageModel? That is calculated as part of the gas plan?
-                val endPressureBase = gas.pressureAfter(volumeUsage = gasRequirements.sortedBase[index].second)
-                val endPressure = gas.pressureAfter(volumeUsage = volume)
+                val endPressureBase = usage.gas.pressureAfter(volumeUsage = usage.amount)
+                val endPressure = usage.gas.pressureAfter(volumeUsage = usage.amountTotal)
 
-                val startPressure = DecimalFormat.format(0, gas.pressure)
+                val startPressure = DecimalFormat.format(0, usage.gas.pressure)
 
                 var alertSeverity: AlertSeverity = AlertSeverity.NONE
                 val pressureText = buildAnnotatedString {

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
@@ -19,6 +19,7 @@ import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.gasplanning.model.GasPlan
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
+import org.neotech.app.abysner.domain.gasplanning.model.GasUsage
 import org.neotech.app.abysner.domain.utilities.mergeInto
 import org.neotech.app.abysner.domain.utilities.updateOrInsert
 import kotlin.math.max
@@ -90,7 +91,11 @@ class GasPlanner {
             scenario.mergeInto(extraRequiredForWorstCaseOutOfAir, ::max)
         }
 
-        return GasPlan(baseLine, extraRequiredForWorstCaseOutOfAir)
+        return baseLine.map {
+            // It may happen that for a specific gas no extra is required, hence the default to 0.0
+            // liters if that gas is not found.
+            GasUsage(it.key, it.value, extraRequiredForWorstCaseOutOfAir[it.key] ?: 0.0)
+        }
     }
 
     private fun List<DiveSegment>.calculateGasRequirementsPerCylinder(sac: Double, environment: Environment): Map<Cylinder, Double> {

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/model/GasPlan.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/model/GasPlan.kt
@@ -12,17 +12,4 @@
 
 package org.neotech.app.abysner.domain.gasplanning.model
 
-import org.neotech.app.abysner.domain.core.model.Cylinder
-import org.neotech.app.abysner.domain.core.model.Gas
-import org.neotech.app.abysner.domain.utilities.merge
-
-data class GasPlan(
-    val base: Map<Cylinder, Double>,
-    val extraRequiredForWorstCaseOutOfAir: Map<Cylinder, Double>
-) {
-
-    val sortedBase = base.toList().sortedByDescending { it.second }
-    val extraRequiredForWorstCaseOutOfAirSorted = extraRequiredForWorstCaseOutOfAir.toList().sortedByDescending { it.second }
-
-    val total = base.merge(extraRequiredForWorstCaseOutOfAir, Double::plus).toList().sortedByDescending { it.second }
-}
+typealias GasPlan = List<GasUsage>

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/model/GasUsage.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/model/GasUsage.kt
@@ -12,6 +12,21 @@
 
 package org.neotech.app.abysner.domain.gasplanning.model
 
-import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.core.model.Cylinder
 
-data class GasUsage(val gas: Gas, val amount: Double)
+data class GasUsage(
+    val gas: Cylinder,
+    /**
+     * Amount of gas used in liters at 1 ATA.
+     */
+    val amount: Double,
+    /**
+     * Amount of gas extra used in liters at 1 ATA.
+     */
+    val amountEmergencyExtra: Double
+) {
+    /**
+     * Amount of gas used in total (normal usage + emergency extra) in liters at 1 ATA.
+     */
+    val amountTotal = amount + amountEmergencyExtra
+}


### PR DESCRIPTION
This was caused by (wrongly) assuming 2 sorted lists were sorted exactly the same (by cylinder). This commit fixes the bug but also avoids working with multiple lists in the first place to hopefully avoid confusion in the future.

Fixes #59