### PR TITLE
Release: 1.0.8-beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ xcuserdata
 # Storage file created by the app when running on desktop
 composeApp/configuration.preferences_pb
 composeApp/release/
-keystore.properties
-release-keystore
 .idea/gradle.xml
+
+# Signing info
+keystore.properties
+abysner-release.p12

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -23,10 +23,10 @@ import java.io.ByteArrayOutputStream
 import java.util.Properties
 
 // DMG distribution does not support "-beta", MSI requires at least MAJOR.MINOR.BUILD
-val abysnerVersionBase = "1.0.7"
+val abysnerVersionBase = "1.0.8"
 val abysnerVersion = "$abysnerVersionBase-beta"
 // iOS supports a String here, but Android only an integer
-val abysnerBuildNumber = 9
+val abysnerBuildNumber = 10
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -109,6 +109,7 @@ kotlin {
             implementation(compose.components.uiToolingPreview)
 
             implementation(compose.material3)
+            implementation(libs.jetbrains.compose.material.icons)
             implementation(libs.koalaplot.core)
 
             // Data storage
@@ -163,6 +164,7 @@ android {
                 storeFile = rootProject.file(it)
             }
             storePassword = keystoreProperties.getProperty("storePassword")
+            storeType = keystoreProperties.getProperty("storeType") ?: "JKS"
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ kotlinInject = "0.8.0"
 datastore = "1.1.7"
 
 # Navigation
-navigationCompose = "2.7.0-alpha07"
+navigationCompose = "2.8.0-alpha13"
 
 [libraries]
 # Testing
@@ -35,9 +35,13 @@ kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-
 # Navigation
 navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 
-# ViewModel
-jetbrains-lifecycle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version = "2.9.1" }
-jetbrains-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version = "2.9.1" }
+# ViewModel & Lifecycle
+# Note: 2.9.1 does not seem to be compatible with multiplatform 1.8.2, probably only compatible with 1.9.0 which is currently in beta)
+jetbrains-lifecycle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version = "2.8.4" }
+jetbrains-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version = "2.8.4" }
+
+# Material
+jetbrains-compose-material-icons = { module = "org.jetbrains.compose.material:material-icons-core", version = "1.7.3" }
 
 # Date & Time
 jetbrains-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.7.1"}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.7</string>
+	<string>1.0.8</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
This is a maintenance release. It contains mostly dependency updates and internal refactoring for upcoming features. In addition, it includes a few small feature changes, such as a higher default GF-low value and the addition of Nitrox 28 as a standard gas.