### PR TITLE
Add: Nitrox 28% as standard gas

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
@@ -126,6 +126,7 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
         const val MAX_PPO2 = 1.6
 
         val Air = Gas(oxygenFraction = 0.21, heliumFraction = 0.0)
+        val Nitrox28 = Gas(oxygenFraction = 0.28, heliumFraction = 0.0)
         val Nitrox32 = Gas(oxygenFraction = 0.32, heliumFraction = 0.0)
         val Nitrox36 = Gas(oxygenFraction = 0.36, heliumFraction = 0.0)
         val Nitrox40 = Gas(oxygenFraction = 0.40, heliumFraction = 0.0)
@@ -143,7 +144,7 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
 
         val StandardGasses = listOf(
             Air,
-            Nitrox32, Nitrox36, Nitrox40,
+            Nitrox28, Nitrox32, Nitrox36, Nitrox40,
             Nitrox50, Nitrox80,
             Oxygen,
             Trimix3030,


### PR DESCRIPTION
Nitrox 28 (EAN28) is a commonly used gas mix, suitable for both recreational and technical diving. It allows for a deeper dives, such as those approaching 40m, while still reducing nitrogen absorption compared to air. This commit adds support for Nitrox28 in gas.kt model to reflect its practical use.