### PR TITLE
Improve: BitmapRenderRoot reliability and fix iOS share sheet

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/MainNavController.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/MainNavController.kt
@@ -30,6 +30,7 @@ import org.neotech.app.abysner.presentation.screens.terms_and_conditions.TermsAn
 import org.neotech.app.abysner.presentation.utilities.DestinationDefinition
 import org.neotech.app.abysner.presentation.utilities.NavHost
 import org.neotech.app.abysner.presentation.utilities.composable
+import androidx.compose.foundation.layout.Box
 import org.neotech.app.abysner.presentation.component.BitmapRenderRoot
 
 enum class Destinations(override val destinationName: String) : DestinationDefinition {
@@ -67,7 +68,8 @@ fun MainNavController(
 
     val navController = rememberNavController()
 
-    BitmapRenderRoot {
+    Box {
+        BitmapRenderRoot {
 
         NavHost(navController = navController, startDestination = startDestination) {
             composable(
@@ -118,5 +120,6 @@ fun MainNavController(
                 popExitTransition = { slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.End, tween()) }
             ) { termsAndConditionsScreen(navController) }
         }
+    }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/BitmapRenderComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/BitmapRenderComponent.kt
@@ -12,21 +12,18 @@
 
 package org.neotech.app.abysner.presentation.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.layout.layout
@@ -35,7 +32,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -70,12 +66,12 @@ class BitmapRenderController {
     }
 }
 
-val LocalBitmapRenderController = staticCompositionLocalOf {
-    BitmapRenderController()
+val LocalBitmapRenderController = staticCompositionLocalOf<BitmapRenderController> {
+    error("No BitmapRenderRoot found in the composition hierarchy.")
 }
 
 @Composable
-fun BitmapRenderRoot(content: @Composable () -> Unit) {
+fun BoxScope.BitmapRenderRoot(content: @Composable BoxScope.() -> Unit) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val render = remember { BitmapRenderController() }
 
@@ -93,24 +89,24 @@ fun BitmapRenderRoot(content: @Composable () -> Unit) {
         }
     }
 
-    val action = actionState.value
-    if (action != null) {
-        RenderBitmap(
-            width = action.width,
-            height = action.height,
-            onRendered = {
-                actionState.value = null
-                coroutineScope.launch {
-                    action.onComplete(it)
+    CompositionLocalProvider(LocalBitmapRenderController provides render) {
+        this@BitmapRenderRoot.content()
+
+        val action = actionState.value
+        if (action != null) {
+            RenderBitmap(
+                    width = action.width,
+                    height = action.height,
+                    onRendered = {
+                        actionState.value = null
+                        coroutineScope.launch {
+                            action.onComplete(it)
+                        }
+                    }
+                ) {
+                    action.composable.invoke()
                 }
             }
-        ) {
-            action.composable.invoke()
-        }
-    }
-
-    CompositionLocalProvider(LocalBitmapRenderController provides render) {
-        content()
     }
 }
 
@@ -122,7 +118,12 @@ private fun RenderBitmap(
     composable: @Composable () -> Unit,
 ) {
     val graphicsLayer = rememberGraphicsLayer()
-    var graphicsLayerDrawn by remember { mutableStateOf(false) }
+    // A CONFLATED channel is used to send a signal from the draw phase to the coroutine that is
+    // waiting for drawing to be completed. trySend() in drawWithContent is safe: it is non-blocking
+    // and does not mutate Compose state, so it cannot trigger recomposition from within the draw
+    // phase.
+    val drawChannel = remember { Channel<Unit>(Channel.CONFLATED) }
+
     Box(
         modifier = Modifier
             .layout { measurable, constraints ->
@@ -161,24 +162,28 @@ private fun RenderBitmap(
                     placeable.place(0, 0)
                 }
             }
-            .background(Color.Transparent)
             .drawWithContent {
+                // Draw into the graphics layer only, keeping this composable invisible on screen.
                 graphicsLayer.record {
                     this@drawWithContent.drawContent()
                 }
-                graphicsLayerDrawn = true
+                // Signal the coroutine (started and suspended below) that the draw has completed.
+                drawChannel.trySend(Unit)
             }
     ) {
         composable()
     }
 
-    if(graphicsLayerDrawn) {
-        LaunchedEffect(true) {
-            // Not sure if this is entirely save to do, but it seems to work regardless.
-            val bitmap = withContext(Dispatchers.IO) {
-                graphicsLayer.toImageBitmap()
-            }
-            onRendered(bitmap)
+    LaunchedEffect(Unit) {
+        // Wait for the first recorded frame before capturing.
+        drawChannel.receive()
+
+        // toImageBitmap() is CPU-bound rasterization (Skia Picture -> pixel buffer). It is probably
+        // safe to call off the main thread because all draw commands were already captured
+        // synchronously by graphicsLayer.record() above.
+        val bitmap = withContext(Dispatchers.Default) {
+            graphicsLayer.toImageBitmap()
         }
+        onRendered(bitmap)
     }
 }

--- a/composeApp/src/iosMain/kotlin/org/neotech/app/abysner/presentation/utilities/ShareExtensions.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/neotech/app/abysner/presentation/utilities/ShareExtensions.ios.kt
@@ -18,15 +18,14 @@ import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CValuesRef
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.refTo
+import kotlinx.cinterop.staticCFunction
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ColorSpace
 import org.jetbrains.skia.ColorType
 import org.jetbrains.skia.ImageInfo
 import platform.CoreGraphics.CGBitmapContextCreate
-import platform.CoreGraphics.CGBitmapContextCreateImage
 import platform.CoreGraphics.CGColorRenderingIntent
 import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
 import platform.CoreGraphics.CGColorSpaceRelease
@@ -59,12 +58,12 @@ import platform.posix.malloc
  * Which is licensed under Apache 2.0
  */
 @OptIn(ExperimentalForeignApi::class)
-fun ImageBitmap.toUiImage(): UIImage {
+fun ImageBitmap.toUiImage(scale: Double = 1.0): UIImage {
     val pixels = asSkiaBitmap().readPixels(
         ImageInfo(width, height, ColorType.RGBA_8888, ColorAlphaType.PREMUL, ColorSpace.sRGB)
     )!!
 
-    return createWithCGImage(pixels.refTo(0), width.toULong(), height.toULong())
+    return createWithCGImage(pixels.refTo(0), width.toULong(), height.toULong(), scale)
 }
 
 /**
@@ -72,7 +71,7 @@ fun ImageBitmap.toUiImage(): UIImage {
  * Which is licensed under Apache 2.0
  */
 @OptIn(ExperimentalForeignApi::class)
-private fun createWithCGImage(buffer: CValuesRef<ByteVar>, width: ULong, height: ULong): UIImage {
+private fun createWithCGImage(buffer: CValuesRef<ByteVar>, width: ULong, height: ULong, scale: Double): UIImage {
     val bufferLength = width * height * 4u
     val bitsPerComponent = 8uL
     val bitsPerPixel = 32uL
@@ -81,9 +80,9 @@ private fun createWithCGImage(buffer: CValuesRef<ByteVar>, width: ULong, height:
     val colorSpaceRef = CGColorSpaceCreateDeviceRGB()
     val bitmapInfo =
         kCGBitmapByteOrderDefault or CGImageAlphaInfo.kCGImageAlphaPremultipliedLast.value
-    val provider = CGDataProviderCreateWithData(null, buffer, bufferLength, null)
+    val srcProvider = CGDataProviderCreateWithData(null, buffer, bufferLength, null)
 
-    val iref = CGImageCreate(
+    val srcImage = CGImageCreate(
         width,
         height,
         bitsPerComponent,
@@ -91,7 +90,7 @@ private fun createWithCGImage(buffer: CValuesRef<ByteVar>, width: ULong, height:
         bytesPerRow,
         colorSpaceRef,
         bitmapInfo,
-        provider,
+        srcProvider,
         null,
         true,
         CGColorRenderingIntent.kCGRenderingIntentDefault
@@ -109,29 +108,50 @@ private fun createWithCGImage(buffer: CValuesRef<ByteVar>, width: ULong, height:
         bitmapInfo
     )!!
 
-    CGContextDrawImage(context, CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()), iref)
+    CGContextDrawImage(context, CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()), srcImage)
 
-    val imageRef = CGBitmapContextCreateImage(context)
+    // Release the source objects now that the draw is done.
+    CGImageRelease(srcImage)
+    CGContextRelease(context)
+    CGDataProviderRelease(srcProvider)
 
-    val scale = UIScreen.mainScreen.scale
+    // Create the final image with a release callback so Core Graphics frees the buffer when it is
+    // truly done with the pixel data.
+    val ownedProvider = CGDataProviderCreateWithData(
+        info = null,
+        data = pixels,
+        size = bufferLength,
+        releaseData = staticCFunction { _, data, _ -> free(data) }
+    )
+    val imageRef = CGImageCreate(
+        width,
+        height,
+        bitsPerComponent,
+        bitsPerPixel,
+        bytesPerRow,
+        colorSpaceRef,
+        bitmapInfo,
+        ownedProvider,
+        null,
+        true,
+        CGColorRenderingIntent.kCGRenderingIntentDefault
+    )
     val image = UIImage.imageWithCGImage(imageRef, scale, UIImageOrientation.UIImageOrientationUp)
 
     CGImageRelease(imageRef)
-    CGContextRelease(context)
+    CGDataProviderRelease(ownedProvider)
     CGColorSpaceRelease(colorSpaceRef)
-    CGImageRelease(iref)
-    CGDataProviderRelease(provider)
-    free(pixels)
     return image
 }
 
 actual suspend fun shareImageBitmap(image: ImageBitmap) {
+    // UIScreen.mainScreen must be read on the main thread.
+    val scale = UIScreen.mainScreen.scale
 
-    // Offload the file & bitmap handling a the IO dispatcher, including the creation of the
-    // UIActivityViewController, as that seems to take a long time to complete (more then a second
-    // sometimes).
-    val shareViewController: UIActivityViewController? = withContext(Dispatchers.IO) {
-        val uiImage: UIImage = image.toUiImage()
+    // Offload pixel conversion, PNG encoding and file writing to a background dispatcher.
+    // UIActivityViewController must be created and presented on the main thread.
+    val filePath: String? = withContext(Dispatchers.Default) {
+        val uiImage: UIImage = image.toUiImage(scale)
 
         val pngData: NSData? = UIImagePNGRepresentation(uiImage)
 
@@ -144,21 +164,25 @@ actual suspend fun shareImageBitmap(image: ImageBitmap) {
         val filePath = "$cachesDirectory/diveplan.png"
 
         if (pngData?.writeToFile(filePath, true) == true) {
-            UIActivityViewController(listOf(NSURL.fileURLWithPath(filePath)), null)
+            filePath
         } else {
             println("Error: Could not share image file because file could not be written or conversion to PNG failed.")
             null
         }
     }
 
-    if (shareViewController == null) {
+    if (filePath == null) {
         return
     }
 
-    val application = UIApplication.sharedApplication
-    application.keyWindow?.rootViewController?.presentViewController(
+    val shareViewController = UIActivityViewController(
+        activityItems = listOf(NSURL.fileURLWithPath(filePath)),
+        applicationActivities = null,
+    )
+
+    UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
         shareViewController,
         true,
-        null
+        null,
     )
 }


### PR DESCRIPTION
- Make BitmapRenderRoot a BoxScope extension so RenderBitmap is stacked as a Box overlay and cannot affect the layout of the main content
- Replace graphicsLayerDrawn state with a CONFLATED Channel to avoid recomposition from within the draw phase
- Make LocalBitmapRenderController default implementation throw instead of silently creating an unconnected controller
- Switch toImageBitmap() to Dispatchers.Default (task is CPU-bound not I/O)
- Fix UIScreen.mainScreen.scale read on a background thread
- Fix premature free(pixels) via a CGDataProvider release callback
- Offload pixel conversion, PNG encoding and file writing to Dispatchers.Default
- Create and present UIActivityViewController on the main thread