### PR TITLE
Refactor: Use pressure instead of length units for depth in internals

### DIFF
--- a/buildSrc/src/main/kotlin/abysner.jacoco-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/abysner.jacoco-conventions.gradle.kts
@@ -12,18 +12,6 @@
 
 import org.gradle.kotlin.dsl.jacoco
 
-/*
- * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
- *
- * Abysner is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License version 3,
- * as published by the Free Software Foundation.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see https://www.gnu.org/licenses/.
- */
-
 plugins {
     jacoco
 }

--- a/buildSrc/src/main/kotlin/org/neotech/gradle/GradleUtilities.kt
+++ b/buildSrc/src/main/kotlin/org/neotech/gradle/GradleUtilities.kt
@@ -1,0 +1,23 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2025 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.gradle
+
+import java.util.Locale
+
+fun String.capitalizeFirstCharacter(): String {
+    return if (isEmpty()) {
+        this
+    } else {
+        this[0].titlecase(Locale.getDefault()) + substring(1)
+    }
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -16,6 +16,8 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.neotech.gradle.capitalizeFirstCharacter
 import java.io.ByteArrayOutputStream
 import java.util.Properties
 
@@ -35,13 +37,11 @@ plugins {
 
 kotlin {
 
-    @OptIn(ExperimentalKotlinGradlePluginApi::class)
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
     androidTarget {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }
@@ -49,7 +49,6 @@ kotlin {
 
     // Do not really support desktop, but this is required to get previews working.
     jvm("desktop") {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
             freeCompilerArgs.add("-Xexpect-actual-classes")
@@ -216,11 +215,12 @@ dependencies {
     // This is the same as repeating:
     //     add(target, libs.kotlinInject.compilerKsp)
     // where `target` is "kspDesktop", "kspAndroid", "kspIosX64" "kspIosArm64" or "kspIosSimulatorArm64"
-    kotlin.targets.asSequence().filter {
+    val kotlinTargets: Sequence<KotlinTarget> = kotlin.targets.asSequence()
+    kotlinTargets.filter {
         // Don't add KSP for common target, only final platforms
         it.platformType != KotlinPlatformType.common
     }.forEach {
-        add("ksp${it.targetName.capitalized()}", libs.kotlinInject.compilerKsp)
+        add("ksp${it.targetName.capitalizeFirstCharacter()}", libs.kotlinInject.compilerKsp)
     }
 }
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -23,13 +23,11 @@ plugins {
 
 kotlin {
 
-    @OptIn(ExperimentalKotlinGradlePluginApi::class)
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
     androidTarget {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }
@@ -37,7 +35,6 @@ kotlin {
 
     // Pure JVM is suitable for Android and Desktop usage
     jvm {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
@@ -13,7 +13,7 @@
 package org.neotech.app.abysner.domain.core.model
 
 import org.neotech.app.abysner.domain.core.physics.barToDepthInMeters
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBars
+import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
 import kotlin.math.round
 
@@ -57,8 +57,8 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
         // Helium has a narc factor of 0 while N2 and O2 have a narc factor of 1
         val narcIndex = (this.oxygenFraction) + (this.nitrogenFraction)
 
-        val bars = depthInMetersToBars(depth, environment)
-        val equivalentBars = bars * narcIndex
+        val bars = depthInMetersToBar(depth, environment)
+        val equivalentBars = bars.value * narcIndex
         return barToDepthInMeters(equivalentBars, environment)
     }
 
@@ -70,8 +70,8 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
     }
 
     fun densityAtDepth(depth: Double, environment: Environment): Double {
-        val bar = depthInMetersToBars(depth, environment)
-        return density * bar
+        val bar = depthInMetersToBar(depth, environment)
+        return density * bar.value
     }
 
     /**

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/DecompressionModel.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/DecompressionModel.kt
@@ -13,6 +13,7 @@
 package org.neotech.app.abysner.domain.decompression.algorithm
 
 import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.core.physics.Pressure
 
 /**
  * A decompression model is allows adding dive sections to load tissues, and a method that returns
@@ -21,24 +22,29 @@ import org.neotech.app.abysner.domain.core.model.Gas
 interface DecompressionModel: Snapshotable {
 
     /**
-     * Add a flat section of the dive to the tissues, this is the same as calling [addDepthChange]
-     * with and equal start and end depth.
+     * Add a flat section of the dive to the tissues, this is the same as calling [addPressureChange]
+     * with and equal start and end pressure.
      *
-     * @see addDepthChange
+     * @param pressureAtDepth the pressure in bars at the current depth (including atmospheric pressure)
+     *
+     * @see addPressureChange
      */
-    fun addFlat(depth: Double, gas: Gas, timeInMinutes: Int) {
-        addDepthChange(depth, depth, gas, timeInMinutes)
+    fun addFlat(pressureAtDepth: Pressure, gas: Gas, timeInMinutes: Int) {
+        addPressureChange(pressureAtDepth, pressureAtDepth, gas, timeInMinutes)
     }
 
     /**
      * Add a descending, ascending or flat section of the dive to tissues.
      *
-     * @param startDepth start depth in meters from the surface.
-     * @param endDepth end depth in meters from the surface.
+     * @param startPressure start pressure (depth) in bars (including atmospheric pressure)
+     * @param endPressure end pressure (depth) in bars (including atmospheric pressure)
      * @param gas the gas being breathe by the diver during this section.
      * @param timeInMinutes the timeInMinutes this section takes.
      */
-    fun addDepthChange(startDepth: Double, endDepth: Double, gas: Gas, timeInMinutes: Int)
+    fun addPressureChange(startPressure: Pressure, endPressure: Pressure, gas: Gas, timeInMinutes: Int)
 
-    fun getCeiling(): Double
+    /**
+     * Returns the current tissue ceiling in bars (including atmospheric pressure)
+     */
+    fun getCeiling(): Pressure
 }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilities.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilities.kt
@@ -14,9 +14,7 @@ package org.neotech.app.abysner.domain.decompression.algorithm.buhlmann
 
 import org.neotech.app.abysner.domain.core.physics.asDegreesCelsiusToDegreesKelvin
 import org.neotech.app.abysner.domain.core.physics.asDegreesKelvinToDegreesCelsius
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBars
 import org.neotech.app.abysner.domain.core.physics.pascalToBar
-import org.neotech.app.abysner.domain.core.model.Environment
 import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.pow
@@ -65,17 +63,13 @@ internal fun waterVapourPressureInBars(degreesCelsius: Double): Double {
 }
 
 /**
- * Calculates the change in depth in bars per minute.
+ * Calculates the change in pressure in bars per minute.
  *
- * TODO: May want the input to this method to be in bars as well? This avoids having to work with a
- *       salinity and atmospheric pressure value here.
- *
- * @return the depth changes in bars per minute, positive if descending, negative if ascending.
+ * @return the pressure changes in bars per minute, positive if descending, negative if ascending.
  */
-internal fun depthChangeInBarsPerMinute(beginDepth: Double, endDepth: Double, timeInMinutes: Int, environment: Environment): Double {
+internal fun pressureChangeInBarsPerMinute(beginPressure: Double, endPressure: Double, timeInMinutes: Int): Double {
     require(timeInMinutes > 0) { "timeInMinutes must be a positive integer, instead got: $timeInMinutes." }
-    val speed = (endDepth - beginDepth) / timeInMinutes
-    return depthInMetersToBars(speed, environment) - environment.atmosphericPressure
+    return (endPressure - beginPressure) / timeInMinutes
 }
 
 /**

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
@@ -14,11 +14,11 @@ package org.neotech.app.abysner.domain.diveplanning.model
 
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.decompression.model.compactSimilarSegments
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBars
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
 import kotlin.math.ceil
 
@@ -63,7 +63,7 @@ data class DivePlan(
         val depth: Double,
         val environment: Environment,
     ) {
-        val ppo2 = gas.oxygenFraction * depthInMetersToBars(depth, environment)
+        val ppo2 = gas.oxygenFraction * depthInMetersToBar(depth, environment).value
         val density: Double = gas.densityAtDepth(depth, environment)
     }
 

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
@@ -14,7 +14,7 @@ package org.neotech.app.abysner.domain.gasplanning
 
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBars
+import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.gasplanning.model.GasPlan
@@ -108,8 +108,8 @@ class GasPlanner {
     private fun List<DiveSegment>.calculateGasRequirementsPerCylinder(sac: Double, environment: Environment): Map<Cylinder, Double> {
         val requiredLitersByGas = mutableMapOf<Cylinder, Double>()
         forEach {
-            val pressure = depthInMetersToBars(it.averageDepth, environment)
-            val sacAtDepth = sac * pressure
+            val pressure = depthInMetersToBar(it.averageDepth, environment)
+            val sacAtDepth = sac * pressure.value
             val liters = it.duration * sacAtDepth
             requiredLitersByGas.updateOrInsert(it.cylinder, liters) { currentValue, newValue ->
                 currentValue + newValue

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculator.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculator.kt
@@ -13,7 +13,7 @@
 package org.neotech.app.abysner.domain.gasplanning
 
 import org.neotech.app.abysner.domain.core.model.Environment
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBars
+import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import kotlin.math.exp
 import kotlin.math.pow
@@ -40,8 +40,8 @@ class OxygenToxicityCalculator {
     }
 
     private fun calculateCns(fO2: Double, startDepth: Double, endDepth: Double, environment: Environment, duration: Int): Double {
-        val avgDepth = depthInMetersToBars((startDepth + endDepth) / 2.0, environment)
-        val ppO2 = fO2 * avgDepth
+        val avgPressure = depthInMetersToBar((startDepth + endDepth) / 2.0, environment).value
+        val ppO2 = fO2 * avgPressure
 
         if(ppO2 <= MINIMUM_CNS_PPO2) {
             return 0.0
@@ -77,8 +77,8 @@ class OxygenToxicityCalculator {
 
     private fun calculateOtu(duration: Int, pO2: Double, startDepth: Double, endDepth: Double, environment: Environment): Double {
         var durationInMinutes = duration.toDouble()
-        val startAAP = depthInMetersToBars(startDepth, environment)
-        val endAAP = depthInMetersToBars(endDepth, environment)
+        val startAAP = depthInMetersToBar(startDepth, environment).value
+        val endAAP = depthInMetersToBar(endDepth, environment).value
         var ppo2Start = startAAP * pO2
         var ppo2End = endAAP * pO2
 

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/physics/PressureTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/physics/PressureTest.kt
@@ -22,10 +22,10 @@ class PressureTest {
     @Test
     fun testDepthInMetersToBars() {
         // 10 meters (pure water)
-        assertEquals(1.9939, depthInMetersToBars(10.0, Environment.Default), DOUBLE_TOLERANCE)
+        assertEquals(1.9939, depthInMetersToBar(10.0, Environment.Default).value, DOUBLE_TOLERANCE)
 
         // 24 meters (pure water)
-        assertEquals(3.3668, depthInMetersToBars(24.0, Environment.Default), DOUBLE_TOLERANCE)
+        assertEquals(3.3668, depthInMetersToBar(24.0, Environment.Default).value, DOUBLE_TOLERANCE)
     }
 
     @Test


### PR DESCRIPTION
This does a few things: avoids many conversions between pressure in bar and depth in meters (better performance), aids in supporting both metric and imperial units in the future, prepares for other feature like planning multiple dives and adding surface intervals.

Functionally nothing has changed, results remain the same.