### PR TITLE
Remove: Compose preview workaround in commonMain sources

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/BigNumberDisplay.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/BigNumberDisplay.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.component
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPickerComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPickerComponent.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.component
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPropertiesComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPropertiesComponent.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.component
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/MultiChoiceSegmentedButtonRowComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/MultiChoiceSegmentedButtonRowComponent.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.component
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.Text

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/SingleChoiceSegmentedButtonRowComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/SingleChoiceSegmentedButtonRowComponent.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.component
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.Text

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/TextAlertComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/TextAlertComponent.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.component
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/graphs/HorizontalGraphAxis.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/graphs/HorizontalGraphAxis.kt
@@ -12,8 +12,8 @@
 
 package org.neotech.app.abysner.presentation.component.graphs
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.desktop.ui.tooling.preview.PreviewWrapper
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.neotech.app.abysner.presentation.utilities.PreviewWrapper
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/AboutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/AboutScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/ShareImage.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/ShareImage.kt
@@ -14,7 +14,7 @@ package org.neotech.app.abysner.presentation.screens
 
 import abysner.composeapp.generated.resources.Res
 import abysner.composeapp.generated.resources.abysner_logo
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
@@ -18,7 +18,6 @@ import abysner.composeapp.generated.resources.ic_outline_tune_24
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
@@ -65,6 +64,7 @@ import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Gas

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/cylinders/CylinderPickerBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/cylinders/CylinderPickerBottomSheet.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.screens.planner.cylinders
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/cylinders/CylindersCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/cylinders/CylindersCard.kt
@@ -14,7 +14,7 @@ package org.neotech.app.abysner.presentation.screens.planner.cylinders
 
 import abysner.composeapp.generated.resources.Res
 import abysner.composeapp.generated.resources.ic_outline_propane_tank_24
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
@@ -18,7 +18,7 @@ import abysner.composeapp.generated.resources.ic_outline_stop_circle_24
 import abysner.composeapp.generated.resources.ic_outline_trending_down_24
 import abysner.composeapp.generated.resources.ic_outline_trending_flat_24
 import abysner.composeapp.generated.resources.ic_outline_trending_up_24
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraph.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraph.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.screens.planner.decoplan
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasBarChart.kt
@@ -12,8 +12,8 @@
 
 package org.neotech.app.abysner.presentation.screens.planner.gasplan
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.desktop.ui.tooling.preview.PreviewWrapper
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.neotech.app.abysner.presentation.utilities.PreviewWrapper
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.screens.planner.gasplan
 
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasUsageDetailsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasUsageDetailsDialog.kt
@@ -16,7 +16,7 @@ import abysner.composeapp.generated.resources.Res
 import abysner.composeapp.generated.resources.ic_baseline_check_circle_24
 import abysner.composeapp.generated.resources.ic_outline_dangerous_24
 import abysner.composeapp.generated.resources.ic_outline_warning_24
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentPickerBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentPickerBottomSheet.kt
@@ -16,7 +16,6 @@ import abysner.composeapp.generated.resources.Res
 import abysner.composeapp.generated.resources.segment_picker_travel_time_hint
 import abysner.composeapp.generated.resources.unit_meter
 import abysner.composeapp.generated.resources.unit_minute
-import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -50,6 +49,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentsCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentsCard.kt
@@ -16,7 +16,7 @@ import abysner.composeapp.generated.resources.Res
 import abysner.composeapp.generated.resources.ic_outline_propane_tank_24
 import abysner.composeapp.generated.resources.ic_outline_timer_24
 import abysner.composeapp.generated.resources.ic_outline_vertical_align_bottom_24
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/terms_and_conditions/TermsAndConditionsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/terms_and_conditions/TermsAndConditionsScreen.kt
@@ -13,7 +13,7 @@
 package org.neotech.app.abysner.presentation.screens.terms_and_conditions
 
 import abysner.composeapp.generated.resources.Res
-import androidx.compose.desktop.ui.tooling.preview.Preview
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/theme/Theme.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.presentation.theme
 
-import androidx.compose.desktop.ui.tooling.preview.PreviewWrapper
+import org.neotech.app.abysner.presentation.utilities.PreviewWrapper
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
@@ -36,6 +36,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 internal val LightColorScheme = lightColorScheme(
     primary = primaryLight,
@@ -177,7 +178,7 @@ private data class ColorPairing(
     val foreground: Color? = null,
 )
 
-@androidx.compose.desktop.ui.tooling.preview.Preview
+@Preview
 @Composable
 private fun ThemePreview() = PreviewWrapper {
     AbysnerTheme(darkTheme = true, dynamicColor = false) {

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/utilities/PreviewWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/utilities/PreviewWrapper.kt
@@ -10,27 +10,11 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-package androidx.compose.desktop.ui.tooling.preview
+package org.neotech.app.abysner.presentation.utilities
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
-
-/**
- * This is a copy of androidx.compose.desktop.ui.tooling.preview.Preview
- * to trick Android Studio (IntelliJ) into showing a gutter icon to get preview
- * capabilities in the commonMain source. It's not perfect, but better then nothing.
- *
- * See: https://github.com/JetBrains/compose-multiplatform/issues/2045
- */
-@MustBeDocumented
-@Retention(AnnotationRetention.BINARY)
-@Target(
-    AnnotationTarget.ANNOTATION_CLASS,
-    AnnotationTarget.FUNCTION
-)
-@Repeatable
-annotation class Preview
 
 /**
  * Improvised fix for: https://github.com/JetBrains/compose-multiplatform/issues/2852


### PR DESCRIPTION
Newer Android Studio versions support previews in commonMain, without workarounds using desktop preview annotations, the code now uses `org.jetbrains.compose.ui.tooling.preview.Preview` for annotating previews.