### PR TITLE
Fix: Use all available gas cylinders of the same gas mix for a gas plan

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/Table.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/Table.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -16,80 +16,119 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LocalAbsoluteTonalElevation
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
+/**
+ * A simple table. Use [TableScope.rows] / [TableScope.row] inside [content] to register
+ * rows, following the same DSL pattern as [androidx.compose.foundation.lazy.LazyColumn].
+ *
+ * **Performance:** the [content] builder runs on every recomposition, but it is plain (non-
+ * composable) code, no composition overhead per row during collection. Each row is identified
+ * by its [key][TableScope.rows] so Compose can correctly handle additions, removals and
+ * reorderings without recomposing unaffected rows.
+ */
 @Composable
 fun Table(
     modifier: Modifier = Modifier,
-    header: (@Composable RowScope.() -> Unit)?,
-    content: @Composable TableScope.() -> Unit
+    header: (@Composable RowScope.() -> Unit)? = null,
+    striped: Boolean = true,
+    defaultRowModifier: Modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
+    defaultHeaderModifier: Modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+    content: TableScope.() -> Unit,
 ) {
+    val rows = TableScopeInstance(defaultRowModifier).apply(content).rows
+
     Column(modifier) {
         if (header != null) {
-            TableHeader { header() }
-            Divider(color = MaterialTheme.colorScheme.outline, modifier = Modifier.height(1.dp))
+            TableHeader(modifier = defaultHeaderModifier) { header() }
+            HorizontalDivider()
         }
-
-        val items = mutableStateListOf<RowComposable>()
-
-        TableScopeInstance(items).apply {
-            CompositionLocalProvider(LocalTextStyle provides MaterialTheme.typography.bodyMedium) {
-                items.clear()
-                content()
-                items.forEach {
-                    it()
+        CompositionLocalProvider(LocalTextStyle provides MaterialTheme.typography.bodyMedium) {
+            rows.forEachIndexed { index, row ->
+                // Fall back to index so keyless rows never share the same Compose slot.
+                key(row.key ?: index) {
+                    val rowModifier = if (striped && index % 2 == 1) {
+                        Modifier.background(MaterialTheme.colorScheme.surfaceColorAtElevation(LocalAbsoluteTonalElevation.current + 2.dp))
+                    } else {
+                        Modifier
+                    }
+                    Row(rowModifier.then(row.modifier)) {
+                        row.content(this)
+                    }
                 }
             }
         }
     }
 }
 
-typealias RowComposable = @Composable () -> Unit
+internal class TableRow(
+    val key: Any?,
+    val modifier: Modifier,
+    val content: @Composable RowScope.() -> Unit,
+)
 
-internal class TableScopeInstance(private val items: SnapshotStateList<RowComposable>) :
-    TableScope {
+internal class TableScopeInstance(private val defaultRowModifier: Modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)) : TableScope {
+    val rows = mutableListOf<TableRow>()
 
-    @Composable
-    override fun row(modifier: Modifier, content: @Composable RowScope.() -> Unit) {
-        val color = if (items.size % 2 == 1) {
-            MaterialTheme.colorScheme.surfaceColorAtElevation(LocalAbsoluteTonalElevation.current + 2.dp)
-        } else {
-            Color.Transparent
+    override fun <T> rows(
+        items: List<T>,
+        key: ((T) -> Any)?,
+        modifier: Modifier?,
+        itemContent: @Composable RowScope.(T) -> Unit,
+    ) {
+        items.forEach { item ->
+            rows.add(TableRow(
+                key = key?.invoke(item),
+                modifier = modifier ?: defaultRowModifier,
+                content = { itemContent(item) },
+            ))
         }
-        val row: RowComposable = {
-            Row(
-                Modifier.background(color).then(modifier)
-                    .padding(horizontal = 4.dp, vertical = 2.dp)
-            ) {
-                content()
-            }
+    }
+
+    override fun <T> rowsIndexed(
+        items: List<T>,
+        key: ((Int, T) -> Any)?,
+        modifier: Modifier?,
+        itemContent: @Composable RowScope.(index: Int, item: T) -> Unit,
+    ) {
+        items.forEachIndexed { index, item ->
+            rows.add(TableRow(
+                key = key?.invoke(index, item),
+                modifier = modifier ?: defaultRowModifier,
+                content = { itemContent(index, item) },
+            ))
         }
-        items.add(row)
+    }
+
+    override fun row(key: Any?, modifier: Modifier?, content: @Composable RowScope.() -> Unit) {
+        rows.add(TableRow(key = key, modifier = modifier ?: defaultRowModifier, content = content))
+    }
+
+    override fun <T> row(key: Any?, item: T, modifier: Modifier?, content: @Composable RowScope.(T) -> Unit) {
+        rows.add(TableRow(key = key, modifier = modifier ?: defaultRowModifier, content = { content(item) }))
     }
 }
 
 interface TableScope {
+    fun <T> rows(items: List<T>, key: ((T) -> Any)? = null, modifier: Modifier? = null, itemContent: @Composable RowScope.(T) -> Unit)
 
-    @Composable
-    fun row(modifier: Modifier, content: @Composable RowScope.() -> Unit)
+    fun <T> rowsIndexed(items: List<T>, key: ((Int, T) -> Any)? = null, modifier: Modifier? = null, itemContent: @Composable RowScope.(index: Int, item: T) -> Unit)
 
-    @Composable
-    fun row(content: @Composable RowScope.() -> Unit) = row(Modifier, content)
+    fun row(key: Any? = null, modifier: Modifier? = null, content: @Composable RowScope.() -> Unit)
+
+    fun <T> row(key: Any? = null, item: T, modifier: Modifier? = null, content: @Composable RowScope.(T) -> Unit)
 }
 
 @Composable
@@ -104,7 +143,6 @@ private fun TableHeader(
     Row(
         modifier = modifier
             .background(MaterialTheme.colorScheme.secondaryContainer)
-            .padding(horizontal = 4.dp, vertical = 4.dp)
     ) {
         CompositionLocalProvider(LocalTextStyle provides textStyle) {
             content()

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -30,7 +30,7 @@ object PreviewData {
                 plan = persistentListOf(
                     DiveProfileSection(16, 45, Cylinder(gas = Gas.Air, pressure = 232.0, waterVolume = 12.0)),
                 ),
-                decoGases = persistentListOf(Cylinder.aluminium80Cuft(Gas.Nitrox50)),
+                cylinders = persistentListOf(Cylinder.aluminium80Cuft(Gas.Nitrox50)),
             )
 
             val gasPlan = GasPlanner().calculateGasPlan(

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
@@ -162,7 +162,7 @@ fun PlannerScreen(
 
                     SegmentsCardComponent(
                         segments = viewState.segments,
-                        addAllowed = viewState.availableGas.any { it.isChecked },
+                        addAllowed = viewState.availableGas.isNotEmpty(),
                         onAddSegment = {
                             segmentBeingEdited.value = null
                             showSegmentPickerBottomSheet.value = true
@@ -236,7 +236,7 @@ private fun ShowSegmentPickerBottomSheet(
             maxPPO2 = configuration.maxPPO2,
             maxDensity = Gas.MAX_GAS_DENSITY,
             environment = configuration.environment,
-            cylinders = viewState.availableGas.filter { it.isChecked }.map { it.cylinder }.toImmutableList(),
+            cylinders = viewState.availableGas.map { it.cylinder }.toImmutableList(),
             previousDepth = viewState.segments.getOrNull(previousIndex)?.depth?.toDouble() ?: 0.0,
             configuration = configuration,
             onAddOrUpdateDiveSegment = {

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -104,7 +104,11 @@ class PlanScreenViewModel(
     init {
         viewModelScope.launch(context = Dispatchers.IO) {
 
-            inputState.value = planningRepository.getDivePlanInput() ?: defaultDivePlanInputModel
+            val loaded = planningRepository.getDivePlanInput() ?: defaultDivePlanInputModel
+            inputState.value = loaded.copy(
+                // Cylinder locked state is not stored, so recalculate it.
+                cylinders = recomputeCylinderState(loaded.plannedProfile, loaded.cylinders)
+            )
             //delay(1000)
             isLoading.value = false
             inputState.debounce(1000).collectLatest {
@@ -117,10 +121,30 @@ class PlanScreenViewModel(
         }
     }
 
-    private fun updateCylinderUsage(segments: List<DiveProfileSection>, cylinders: List<PlannedCylinderModel>): List<PlannedCylinderModel> {
-        val inUse = segments.map { it.cylinder }
-        return cylinders.map {
-            it.copy(isInUse = inUse.contains(it.cylinder))
+    private fun recomputeCylinderState(segments: List<DiveProfileSection>, cylinders: List<PlannedCylinderModel>): List<PlannedCylinderModel> {
+        val gasesInUse = segments.gasesInUse()
+        val autoCheckedGases = mutableSetOf<Gas>()
+
+        val updated = cylinders.map { planned ->
+            val gas = planned.cylinder.gas
+            val shouldAutoCheck = gas in gasesInUse
+                && gas !in autoCheckedGases
+                && cylinders.checkedCylinderCountFor(gas) == 0
+
+            if (shouldAutoCheck) {
+                autoCheckedGases.add(gas)
+                planned.copy(isChecked = true)
+            } else {
+                planned
+            }
+        }
+
+        return updated.map { planned ->
+            planned.copy(
+                isLocked = planned.isChecked
+                    && planned.cylinder.gas in gasesInUse
+                    && updated.checkedCylinderCountFor(planned.cylinder.gas) == 1
+            )
         }
     }
 
@@ -131,7 +155,7 @@ class PlanScreenViewModel(
             }
             it.copy(
                 plannedProfile = newSegments,
-                cylinders = updateCylinderUsage(newSegments, it.cylinders)
+                cylinders = recomputeCylinderState(newSegments, it.cylinders)
             )
         }
     }
@@ -141,7 +165,7 @@ class PlanScreenViewModel(
             val newSegments = it.plannedProfile.plus(diveProfileSection)
             it.copy(
                 plannedProfile = newSegments,
-                cylinders = updateCylinderUsage(newSegments, it.cylinders)
+                cylinders = recomputeCylinderState(newSegments, it.cylinders)
             )
         }
     }
@@ -153,21 +177,22 @@ class PlanScreenViewModel(
             }
             it.copy(
                 plannedProfile = newSegments,
-                cylinders = updateCylinderUsage(newSegments, it.cylinders)
+                cylinders = recomputeCylinderState(newSegments, it.cylinders)
             )
         }
     }
 
     fun addCylinder(cylinder: Cylinder) {
         inputState.update {
+            val newCylinders = it.cylinders.plus(
+                PlannedCylinderModel(
+                    cylinder = cylinder,
+                    isChecked = false,
+                    isLocked = false
+                )
+            ).sortedBy { gas -> gas.cylinder.gas.oxygenFraction }
             it.copy(
-                cylinders = it.cylinders.plus(
-                    PlannedCylinderModel(
-                        cylinder = cylinder,
-                        isChecked = false,
-                        isInUse = false
-                    )
-                ).sortedBy { gas -> gas.cylinder.gas.oxygenFraction }
+                cylinders = recomputeCylinderState(it.plannedProfile, newCylinders)
             )
         }
     }
@@ -176,35 +201,39 @@ class PlanScreenViewModel(
         inputState.update { inputState ->
             val index = inputState.cylinders.indexOfFirst { it.cylinder.uniqueIdentifier == cylinder.uniqueIdentifier }
             val item = inputState.cylinders[index]
-            inputState.copy(
-                cylinders = inputState.cylinders.toMutableList().apply {
-                    set(index, item.copy(cylinder = cylinder))
-                },
-                plannedProfile = inputState.plannedProfile.map {
-                    if (it.cylinder.uniqueIdentifier == cylinder.uniqueIdentifier) {
-                        it.copy(cylinder = cylinder)
-                    } else {
-                        it
-                    }
+            val newCylinders = inputState.cylinders.toMutableList().apply {
+                set(index, item.copy(cylinder = cylinder))
+            }
+            val newProfile = inputState.plannedProfile.map {
+                if (it.cylinder.uniqueIdentifier == cylinder.uniqueIdentifier) {
+                    it.copy(cylinder = cylinder)
+                } else {
+                    it
                 }
+            }
+            inputState.copy(
+                cylinders = recomputeCylinderState(newProfile, newCylinders),
+                plannedProfile = newProfile
             )
         }
     }
 
     fun toggleCylinder(cylinder: Cylinder, enabled: Boolean) {
         inputState.update { inputState ->
-            if (inputState.plannedProfile.any { it.cylinder == cylinder }) {
-                // Cylinder is in used, do not allow toggle.
+            val currentModel = inputState.cylinders.find { it.cylinder == cylinder }
+            if (currentModel?.isLocked == true) {
+                // Last checked cylinder of a gas used in a segment — do not allow toggle.
                 inputState
             } else {
-                inputState.copy(
-                    cylinders = inputState.cylinders.map { pair ->
-                        if (pair.cylinder == cylinder) {
-                            pair.copy(isChecked = enabled)
-                        } else {
-                            pair
-                        }
+                val newCylinders = inputState.cylinders.map { pair ->
+                    if (pair.cylinder == cylinder) {
+                        pair.copy(isChecked = enabled)
+                    } else {
+                        pair
                     }
+                }
+                inputState.copy(
+                    cylinders = recomputeCylinderState(inputState.plannedProfile, newCylinders)
                 )
             }
         }
@@ -212,14 +241,16 @@ class PlanScreenViewModel(
 
     fun removeCylinder(gas: Cylinder) {
         inputState.update { inputState ->
-            if (inputState.plannedProfile.any { it.cylinder == gas }) {
-                // Cylinder is in used, do not allow removal.
+            val currentModel = inputState.cylinders.find { it.cylinder == gas }
+            if (currentModel?.isLocked == true) {
+                // Last checked cylinder of a gas used in a segment — do not allow removal.
                 inputState
             } else {
+                val newCylinders = inputState.cylinders.toMutableList().apply {
+                    removeAll { pair -> pair.cylinder == gas }
+                }
                 inputState.copy(
-                    cylinders = inputState.cylinders.toMutableList().apply {
-                        removeAll { pair -> pair.cylinder == gas }
-                    }
+                    cylinders = recomputeCylinderState(inputState.plannedProfile, newCylinders)
                 )
             }
         }
@@ -248,11 +279,11 @@ class PlanScreenViewModel(
                     )
                 }
 
-                val decoGasses = inputState.cylinders.filter { it.isChecked }.map { it.cylinder }
+                val cylinders = inputState.cylinders.filter { it.isChecked }.map { it.cylinder }
 
                 val adjustedPlan = planner.addDive(
                     plan = segmentsAdjusted,
-                    decoGases = decoGasses,
+                    cylinders = cylinders,
                 )
 
                 val gasPlan = GasPlanner().calculateGasPlan(adjustedPlan)
@@ -301,17 +332,17 @@ private val defaultCylinderAir = Cylinder.steel12Liter(gas = Gas.Air, pressure =
 private val defaultCylinders: List<PlannedCylinderModel> = listOf(
     PlannedCylinderModel(
         cylinder = defaultCylinderAir,
-        isInUse = true,
+        isLocked = true,
         isChecked = true
     ),
     PlannedCylinderModel(
         cylinder = Cylinder.aluminium80Cuft(gas = Gas.Nitrox50, pressure = 207.0),
-        isInUse = false,
+        isLocked = false,
         isChecked = true
     ),
     PlannedCylinderModel(
         cylinder = Cylinder.aluminium63Cuft(gas = Gas.Nitrox80, pressure = 207.0),
-        isInUse = false,
+        isLocked = false,
         isChecked = false
     )
 )
@@ -334,3 +365,10 @@ private val defaultDivePlanInputModel = DivePlanInputModel(
 
 
 private const val SUBSCRIPTION_TIME_OUT: Long = 5 * 60 * 1000
+
+private fun List<DiveProfileSection>.gasesInUse(): Set<Gas> =
+    mapTo(mutableSetOf()) { it.cylinder.gas }
+
+private fun List<PlannedCylinderModel>.checkedCylinderCountFor(gas: Gas): Int =
+    count { it.cylinder.gas == gas && it.isChecked }
+

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/cylinders/CylindersCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/cylinders/CylindersCard.kt
@@ -16,29 +16,45 @@ import abysner.composeapp.generated.resources.Res
 import abysner.composeapp.generated.resources.ic_outline_propane_tank_24
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Lock
+import com.mikepenz.markdown.compose.Markdown
+import com.mikepenz.markdown.m3.markdownColor
+import com.mikepenz.markdown.m3.markdownTypography
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
+import com.mikepenz.markdown.model.markdownPadding
 import org.jetbrains.compose.resources.painterResource
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
-import org.neotech.app.abysner.presentation.component.CheckableListItemComponent
 import org.neotech.app.abysner.presentation.component.IconAndTextButton
 import org.neotech.app.abysner.presentation.component.TextWithStartIcon
 import org.neotech.app.abysner.presentation.component.core.ifTrue
@@ -54,6 +70,12 @@ fun CylinderSelectionCardComponent(
     onCylinderChecked: (cylinder: Cylinder, checked: Boolean) -> Unit,
     onEditCylinder: (cylinder: Cylinder) -> Unit
 ) {
+    var showLockedExplanation by remember { mutableStateOf(false) }
+
+    if (showLockedExplanation) {
+        GasInUseDialog(onDismiss = { showLockedExplanation = false })
+    }
+
     Card(modifier = modifier) {
         Column(modifier = Modifier
             .padding(vertical = 16.dp)
@@ -64,68 +86,40 @@ fun CylinderSelectionCardComponent(
                 text = "Gas & cylinders"
             )
 
-            val grouped = gases.groupBy { it.isInUse }
-            val inUse = grouped[true] ?: emptyList()
-            val available = grouped[false] ?: emptyList()
-
-            if(inUse.isNotEmpty()) {
-                Text(
-                    modifier = Modifier.padding(horizontal = 16.dp).padding(top = 8.dp),
-                    style = MaterialTheme.typography.labelLarge,
-                    text = "In use"
+            gases.forEach { availableGas ->
+                CylinderListItemComponent(
+                    modifier = Modifier.clickable {
+                        onEditCylinder(availableGas.cylinder)
+                    },
+                    isChecked = availableGas.isChecked,
+                    isLocked = availableGas.isLocked,
+                    cylinder = availableGas.cylinder,
+                    onDelete = {
+                        onRemoveCylinder(availableGas.cylinder)
+                    },
+                    onChecked = { _, isCheckedChanged ->
+                        onCylinderChecked(availableGas.cylinder, isCheckedChanged)
+                    },
+                    onLockedClick = {
+                        showLockedExplanation = true
+                    }
                 )
-                inUse.forEach { availableGas ->
-                    CylinderListItemComponent(
-                        modifier = Modifier.clickable {
-                            onEditCylinder(availableGas.cylinder)
-                        },
-                        isChecked = availableGas.isChecked,
-                        isInUse = availableGas.isInUse,
-                        cylinder = availableGas.cylinder,
-                        onDelete = {
-                            onRemoveCylinder(availableGas.cylinder)
-                        },
-                        onChecked = { _, isCheckedChanged ->
-                            onCylinderChecked(availableGas.cylinder, isCheckedChanged)
-                        }
-                    )
-                }
-            }
-
-            if(available.isNotEmpty()) {
-                Text(
-                    modifier = Modifier.padding(horizontal = 16.dp).padding(top = 8.dp),
-                    style = MaterialTheme.typography.labelLarge,
-                    text = "Available"
-                )
-                available.forEach { availableGas ->
-                    CylinderListItemComponent(
-                        modifier = Modifier.clickable {
-                            onEditCylinder(availableGas.cylinder)
-                        },
-                        isChecked = availableGas.isChecked,
-                        isInUse = availableGas.isInUse,
-                        cylinder = availableGas.cylinder,
-                        onDelete = {
-                            onRemoveCylinder(availableGas.cylinder)
-                        },
-                        onChecked = { _, isCheckedChanged ->
-                            onCylinderChecked(availableGas.cylinder, isCheckedChanged)
-                        }
-                    )
-                }
             }
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.padding(horizontal = 16.dp).padding(top = 8.dp)
             ) {
-                Column(modifier = Modifier.weight(1f).padding(end = 16.dp)) {
-                    Text(
-                        text = "Note: Selected gases are available to the decompression algorithm.",
-                        style = MaterialTheme.typography.bodySmall.copy(fontStyle = FontStyle.Italic)
-                    )
+                val message = if (gases.isEmpty()) {
+                    "Add at least one cylinder to start planning your dive."
+                } else {
+                    "Checked cylinders are offered to the decompression algorithm for ascent planning."
                 }
+                Text(
+                    modifier = Modifier.weight(1f).padding(end = 16.dp),
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall.copy(fontStyle = FontStyle.Italic)
+                )
                 IconAndTextButton(
                     onClick = onAddCylinder,
                     text = "Add",
@@ -137,22 +131,76 @@ fun CylinderSelectionCardComponent(
 }
 
 @Composable
+private fun GasInUseDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Gas in use") },
+        text = {
+            Markdown(
+                modifier = Modifier.fillMaxWidth(),
+                content = """
+                    This cylinder's gas is **used in the dive profile** and cannot be unchecked or removed.
+                    
+                    **To free it up:**
+                    - Remove all segments using this gas.
+                    - Switch those segments to a different gas.
+                    - Add an additional cylinder with the same gas.
+                """.trimIndent(),
+                colors = markdownColor(),
+                padding = markdownPadding(
+                    list = 0.dp,
+                    block = 4.dp,
+                    listItemTop = 1.dp,
+                    listItemBottom = 1.dp,
+                ),
+                typography = markdownTypography(),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("OK")
+            }
+        }
+    )
+}
+
+@Composable
 fun CylinderListItemComponent(
     modifier: Modifier = Modifier,
     cylinder: Cylinder,
     isChecked: Boolean,
-    isInUse: Boolean,
+    isLocked: Boolean,
     onDelete: (cylinder: Cylinder) -> Unit = {},
     onChecked: (cylinder: Cylinder, isChecked: Boolean) -> Unit = { _, _ -> },
+    onLockedClick: () -> Unit = {},
 ) {
-    CheckableListItemComponent(
-        modifier = modifier,
-        enabled = !isInUse,
-        checked = isChecked,
-        onCheckedChanged = { onChecked(cylinder, it) }
-    ) {
+    val cylinderSuffix = " - ${DecimalFormat.format(0, cylinder.pressure)} bar (${DecimalFormat.format(1, cylinder.waterVolume)} l)"
 
-        val cylinderSuffix = " - ${DecimalFormat.format(0, cylinder.pressure)} bar (${DecimalFormat.format(1, cylinder.waterVolume)} l)"
+    Row(
+        modifier = modifier.padding(start = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 0.dp) {
+            if (isLocked) {
+                Box(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clickable { onLockedClick() },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Lock,
+                        contentDescription = "Gas in use",
+                        modifier = Modifier.alpha(0.38f)
+                    )
+                }
+            } else {
+                Checkbox(
+                    checked = isChecked,
+                    onCheckedChange = { onChecked(cylinder, it) }
+                )
+            }
+        }
 
         TextWithStartIcon(
             text = "${cylinder.gas}$cylinderSuffix",
@@ -163,10 +211,8 @@ fun CylinderListItemComponent(
         )
 
         IconButton(
-            enabled = !isInUse,
-            modifier = Modifier.ifTrue(isInUse) {
-                invisible()
-            },
+            enabled = !isLocked,
+            modifier = Modifier.ifTrue(isLocked) { invisible() },
             onClick = { onDelete(cylinder) }
         ) {
             Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete cylinder")
@@ -176,11 +222,19 @@ fun CylinderListItemComponent(
 
 @Preview
 @Composable
+private fun GasInUseDialogPreview() {
+    AbysnerTheme {
+        GasInUseDialog(onDismiss = {})
+    }
+}
+
+@Preview
+@Composable
 fun CylinderListItemComponentPreview() {
     AbysnerTheme {
         CylinderListItemComponent(
             isChecked = true,
-            isInUse = false,
+            isLocked = false,
             cylinder = Cylinder.steel12Liter(Gas.Air),
             onDelete = {},
             onChecked = { _, _ -> },
@@ -196,17 +250,17 @@ fun CylinderSelectionCardComponentPreview() {
             gases = listOf(
                 PlannedCylinderModel(
                     isChecked = true,
-                    isInUse = true,
+                    isLocked = true,
                     cylinder = Cylinder(gas = Gas.Air, 232.0, 12.0)
                 ),
                 PlannedCylinderModel(
                     isChecked = true,
-                    isInUse = false,
+                    isLocked = false,
                     cylinder = Cylinder(gas = Gas.Nitrox50, 207.0, 11.1)
                 ),
                 PlannedCylinderModel(
                     isChecked = false,
-                    isInUse = false,
+                    isLocked = false,
                     cylinder = Cylinder(gas = Gas.Nitrox80, 207.0, 9.0)
                 )
             ),

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -297,52 +297,38 @@ fun DecoPlanTable(
     divePlan: DivePlan,
     settings: SettingsModel,
 ) {
-    Table(modifier = modifier,
+
+    Table(
+        modifier = modifier,
         header = {
             TextWithStartIcon(
-                modifier = Modifier.weight(0.2f),
+                modifier = Modifier.weight(0.25f),
                 text = "Depth",
                 icon = ColorPainter(Color.Transparent),
             )
-            Text(
-                modifier = Modifier.weight(0.2f),
-                text = "Runtime",
-            )
-            Text(
-                modifier = Modifier.weight(0.2f),
-                text = "Duration",
-            )
-            TextWithStartIcon(
-                modifier = Modifier.weight(0.2f),
-                text = "Gas",
-                icon = ColorPainter(Color.Transparent),
-            )
+            Text(modifier = Modifier.weight(0.2f), text = "Runtime")
+            Text(modifier = Modifier.weight(0.2f), text = "Duration")
+            Text(modifier = Modifier.weight(0.15f), text = "Gas")
         }
     ) {
-
         val segments = divePlan.segmentsCollapsed
             .toMutableList()
             .compactSimilarSegments(compactAscentsBetweenDecoStops = settings.showBasicDecoTable)
 
-        segments.forEachIndexed { index, diveSegment ->
-
-            // For gas switch segments, resolve the target gas the diver is switching to, so the
-            // table reads as an instruction ("switch to Nx50") rather than showing the old gas that
-            // is used for the tissue loading calculation.
+        rowsIndexed(segments, key = { _, segment -> segment.start }) { index, diveSegment ->
+            // For gas switch segments show the gas the diver is switching to, rather than the gas
+            // currently being breathed. The actual switch happens at the end of the section, so the
+            // row reads as an instruction (e.g. "switch to Nx50").
             val displayGas = if (diveSegment.isGasSwitch) {
-                // Theoretically speaking this should not occur, a gas switch is never the last
-                // segment in a dive
                 segments.getOrNull(index + 1)?.cylinder?.gas ?: diveSegment.cylinder.gas
             } else {
                 diveSegment.cylinder.gas
             }
-            row {
-                DecoPlanRow(
-                    diveSegment = diveSegment,
-                    runtime = diveSegment.end,
-                    gas = displayGas,
-                )
-            }
+            DecoPlanRow(
+                diveSegment = diveSegment,
+                runtime = diveSegment.end,
+                gas = displayGas,
+            )
         }
     }
 }
@@ -381,7 +367,7 @@ private fun RowScope.DecoPlanRow(
     }
 
     TextWithStartIcon(
-        modifier = Modifier.weight(0.2f),
+        modifier = Modifier.weight(0.25f),
         text = diveSegment.endDepth.toString(),
         icon = painterResource(resource = typeIcon)
     )
@@ -393,9 +379,8 @@ private fun RowScope.DecoPlanRow(
         modifier = Modifier.weight(0.2f),
         text = "+${diveSegment.duration}",
     )
-
     Text(
-        modifier = Modifier.weight(0.2f),
+        modifier = Modifier.weight(0.15f),
         text = gas.toString(),
     )
 }
@@ -411,7 +396,7 @@ fun DecoPlanCardComponentPreview() {
             plan = listOf(
                 DiveProfileSection(16, 45, Cylinder(gas = Gas.Air, pressure = 232.0, waterVolume = 12.0)),
             ),
-            decoGases = listOf(Cylinder.aluminium80Cuft(Gas.Nitrox50)),
+            cylinders = listOf(Cylinder.aluminium80Cuft(Gas.Nitrox50)),
         )
 
         DecoPlanCardComponent(

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraph.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraph.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -246,7 +246,7 @@ private fun DecoPlanGraphPreview() {
 
                 ),
             alternativeAccents = persistentMapOf(),
-            decoGasses = persistentListOf(),
+            cylinders = persistentListOf(),
             configuration = Configuration(),
             totalCns = 0.0,
             totalOtu = 0.0

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasBarChart.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2025 Neotech
+ * Copyright (C) 2025-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -97,7 +97,7 @@ fun GasBarChartPreview() = PreviewWrapper {
 fun GasPlanBarChart(
     modifier: Modifier = Modifier,
     gasPlan: GasPlan,
-    onGasBarClicked: (CylinderGasRequirements) -> Unit = {},
+    onGasBarClicked: (Int, CylinderGasRequirements) -> Unit = { _, _ -> },
 ) {
     Column(modifier = modifier) {
         FlowLegend(
@@ -187,7 +187,7 @@ fun GasPlanBarChart(
                     modifier = Modifier.padding(end = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    gasPlan.forEachIndexed { index, gas ->
+                    gasPlan.forEach { gas ->
                         Text(
                             textAlign = TextAlign.Center,
                             modifier = Modifier.weight(1f)
@@ -213,11 +213,11 @@ fun GasPlanBarChart(
                     )
 
                 }, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    gasPlan.forEach {
+                    gasPlan.forEachIndexed { index, it ->
                         Box(contentAlignment = Alignment.Center) {
                             GasUsageBar(
                                 modifier = Modifier.height(36.dp).clickable {
-                                    onGasBarClicked(it)
+                                    onGasBarClicked(index, it)
                                 },
                                 cylinderGasRequirements = it,
                                 maxValue = max,

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2025 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -110,11 +110,10 @@ fun GasPlanCardComponent(
                 } else {
                     val gasRequirements = divePlanSet.gasPlan
 
+                    var showCylinderDetails: Int? by remember(gasRequirements) { mutableStateOf(null) }
 
-                    var showCylinderDetails: CylinderGasRequirements? by remember { mutableStateOf(null) }
-
-                    if (showCylinderDetails != null) {
-                        GasUsageDetailsDialog(showCylinderDetails!!) {
+                    showCylinderDetails?.let { index ->
+                        GasUsageDetailsDialog(gasPlan = gasRequirements, index = index) {
                             showCylinderDetails = null
                         }
                     }
@@ -122,22 +121,21 @@ fun GasPlanCardComponent(
                     GasPlanBarChart(
                         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                         gasPlan = gasRequirements,
-                    ) {
-                        showCylinderDetails = it
+                    ) { index, _ ->
+                        showCylinderDetails = index
                     }
 
-                    /*
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Center
-                    ) {
-                        GasPieChart(
-                            modifier = Modifier.widthIn(max = 350.dp),
-                            gasRequirement = gasRequirements
-                        )
-                    }
+                    Text(
+                        modifier = Modifier.padding(top = 16.dp, bottom = 4.dp)
+                            .padding(horizontal = 16.dp),
+                        text = "Totals (ℓ)",
+                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+                    )
 
-                     */
+                    GasTotalsTable(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        gasPlan = gasRequirements,
+                    )
 
                     Text(
                         modifier = Modifier.padding(top = 16.dp, bottom = 4.dp)
@@ -203,71 +201,85 @@ fun CylindersTable(
     Table(
         modifier = modifier,
         header = {
-            Text(
-                modifier = Modifier.weight(0.1f),
-                text = "No.",
-            )
-            Text(
-                modifier = Modifier.weight(0.15f),
-                text = "Mix",
-            )
-            Text(
-                modifier = Modifier.weight(0.2f),
-                text = "Size (ℓ)",
-            )
-            Text(
-                modifier = Modifier.weight(0.35f),
-                text = "Usage (bar)"
-            )
+            Text(modifier = Modifier.weight(0.3f), text = "Mix")
+            Text(modifier = Modifier.weight(0.3f), text = "Size (ℓ)")
+            Text(modifier = Modifier.weight(0.4f), text = "Usage (bar)")
         }
     ) {
+        rows(divePlanSet.gasPlan, key = { it.cylinder.uniqueIdentifier }) { usage ->
+            Text(
+                modifier = Modifier.weight(0.3f),
+                text = usage.cylinder.gas.toString(),
+            )
+            Text(
+                modifier = Modifier.weight(0.3f),
+                text = DecimalFormat.format(1, usage.cylinder.waterVolume),
+            )
 
-        val gasRequirements = divePlanSet.gasPlan
-        gasRequirements.forEachIndexed { index, usage ->
-            row {
-                Text(
-                    modifier = Modifier.weight(0.1f),
-                    text = (index + 1).toString(),
-                )
-                Text(
-                    modifier = Modifier.weight(0.15f),
-                    text = usage.cylinder.gas.toString(),
-                )
-                val size = DecimalFormat.format(1, usage.cylinder.waterVolume)
-                Text(
-                    modifier = Modifier.weight(0.2f),
-                    text = size,
-                )
+            // TODO extract these values to a CylinderUsageModel? That is calculated as part of the gas plan?
+            val endPressureBase = usage.cylinder.pressureAfter(volumeUsage = usage.normalRequirement)
+            val endPressure = usage.cylinder.pressureAfter(volumeUsage = usage.totalGasRequirement)
+            val startPressure = DecimalFormat.format(0, usage.cylinder.pressure)
 
-                // TODO extract these values to a CylinderUsageModel? That is calculated as part of the gas plan?
-                val endPressureBase = usage.cylinder.pressureAfter(volumeUsage = usage.normalRequirement)
-                val endPressure = usage.cylinder.pressureAfter(volumeUsage = usage.totalGasRequirement)
-
-                val startPressure = DecimalFormat.format(0, usage.cylinder.pressure)
-
-                var alertSeverity: AlertSeverity = AlertSeverity.NONE
-                val pressureText = buildAnnotatedString {
-                    if (endPressureBase == null && endPressure == null) {
-                        alertSeverity = AlertSeverity.ERROR
-                        append("$startPressure > empty")
-                        appendIcon(IconFont.WARNING)
-                    } else if(endPressure == null && endPressureBase != null) {
-                        alertSeverity = AlertSeverity.WARNING
-                        append("$startPressure > ${endPressureBase.format(0)} (")
-                        appendIcon(IconFont.WARNING)
-                        append("0)")
-                    } else {
-                        alertSeverity = AlertSeverity.NONE
-                        append("$startPressure > ${endPressureBase!!.format(0)} (${endPressure!!.format(0)})")
-                    }
+            var alertSeverity: AlertSeverity = AlertSeverity.NONE
+            val pressureText = buildAnnotatedString {
+                if (endPressureBase == null && endPressure == null) {
+                    alertSeverity = AlertSeverity.ERROR
+                    append("$startPressure > empty")
+                    appendIcon(IconFont.WARNING)
+                } else if (endPressure == null && endPressureBase != null) {
+                    alertSeverity = AlertSeverity.WARNING
+                    append("$startPressure > ${endPressureBase.format(0)} (")
+                    appendIcon(IconFont.WARNING)
+                    append("0)")
+                } else {
+                    alertSeverity = AlertSeverity.NONE
+                    append("$startPressure > ${endPressureBase!!.format(0)} (${endPressure!!.format(0)})")
                 }
-
-                TextAlert(
-                    modifier = Modifier.weight(0.35f),
-                    alertSeverity = alertSeverity,
-                    text = pressureText
-                )
             }
+
+            TextAlert(
+                modifier = Modifier.weight(0.4f),
+                alertSeverity = alertSeverity,
+                text = pressureText,
+            )
+        }
+    }
+}
+
+@Composable
+fun GasTotalsTable(
+    modifier: Modifier = Modifier,
+    gasPlan: List<CylinderGasRequirements>,
+) {
+    Table(
+        modifier = modifier,
+        header = {
+            Text(modifier = Modifier.weight(0.17f), text = "Mix")
+            Text(modifier = Modifier.weight(0.29f), text = "Available")
+            Text(modifier = Modifier.weight(0.19f), text = "Normal")
+            Text(modifier = Modifier.weight(0.27f), text = "Emergency")
+        }
+    ) {
+        rows(gasPlan.groupBy { it.cylinder.gas }.toList(), key = { (gas, _) -> gas }) { (gas, entries) ->
+            val totalNormal = entries.sumOf { it.normalRequirement }
+            val totalRequired = entries.sumOf { it.totalGasRequirement }
+            val totalCapacity = entries.sumOf { it.cylinder.capacity() }
+
+            val alertSeverity = when {
+                totalNormal > totalCapacity -> AlertSeverity.ERROR
+                totalRequired > totalCapacity -> AlertSeverity.WARNING
+                else -> AlertSeverity.NONE
+            }
+
+            Text(modifier = Modifier.weight(0.17f), text = gas.toString())
+            Text(modifier = Modifier.weight(0.29f), text = DecimalFormat.format(0, totalCapacity))
+            Text(modifier = Modifier.weight(0.19f), text = "-${DecimalFormat.format(0, totalNormal)}")
+            TextAlert(
+                modifier = Modifier.weight(0.27f),
+                alertSeverity = alertSeverity,
+                text = "-${DecimalFormat.format(0, totalRequired)}",
+            )
         }
     }
 }
@@ -280,71 +292,41 @@ fun GasLimitsTable(
     Table(
         modifier = modifier,
         header = {
-            Text(
-                modifier = Modifier.weight(0.15f),
-                text = "Mix",
-            )
-            Text(
-                modifier = Modifier.weight(0.3f),
-                text = "Depth (m)",
-            )
-            Text(
-                modifier = Modifier.weight(0.35f),
-                text = "Density (g/ℓ)",
-            )
-            Text(
-                modifier = Modifier.weight(0.2f),
-                text = "PPO2"
-            )
+            Text(modifier = Modifier.weight(0.2f), text = "Mix")
+            Text(modifier = Modifier.weight(0.3f), text = "Depth (m)")
+            Text(modifier = Modifier.weight(0.3f), text = "Density (g/ℓ)")
+            Text(modifier = Modifier.weight(0.2f), text = "PPO2")
         }
     ) {
+        rows(
+            divePlanSet.base.maximumGasDensities.distinct().sortedBy { it.gas.oxygenFraction },
+            key = { it.gas },
+        ) { gasAtDepth ->
+            Text(modifier = Modifier.weight(0.2f), text = gasAtDepth.gas.toString())
+            Text(modifier = Modifier.weight(0.3f), text = "${gasAtDepth.depth.toInt()}m")
 
-        (divePlanSet.base.maximumGasDensities)
-            .distinct().sortedBy { it.gas.oxygenFraction }.forEach {
-
-                row {
-                    Text(
-                        modifier = Modifier.weight(0.15f),
-                        text = it.gas.toString(),
-                    )
-
-                    Text(
-                        modifier = Modifier.weight(0.3f),
-                        text = "${it.depth.toInt()}m",
-                    )
-
-                    val density = DecimalFormat.format(2, it.density)
-
-                    val alertSeverityDensity =
-                        if (it.density.higherThenDelta(Gas.MAX_GAS_DENSITY, 0.01)) {
-                            AlertSeverity.ERROR
-                        } else if (it.density.higherThenDelta(Gas.MAX_RECOMMENDED_GAS_DENSITY, 0.01)) {
-                            AlertSeverity.WARNING
-                        } else {
-                            AlertSeverity.NONE
-                        }
-
-                    TextAlert(
-                        alertSeverity = alertSeverityDensity,
-                        modifier = Modifier.weight(0.35f),
-                        text = density,
-                    )
-
-                    val ppo2 = DecimalFormat.format(2, it.ppo2)
-                    val alertSeverityPPO2 =
-                        if (it.ppo2.higherThenDelta(Gas.MAX_PPO2, 0.01)) {
-                            AlertSeverity.ERROR
-                        } else {
-                            AlertSeverity.NONE
-                        }
-
-                    TextAlert(
-                        alertSeverity = alertSeverityPPO2,
-                        modifier = Modifier.weight(0.2f),
-                        text = ppo2,
-                    )
-                }
+            val alertSeverityDensity = when {
+                gasAtDepth.density.higherThenDelta(Gas.MAX_GAS_DENSITY, 0.01) -> AlertSeverity.ERROR
+                gasAtDepth.density.higherThenDelta(Gas.MAX_RECOMMENDED_GAS_DENSITY, 0.01) -> AlertSeverity.WARNING
+                else -> AlertSeverity.NONE
             }
+            TextAlert(
+                modifier = Modifier.weight(0.3f),
+                alertSeverity = alertSeverityDensity,
+                text = DecimalFormat.format(2, gasAtDepth.density),
+            )
+
+            val alertSeverityPPO2 = if (gasAtDepth.ppo2.higherThenDelta(Gas.MAX_PPO2, 0.01)) {
+                AlertSeverity.ERROR
+            } else {
+                AlertSeverity.NONE
+            }
+            TextAlert(
+                modifier = Modifier.weight(0.2f),
+                alertSeverity = alertSeverityPPO2,
+                text = DecimalFormat.format(2, gasAtDepth.ppo2),
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasUsageDetailsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasUsageDetailsDialog.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2025 Neotech
+ * Copyright (C) 2025-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -16,7 +16,6 @@ import abysner.composeapp.generated.resources.Res
 import abysner.composeapp.generated.resources.ic_baseline_check_circle_24
 import abysner.composeapp.generated.resources.ic_outline_dangerous_24
 import abysner.composeapp.generated.resources.ic_outline_warning_24
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,35 +28,42 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.gasplanning.model.CylinderGasRequirements
+import org.neotech.app.abysner.domain.gasplanning.model.GasPlan
+import kotlinx.collections.immutable.persistentListOf
 import org.neotech.app.abysner.domain.utilities.format
+import androidx.compose.ui.text.font.FontWeight
 import org.neotech.app.abysner.presentation.component.AlertSeverity
+import org.neotech.app.abysner.presentation.component.Table
 import org.neotech.app.abysner.presentation.component.appendBold
 import org.neotech.app.abysner.presentation.component.appendBoldLine
 import org.neotech.app.abysner.presentation.theme.onWarning
 import org.neotech.app.abysner.presentation.theme.warning
-
-@Preview
-@Composable
-private fun GasUsageDetailsDialogPreview() {
-    GasUsageDetailsDialog(cylinderGasRequirements = CylinderGasRequirements(Cylinder.steel12Liter(Gas.Air), 3000.0, 700.0)) {
-
-    }
-}
+import kotlin.math.roundToInt
 
 @Composable
 fun GasUsageDetailsDialog(
-    cylinderGasRequirements: CylinderGasRequirements,
+    gasPlan: GasPlan,
+    index: Int,
     onDismissRequest: () -> Unit
 ) {
+    val cylinderGasRequirements = gasPlan[index]
+    val sameMixCylinders = gasPlan.filter { it.cylinder.gas == cylinderGasRequirements.cylinder.gas }
+
     AlertDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
@@ -65,92 +71,147 @@ fun GasUsageDetailsDialog(
                 Text("OK")
             }
         },
-        title = { Text("Cylinder details") },
         text = {
             Column {
 
+                Text(
+                    modifier = Modifier.padding(bottom = 4.dp),
+                    text = "Cylinder details",
+                    style = MaterialTheme.typography.titleLarge
+                )
+
                 val capacity = cylinderGasRequirements.cylinder.capacity()
+                val labelWidthState = remember { mutableIntStateOf(0) }
 
-                val litersRequiredTotalFormatted = "${cylinderGasRequirements.totalGasRequirement.format(0)} liters"
-                val litersAvailableTotal = "${capacity.format(0)} liters"
-                val litersUnusedTotal = "${(capacity - cylinderGasRequirements.totalGasRequirement).format(0)} liters"
-
-                Text(
-                    text = buildAnnotatedString {
-                        appendBold("Contents: ")
-                        appendLine("${cylinderGasRequirements.cylinder.gas} (${cylinderGasRequirements.cylinder.gas.diveIndustryName()})")
-                        appendBold("Volume: ")
-                        appendLine("${cylinderGasRequirements.cylinder.waterVolume.format(1)} liters")
-                        appendBold("Pressure: ")
-                        appendLine("${cylinderGasRequirements.cylinder.pressure.format(0)} bar")
-                        appendBold("Available gas: ")
-                        append("${cylinderGasRequirements.cylinder.capacity().format(0)} liters")
-                    },
-                    style = MaterialTheme.typography.bodyMedium
-                )
-
-                Text(
-                    modifier = Modifier.padding(top = 8.dp),
-                    text = "Gas Required",
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = buildAnnotatedString {
-                        appendBold("Normal: ")
-                        appendLine("${cylinderGasRequirements.normalRequirement.format(0)} liters")
-                        appendBold("Emergency: ")
-                        appendLine("${cylinderGasRequirements.totalGasRequirement.format(0)} liters")
-                        if(cylinderGasRequirements.pressureLeftWithEmergency != null) {
-                            appendBold("Unused: ")
-                            append(litersUnusedTotal)
-                        }
-                    },
-                    style = MaterialTheme.typography.bodyMedium
-                )
-
-                var severity = AlertSeverity.NONE
-
-                // Summery
-                val summery = if(cylinderGasRequirements.pressureLeft == null) {
-
-                    severity = AlertSeverity.ERROR
-
-                    buildAnnotatedString {
-                        // Critical gas shortage message
-                        appendBoldLine("This cylinder has a critical gas shortage!")
-                        append("You need a total of ")
-                        appendBold(litersRequiredTotalFormatted)
-                        append(" to finish the dive, but this cylinder only has ")
-                        appendBold(litersAvailableTotal)
-                        append("!")
+                // Cylinder-specific info
+                Table(striped = false, defaultRowModifier = Modifier.padding(vertical = 1.dp)) {
+                    row {
+                        Text(
+                            modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
+                            text = "Contents", fontWeight = FontWeight.Bold
+                        )
+                        Text(modifier = Modifier.weight(1f), text = "${cylinderGasRequirements.cylinder.gas} (${cylinderGasRequirements.cylinder.gas.diveIndustryName()})")
                     }
-                } else if(cylinderGasRequirements.pressureLeftWithEmergency == null) {
-
-                    severity = AlertSeverity.WARNING
-
-                    buildAnnotatedString {
-                        // Gas shortage with emergency context
-                        appendBoldLine("This cylinder has a gas shortage!")
-                        append("You need a total of ")
-                        appendBold(litersRequiredTotalFormatted)
-                        append(" to finish the dive, but you only have ")
-                        appendBold(litersAvailableTotal)
-                        append(". Without accounting for emergencies, this cylinder would have enough gas, but you should prepare for unexpected situations.")
+                    row {
+                        Text(
+                            modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
+                            text = "Volume", fontWeight = FontWeight.Bold
+                        )
+                        Text(modifier = Modifier.weight(1f), text = "${cylinderGasRequirements.cylinder.waterVolume.format(1)} ℓ")
                     }
+                    row {
+                        Text(
+                            modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
+                            text = "Pressure", fontWeight = FontWeight.Bold
+                        )
+                        Text(modifier = Modifier.weight(1f), text = "${cylinderGasRequirements.cylinder.pressure.format(0)} bar")
+                    }
+                    row {
+                        Text(
+                            modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
+                            text = "Available gas", fontWeight = FontWeight.Bold
+                        )
+                        Text(modifier = Modifier.weight(1f), text = "${capacity.format(0)} ℓ")
+                    }
+                }
+
+                val totalNormal = sameMixCylinders.sumOf { it.normalRequirement }
+                val totalRequired = sameMixCylinders.sumOf { it.totalGasRequirement }
+                val totalCapacity = sameMixCylinders.sumOf { it.cylinder.capacity() }
+
+                val showTotals = sameMixCylinders.size > 1
+
+                Text(
+                    modifier = Modifier.padding(top = 16.dp, bottom = 4.dp),
+                    text = "Required for dive",
+                    style = MaterialTheme.typography.titleLarge
+                )
+                Table(striped = false, defaultRowModifier = Modifier.padding(vertical = 1.dp)) {
+                    row {
+                        Text(
+                            modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
+                            text = "Normal", fontWeight = FontWeight.Bold
+                        )
+                        Text(modifier = Modifier.weight(1f), text = "${totalNormal.format(0)} ℓ")
+                    }
+                    row {
+                        Text(
+                            modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
+                            text = "Emergency", fontWeight = FontWeight.Bold
+                        )
+                        Text(modifier = Modifier.weight(1f), text = "${totalRequired.format(0)} ℓ")
+                    }
+                    row {
+                        Text(
+                            modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
+                            text = "Available", fontWeight = FontWeight.Bold
+                        )
+                        Text(modifier = Modifier.weight(1f), text = "${totalCapacity.format(0)} ℓ")
+                    }
+                }
+
+                // Coverage percentage, only shown if multiple cylinders of the same mix make up the total capacity
+                if (showTotals) {
+                    val coveragePercent = (capacity / totalCapacity * 100).roundToInt()
+                    val cylinderIndex = sameMixCylinders.indexOf(cylinderGasRequirements) + 1
+                    val gasName = cylinderGasRequirements.cylinder.gas.toString()
+                    Text(
+                        modifier = Modifier.padding(top = 4.dp),
+                        text = "This cylinder ($cylinderIndex out of ${sameMixCylinders.size}) covers $coveragePercent% of the $gasName mix requirement.",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+
+                val totalCapacityFormatted = "${totalCapacity.format(0)} ℓ"
+
+                // Bar pressure for a single cylinder (what divers read on gauges), liters for
+                // multiple cylinders (no meaningful single pressure to show).
+                val unusedNormalFormatted = if (showTotals) {
+                    "${(totalCapacity - totalNormal).format(0)} ℓ"
                 } else {
+                    "${cylinderGasRequirements.pressureLeft?.format(0)} bar"
+                }
+                val unusedEmergencyFormatted = if (showTotals) {
+                    "${(totalCapacity - totalRequired).format(0)} ℓ"
+                } else {
+                    "${cylinderGasRequirements.pressureLeftWithEmergency?.format(0)} bar"
+                }
 
-                    severity = AlertSeverity.POSITIVE
+                val severity = when {
+                    totalNormal > totalCapacity -> AlertSeverity.ERROR
+                    totalRequired > totalCapacity -> AlertSeverity.WARNING
+                    else -> AlertSeverity.POSITIVE
+                }
 
-                    val pressureAfterFinishingDiveNormally = "${cylinderGasRequirements.pressureLeft!!.format(0)} bar"
-                    val pressureAfterFinishingDiveAbnormally = "${cylinderGasRequirements.pressureLeftWithEmergency!!.format(0)} bar"
-
-                    buildAnnotatedString {
-                        appendBoldLine("This cylinder has enough gas for the dive, even if an emergency occurs.")
-                        append("After finishing normally, you will have about ")
-                        appendBold(pressureAfterFinishingDiveNormally)
-                        append(" left. In case of an emergency, this will be about ")
-                        appendBold(pressureAfterFinishingDiveAbnormally)
-                        append(".")
+                val alertMessage = buildAnnotatedString {
+                    when (severity) {
+                        AlertSeverity.ERROR -> {
+                            if (showTotals) appendBoldLine("Together, these ${sameMixCylinders.size} cylinders have a critical gas shortage!")
+                            else appendBoldLine("This cylinder has a critical gas shortage!")
+                            append("You need at least ")
+                            appendBold("${totalNormal.format(0)} ℓ")
+                            append(if (showTotals) " for the dive, but only have a combined " else " for the dive, but only have ")
+                            appendBold(totalCapacityFormatted)
+                            append(".")
+                        }
+                        AlertSeverity.WARNING -> {
+                            if (showTotals) appendBoldLine("Together, these ${sameMixCylinders.size} cylinders have a gas shortage!")
+                            else appendBoldLine("This cylinder has a gas shortage!")
+                            append("You need ")
+                            appendBold("${totalRequired.format(0)} ℓ")
+                            append(if (showTotals) " in case of an emergency, but only have a combined " else " in case of an emergency, but only have ")
+                            appendBold(totalCapacityFormatted)
+                            append(". Without emergencies, there is enough gas.")
+                        }
+                        AlertSeverity.POSITIVE, AlertSeverity.NONE -> {
+                            if (showTotals) appendBoldLine("Together, these ${sameMixCylinders.size} cylinders have enough gas for the dive, even in an emergency.")
+                            else appendBoldLine("This cylinder has enough gas for the dive, even in an emergency.")
+                            append("After a normal dive about ")
+                            appendBold(unusedNormalFormatted)
+                            append(" remains, and about ")
+                            appendBold(unusedEmergencyFormatted)
+                            append(" after an emergency.")
+                        }
                     }
                 }
 
@@ -163,19 +224,19 @@ fun GasUsageDetailsDialog(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        if(severity != AlertSeverity.NONE) {
+                        if (severity != AlertSeverity.NONE) {
                             Icon(
                                 painter = when (severity) {
-                                    AlertSeverity.NONE -> painterResource(Res.drawable.ic_baseline_check_circle_24)
                                     AlertSeverity.POSITIVE -> painterResource(Res.drawable.ic_baseline_check_circle_24)
                                     AlertSeverity.WARNING -> painterResource(Res.drawable.ic_outline_warning_24)
                                     AlertSeverity.ERROR -> painterResource(Res.drawable.ic_outline_dangerous_24)
+                                    AlertSeverity.NONE -> painterResource(Res.drawable.ic_baseline_check_circle_24)
                                 },
                                 contentDescription = null
                             )
                         }
                         Text(
-                            text = summery,
+                            text = alertMessage,
                             style = MaterialTheme.typography.bodySmall
                         )
                     }
@@ -184,6 +245,19 @@ fun GasUsageDetailsDialog(
         }
     )
 }
+
+private fun Modifier.uniformLabelWidth(
+    state: MutableIntState,
+): Modifier = onSizeChanged { state.intValue = maxOf(state.intValue, it.width) }
+    .layout { measurable, constraints ->
+        val minWidthPx = state.intValue
+        val placeable = measurable.measure(
+            constraints.copy(minWidth = maxOf(constraints.minWidth, minWidthPx))
+        )
+        layout(placeable.width, placeable.height) {
+            placeable.placeRelative(0, 0)
+        }
+    }
 
 @Composable
 fun AlertCard(
@@ -205,3 +279,55 @@ fun AlertCard(
         content()
     }
 }
+
+@Preview
+@Composable
+private fun TwoCylindersPositivePreview() {
+    val cylinderA = CylinderGasRequirements(Cylinder.aluminium80Cuft(Gas.Nitrox50, 207.0), 800.0, 300.0)
+    val cylinderB = CylinderGasRequirements(Cylinder.aluminium80Cuft(Gas.Nitrox50, 207.0), 800.0, 300.0)
+    GasUsageDetailsDialog(gasPlan = persistentListOf(cylinderA, cylinderB), index = 0) {}
+}
+
+@Preview
+@Composable
+private fun TwoCylindersWarningPreview() {
+    val cylinderA = CylinderGasRequirements(Cylinder.steel12Liter(Gas.Nitrox50), 2000.0, 900.0)
+    val cylinderB = CylinderGasRequirements(Cylinder.steel12Liter(Gas.Nitrox50), 2000.0, 900.0)
+    GasUsageDetailsDialog(gasPlan = persistentListOf(cylinderA, cylinderB), index = 0) {}
+}
+
+@Preview
+@Composable
+private fun TwoCylindersErrorPreview() {
+    val cylinderA = CylinderGasRequirements(Cylinder.aluminium80Cuft(Gas.Air, 200.0), 2500.0, 400.0)
+    val cylinderB = CylinderGasRequirements(Cylinder.aluminium80Cuft(Gas.Air, 200.0), 2500.0, 400.0)
+    GasUsageDetailsDialog(gasPlan = persistentListOf(cylinderA, cylinderB), index = 0) {}
+}
+
+@Preview
+@Composable
+private fun OneCylinderPositivePreview() {
+    GasUsageDetailsDialog(
+        gasPlan = persistentListOf(CylinderGasRequirements(Cylinder.steel12Liter(Gas.Air), 1200.0, 600.0)),
+        index = 0,
+    ) {}
+}
+
+@Preview
+@Composable
+private fun OneCylinderWarningPreview() {
+    GasUsageDetailsDialog(
+        gasPlan = persistentListOf(CylinderGasRequirements(Cylinder.aluminium80Cuft(Gas.Nitrox50, 207.0), 1900.0, 600.0)),
+        index = 0,
+    ) {}
+}
+
+@Preview
+@Composable
+private fun OneCylinderErrorPreview() {
+    GasUsageDetailsDialog(
+        gasPlan = persistentListOf(CylinderGasRequirements(Cylinder.steel12Liter(Gas.Air), 2800.0, 400.0)),
+        index = 0,
+    ) {}
+}
+

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentPickerBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentPickerBottomSheet.kt
@@ -26,11 +26,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -43,7 +41,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
@@ -51,6 +48,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.neotech.app.abysner.domain.core.model.Configuration
@@ -58,7 +56,6 @@ import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
-import org.neotech.app.abysner.domain.utilities.DecimalFormat
 import org.neotech.app.abysner.presentation.component.DropDown
 import org.neotech.app.abysner.presentation.component.GasPropertiesComponent
 import org.neotech.app.abysner.presentation.component.bottomsheet.ModalBottomSheetScaffold
@@ -112,9 +109,18 @@ fun SegmentPickerBottomSheet(
                     text = "Dive segment"
                 )
 
-                var cylinder: Cylinder by remember {
-                    mutableStateOf(initialValue?.cylinder ?: cylinders.first())
+                val availableCylinders = remember(cylinders) {
+                    cylinders.distinctBy { it.gas }.sortedBy { it.gas.oxygenFraction }.toImmutableList()
                 }
+
+                // Match by gas instead of identity: availableCylinders is deduplicated, so the
+                // exact cylinder object from initialValue may differ.
+                val initialCylinder = initialValue?.cylinder?.gas?.let { gas ->
+                    availableCylinders.firstOrNull { it.gas == gas }
+                        ?: error("Gas $gas from initialValue not found in availableCylinders.")
+                }
+
+                var selectedCylinder: Cylinder by remember { mutableStateOf(initialCylinder ?: availableCylinders.first()) }
 
                 var depth by remember {
                     mutableIntStateOf(initialValue?.depth ?: 10)
@@ -135,7 +141,7 @@ fun SegmentPickerBottomSheet(
 
                 GasPropertiesComponent(
                     modifier = Modifier.padding(vertical = 16.dp),
-                    gas = cylinder.gas,
+                    gas = selectedCylinder.gas,
                     maxDensity = maxDensity,
                     maxPPO2 = maxPPO2,
                     maxPPO2Secondary = null,
@@ -145,20 +151,20 @@ fun SegmentPickerBottomSheet(
 
                 DropDown(
                     modifier = Modifier.fillMaxWidth(),
-                    label = "Cylinder",
-                    selectedValue = cylinder,
-                    items = cylinders,
+                    label = "Gas",
+                    selectedValue = selectedCylinder,
+                    items = availableCylinders,
                     selectedText = {
-                        it?.buildGasText() ?: AnnotatedString("")
+                        it?.gas?.buildText() ?: AnnotatedString("")
                     },
-                    dropdownRow = { _, gas ->
+                    dropdownRow = { _, cylinder ->
                         Text(
                             style = MaterialTheme.typography.bodyLarge,
-                            text = gas.buildGasText()
+                            text = cylinder.gas.buildText()
                         )
                     },
-                    onSelectionChanged = { _, gas ->
-                        cylinder = gas
+                    onSelectionChanged = { _, cylinder ->
+                        selectedCylinder = cylinder
                     }
                 )
 
@@ -201,7 +207,7 @@ fun SegmentPickerBottomSheet(
                     )
                 }
 
-                val gas = cylinder.gas
+                val gas = selectedCylinder.gas
 
                 var anyErrorMessage = errorMessageDepth.value ?: errorMessageTime.value
 
@@ -255,7 +261,7 @@ fun SegmentPickerBottomSheet(
                                 DiveProfileSection(
                                     duration = time,
                                     depth = depth,
-                                    cylinder = cylinder
+                                    cylinder = selectedCylinder
                                 )
                             )
                             scope.launch {
@@ -272,13 +278,17 @@ fun SegmentPickerBottomSheet(
 }
 
 @Composable
-private fun Cylinder.buildGasText() = buildAnnotatedString {
-    withStyle(MaterialTheme.typography.bodyExtraLarge.toSpanStyle()) {
-        append(gas.toString())
+private fun Gas.buildText(): AnnotatedString {
+    // Capture before entering the builder lambda — inside buildAnnotatedString the implicit
+    // receiver becomes AnnotatedString.Builder, so toString() would resolve to that instead.
+    val name = diveIndustryName()
+    val mix = toString()
+    return buildAnnotatedString {
+        withStyle(MaterialTheme.typography.bodyExtraLarge.toSpanStyle()) {
+            append(name)
+        }
+        append(" ($mix)")
     }
-    val liters = DecimalFormat.format(1, waterVolume)
-    val pressure = DecimalFormat.format(0, pressure)
-    append(" (${liters}l @ ${pressure}bar)")
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentsCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentsCard.kt
@@ -80,9 +80,9 @@ fun SegmentsCardComponent(
             ) {
 
                 val message = if(!addAllowed) {
-                   "You must add (and select) at least one cylinder before creating the dive profile."
+                   "Add a cylinder first, then build your dive profile here."
                 } else if(segments.isEmpty()) {
-                   "Add at least one section to your dive profile to see your deco & gas plan."
+                   "No segments yet, add one to see your deco & gas plan!"
                 } else {
                     null
                 }

--- a/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraphCoordinatesTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraphCoordinatesTest.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -46,7 +46,7 @@ class DecoPlanGraphCoordinatesTest {
         )
         return divePlanner.addDive(
             plan = listOf(DiveProfileSection(duration = 30, 30, bottomGas)),
-            decoGases = listOf(decoGas),
+            cylinders = listOf(decoGas),
         )
     }
 
@@ -66,7 +66,7 @@ class DecoPlanGraphCoordinatesTest {
         )
         return divePlanner.addDive(
             plan = listOf(DiveProfileSection(duration = 20, 20, bottomGas)),
-            decoGases = emptyList(),
+            cylinders = emptyList(),
         )
     }
 

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
@@ -99,24 +99,23 @@ private fun Gas.toResource() = DivePlanInputResourceV1.GasResource(
 )
 
 fun DivePlanInputResourceV1.toModel(): DivePlanInputModel {
-
-    val inUse = profile.map { it.cylinderIdentifier }.toSet()
-    val cylinders = cylinders.map { it.toModel(inUse.contains(it.cylinder.uniqueIdentifier)) }
-
+    val cylinders = cylinders.map { it.toModel() }
     return DivePlanInputModel(
         deeper = deeper,
         longer = longer,
         cylinders = cylinders,
         plannedProfile = profile.map {
-            it.toModel(cylinders.find { cylinder -> cylinder.cylinder.uniqueIdentifier == it.cylinderIdentifier  }!!.cylinder)
+            it.toModel(cylinders.find { cylinder -> cylinder.cylinder.uniqueIdentifier == it.cylinderIdentifier }!!.cylinder)
         }
     )
 }
 
-private fun DivePlanInputResourceV1.CheckableCylinderResource.toModel(isInUse: Boolean) = PlannedCylinderModel(
+private fun DivePlanInputResourceV1.CheckableCylinderResource.toModel() = PlannedCylinderModel(
     cylinder = cylinder.toModel(),
     isChecked = checked,
-    isInUse = isInUse
+
+    // Will be recalculated by the ViewModel
+    isLocked = false,
 )
 
 private fun DivePlanInputResourceV1.ProfileSegmentResource.toModel(cylinder: Cylinder) = DiveProfileSection(

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
@@ -74,9 +74,6 @@ class DecompressionPlanner(
         this.decoGasses.addAll(gasses)
     }
 
-    fun addCylinder(cylinder: Cylinder) {
-        this.decoGasses.add(cylinder)
-    }
 
     fun addFlat(depth: Double, gas: Cylinder, timeInMinutes: Int) {
         return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.FLAT)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -30,22 +30,22 @@ import kotlin.time.Duration
  * turn the user provided dive profile into segments usable by the decompression planner. It also
  * adds multi-level dive handling.
  */
-class DivePlanner {
-
-    var configuration = Configuration()
+class DivePlanner(
+    var configuration: Configuration = Configuration()
+) {
 
     private var decompressionModelSnapshot: DecompressionModel.Snapshot? = null
 
     fun addDive(
         plan: List<DiveProfileSection>,
-        decoGases: List<Cylinder>,
+        cylinders: List<Cylinder>,
     ): DivePlan {
 
         if(plan.isEmpty()) {
             return DivePlan(
                 persistentListOf(),
                 persistentMapOf(),
-                decoGases.toPersistentList(),
+                cylinders.toPersistentList(),
                 configuration,
                 0.0,
                 0.0
@@ -67,9 +67,7 @@ class DivePlanner {
             decompressionPlanner.setDecompressionModelSnapshot(it)
         }
 
-        decoGases.forEach {
-            decompressionPlanner.addCylinder(it)
-        }
+        decompressionPlanner.setDecoGasses(cylinders)
 
         var currentDepth = 0.0
         plan.forEach {
@@ -157,7 +155,7 @@ class DivePlanner {
         return DivePlan(
             segments = segments,
             alternativeAccents = decompressionPlanner.getAlternativeAccents(),
-            decoGasses = decoGases.toPersistentList(),
+            cylinders = cylinders.toPersistentList(),
             configuration = configuration,
             totalCns = OxygenToxicityCalculator().calculateCns(segments, configuration.environment),
             totalOtu = OxygenToxicityCalculator().calculateOtu(segments, configuration.environment)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -27,7 +27,7 @@ import kotlin.math.ceil
 data class DivePlan(
     val segments: ImmutableList<DiveSegment>,
     val alternativeAccents: ImmutableMap<Int, ImmutableList<DiveSegment>>,
-    val decoGasses: ImmutableList<Cylinder>,
+    val cylinders: ImmutableList<Cylinder>,
     val configuration: Configuration,
     val totalCns: Double,
     val totalOtu: Double,

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanInputModel.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanInputModel.kt
@@ -24,5 +24,10 @@ data class DivePlanInputModel(
 data class PlannedCylinderModel(
     val cylinder: Cylinder,
     val isChecked: Boolean,
-    val isInUse: Boolean,
+    /**
+     * True only when this is the last checked cylinder of a gas mix that is referenced in a
+     * planned segment. When true the checkbox and delete controls are disabled/hidden, preventing
+     * the planner from being left without any cylinder of that gas.
+     */
+    val isLocked: Boolean,
 )

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2025 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -15,6 +15,7 @@ package org.neotech.app.abysner.domain.gasplanning
 import kotlinx.collections.immutable.toImmutableList
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment
+import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
@@ -27,7 +28,7 @@ import kotlin.math.max
 class GasPlanner {
 
     /**
-     * Given a [DivePlan] find the potential worst-case spots to ascent from, by comparing TTS values
+     * Given a [DivePlan] find the potential worst-case spots to ascend from, by comparing TTS values
      * at various depths. This returns a List of [DiveSegments][DiveSegment] with the highest TTS
      * values, as well as spots during the dive that have a lower TTS value but are deeper.
      */
@@ -78,20 +79,17 @@ class GasPlanner {
         // diver is at the maximum TTS at those depths
         val outOfAirScenarios = worstCaseGasLossScenarios.map { maxTtsSegment ->
 
-            // For each TTS calculated the dive plan should have a accent schedule, retrieve it and use it to calculate gas usage.
+            // For each TTS calculated the dive plan should have an ascent schedule, retrieve it and use it to calculate gas usage.
             val ascent = divePlan.alternativeAccents[maxTtsSegment.end]
 
-            // This only calculates the gas usage for the emergency accent itself, for the diver
-            // that needs the gas (is out-of-air). It does not take into account that sometimes
-            // because of a emergency the dive could end sooner then expected, which also saves you
-            // some gas. However since usually the worst case scenario for a out-of-gas situation is
-            // at the end of the dive (deepest and longest point), this probably cancels out enough
-            // to be of no significance, and by not accounting for it we are on the safe side of
-            // things.
+            // This only calculates the gas needed for the emergency ascent itself, for the diver
+            // that is out-of-air. Any out-of-air event occurring earlier in the dive would require
+            // ascending from a shallower depth or lower TTS, and therefore less emergency gas,
+            // so computing from the worst-case point is inherently conservative.
             ascent?.calculateGasRequirementsPerCylinder(
                 divePlan.configuration.sacRateOutOfAir,
                 divePlan.configuration.environment
-            ) ?: error("DivePlan does not have alternative accent for T=${maxTtsSegment.end}, this should not happen and is a developer mistake.")
+            ) ?: error("DivePlan does not have alternative ascent for T=${maxTtsSegment.end}, this should not happen and is a developer mistake.")
         }
 
         val extraRequiredForWorstCaseOutOfAir = mutableMapOf<Cylinder, Double>()
@@ -99,11 +97,56 @@ class GasPlanner {
             scenario.mergeInto(extraRequiredForWorstCaseOutOfAir, ::max)
         }
 
-        return baseLine.map {
-            // It may happen that for a specific gas no extra is required, hence the default to 0.0
-            // liters if that gas is not found.
-            CylinderGasRequirements(it.key, it.value, extraRequiredForWorstCaseOutOfAir[it.key] ?: 0.0)
-        }.toImmutableList()
+        // Pool total gas requirements by gas mix rather than by individual cylinder identity.
+        //
+        // The decompression planner currently always selects one representative cylinder per gas
+        // mix via List<Cylinder>.findBestDecoGas(). When the user has multiple cylinders with the
+        // same mix (e.g. doubles for back mount diving or sidemount diving), the other cylinder(s)
+        // never appear in any DiveSegment and are therefore invisible to the raw baseLine gas
+        // requirement map.
+        //
+        // By pooling requirements by Gas and then redistributing proportionally to each cylinder's
+        // capacity, we correctly spread the usage across all same-mix cylinders.
+        //
+        // Note: this does not address the scenario where, once a cylinder is empty, a less-than-ideal
+        // gas may still be breathed for the remainder of the dive. Fixing that requires a significant
+        // change in the planner.
+        val normalByGas = mutableMapOf<Gas, Double>()
+        baseLine.forEach { (cylinder, req) ->
+            normalByGas.updateOrInsert(cylinder.gas, req, Double::plus)
+        }
+        val emergencyByGas = mutableMapOf<Gas, Double>()
+        extraRequiredForWorstCaseOutOfAir.forEach { (cylinder, req) ->
+            emergencyByGas.updateOrInsert(cylinder.gas, req, Double::plus)
+        }
+
+        val cylindersByGas = divePlan.cylinders.groupBy { it.gas }
+
+        return cylindersByGas
+            // Some cylinders may never appear in any segment (planner did not use the cylinder), in
+            // which case it has no entry in normalByGas and no gas requirement to report. Thus we
+            // filter those out.
+            .filter { (gas, _) -> gas in normalByGas }
+            .flatMap { (gas, cylinders) ->
+                distributeProportionally(
+                    cylinders = cylinders,
+                    totalNormal = normalByGas.getValue(gas),
+                    totalEmergency = emergencyByGas[gas] ?: 0.0,
+                )
+            }
+            .toImmutableList()
+    }
+
+    private fun distributeProportionally(
+        cylinders: List<Cylinder>,
+        totalNormal: Double,
+        totalEmergency: Double,
+    ): List<CylinderGasRequirements> {
+        val totalCapacity = cylinders.sumOf { it.capacity() }
+        return cylinders.map { cylinder ->
+            val fraction = cylinder.capacity() / totalCapacity
+            CylinderGasRequirements(cylinder, totalNormal * fraction, totalEmergency * fraction)
+        }
     }
 
     private fun List<DiveSegment>.calculateGasRequirementsPerCylinder(sac: Double, environment: Environment): Map<Cylinder, Double> {
@@ -112,9 +155,7 @@ class GasPlanner {
             val pressure = depthInMetersToBar(it.averageDepth, environment)
             val sacAtDepth = sac * pressure.value
             val liters = it.duration * sacAtDepth
-            requiredLitersByGas.updateOrInsert(it.cylinder, liters) { currentValue, newValue ->
-                currentValue + newValue
-            }
+            requiredLitersByGas.updateOrInsert(it.cylinder, liters, Double::plus)
         }
         return requiredLitersByGas
     }

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -26,7 +26,7 @@ import kotlin.test.assertTrue
 class GasPlannerTest {
 
     @Test
-    fun testFindPotentialWorstCaseTtsPointsScenario1() {
+    fun findPotentialWorstCaseTtsPoints_returnsNonDominatedScenariosAtEachDepth() {
 
         val bottomGas = Cylinder.steel12Liter(Gas.Trimix2135)
         val decoGas = Cylinder.aluminium80Cuft(Gas.Nitrox50)
@@ -55,7 +55,7 @@ class GasPlannerTest {
                 DiveProfileSection(10, 20, bottomGas),
                 DiveProfileSection(30, 20, bottomGas)
             ),
-            decoGases = listOf(bottomGas, decoGas)
+            cylinders = listOf(bottomGas, decoGas)
         )
 
         // at T=10 and D=50.0: TTS=11
@@ -63,7 +63,7 @@ class GasPlannerTest {
         // at T=21 and D=20.0: TTS=6
         // at T=51 and D=20.0: TTS=14
 
-        // TTS at 51 minutes in the dive (20 meters) is longer then the TTS at 11 minutes in the
+        // TTS at 51 minutes in the dive (20 meters) is longer than the TTS at 11 minutes in the
         // dive, at depth 50 meters! However the depth of 50 meters could still require more gas due
         // to the depth in general (but figuring out this is done in 'calculateGasPlan' in the
         // GasPlanner)
@@ -75,7 +75,7 @@ class GasPlannerTest {
     }
 
     @Test
-    fun testFindPotentialWorstCaseTtsPointsScenario2() {
+    fun findPotentialWorstCaseTtsPoints_returnsOnlyDeepestWorstCaseScenario() {
 
         val bottomGas = Cylinder.steel12Liter(Gas.Air)
 
@@ -102,12 +102,12 @@ class GasPlannerTest {
                 // +3 + 3 (contingency plan)
                 DiveProfileSection(18, 23, bottomGas),
             ),
-            decoGases = listOf(bottomGas)
+            cylinders = listOf(bottomGas)
         )
 
         // at T=15 and D=10.0: TTS=2
         // at T=30 and D=15.0: TTS=3
-        // at T=48 and D=23.0: TTS=7
+        // at T=48 and D=23.0: TTS=15
 
         val ttsWorstCaseScenarios = GasPlanner().findPotentialWorstCaseTtsPoints(divePlan)
         assertEquals(1, ttsWorstCaseScenarios.size)
@@ -119,9 +119,9 @@ class GasPlannerTest {
      * Making sure the calculated volumes and pressures are as expected.
      */
     @Test
-    fun testBarUsage() {
+    fun calculateGasPlan_calculatesCorrectGasRequirements() {
 
-        val bottomGas = Cylinder(Gas.Air, 200, 22)
+        val bottomGas = Cylinder.steel12Liter(Gas.Air)
         val decoGas = Cylinder(Gas.Nitrox50, 207, 7)
 
         val divePlanner = DivePlanner()
@@ -145,12 +145,104 @@ class GasPlannerTest {
             plan = listOf(
                 DiveProfileSection(30, 50, bottomGas),
             ),
-            decoGases = listOf(bottomGas, decoGas)
+            cylinders = listOf(bottomGas, decoGas)
         )
 
         val gasPlan = GasPlanner().calculateGasPlan(divePlan)
 
         assertEquals(3769.0, gasPlan[0].totalGasRequirement, tenthAtDecimalPoint(0))
         assertEquals(4131.0, gasPlan[1].totalGasRequirement, tenthAtDecimalPoint(0))
+    }
+
+    /**
+     * Test for GitHub issue: https://github.com/NeoTech-Software/Abysner/issues/55
+     *
+     * When a diver configures doubles or sidemount (two cylinders with the same gas mix), the gas
+     * plan must split the total requirement evenly across them (when they have equal capacity).
+     */
+    @Test
+    fun calculateGasPlan_distributesSameMixGasEquallyAcrossIdenticalCylinders() {
+        val decoGas = Cylinder.aluminium80Cuft(Gas.Nitrox50, 207.0)
+
+        val config = Configuration(
+            sacRate = 14.0,
+            maxPPO2 = 1.4,
+            maxPPO2Deco = 1.6,
+            maxEND = 30.0,
+            maxAscentRate = 5.0,
+            maxDescentRate = 10.0,
+            gfLow = 0.4,
+            gfHigh = 0.8,
+            forceMinimalDecoStopTime = true,
+            decoStepSize = 3,
+            lastDecoStopDepth = 3,
+            salinity = Salinity.WATER_FRESH,
+            algorithm = Configuration.Algorithm.BUHLMANN_ZH16C,
+            gasSwitchTime = 0
+        )
+
+        val bottomGasOne = Cylinder.steel12Liter(Gas.Air)
+        val bottomGasTwo = Cylinder.steel12Liter(Gas.Air)
+        val gasPlan = GasPlanner().calculateGasPlan(
+            DivePlanner(config).addDive(
+                plan = listOf(DiveProfileSection(30, 50, bottomGasOne)),
+                cylinders = listOf(bottomGasOne, bottomGasTwo, decoGas)
+            )
+        )
+
+        // Gas plan must list both Air cylinders — previously only one appeared
+        val airEntries = gasPlan.filter { it.cylinder.gas == Gas.Air }
+        assertEquals(2, airEntries.size)
+
+        // Since both cylinders are identical each must receive exactly half
+        assertEquals(airEntries[0].normalRequirement, airEntries[1].normalRequirement, tenthAtDecimalPoint(0))
+        assertEquals(airEntries[0].extraEmergencyRequirement, airEntries[1].extraEmergencyRequirement, tenthAtDecimalPoint(0))
+    }
+
+    /**
+     * Test for GitHub issue: https://github.com/NeoTech-Software/Abysner/issues/55
+     *
+     * A recreational diver carries a 12 L steel back mount and an AL63 stage, both filled with
+     * Air. The gas requirement is distributed proportionally to each cylinder's capacity.
+     */
+    @Test
+    fun calculateGasPlan_distributesSameMixGasProportionallyToCapacity() {
+        val config = Configuration(
+            sacRate = 14.0,
+            maxPPO2 = 1.4,
+            maxPPO2Deco = 1.6,
+            maxEND = 30.0,
+            maxAscentRate = 5.0,
+            maxDescentRate = 10.0,
+            gfLow = 0.8,
+            gfHigh = 1.0,
+            forceMinimalDecoStopTime = true,
+            decoStepSize = 3,
+            lastDecoStopDepth = 3,
+            salinity = Salinity.WATER_FRESH,
+            algorithm = Configuration.Algorithm.BUHLMANN_ZH16C,
+            gasSwitchTime = 0
+        )
+
+        val backMount = Cylinder.steel12Liter(Gas.Air)
+        val stage = Cylinder.aluminium63Cuft(Gas.Air)
+
+        val divePlan = DivePlanner(config).addDive(
+            plan = listOf(DiveProfileSection(25, 20, backMount)),
+            cylinders = listOf(backMount, stage)
+        )
+        val gasPlan = GasPlanner().calculateGasPlan(divePlan)
+
+        val airEntries = gasPlan.filter { it.cylinder.gas == Gas.Air }
+        assertEquals(2, airEntries.size)
+
+        val backMountEntry = airEntries.first { it.cylinder.waterVolume == backMount.waterVolume }
+        val stageEntry = airEntries.first { it.cylinder.waterVolume == stage.waterVolume }
+
+        // Proportional distribution: the ratio of requirements must match the ratio of capacities
+        val expectedRatio = backMount.capacity() / stage.capacity()
+        val actualRatio   = backMountEntry.totalGasRequirement / stageEntry.totalGasRequirement
+
+        assertEquals(expectedRatio, actualRatio, tenthAtDecimalPoint(2))
     }
 }


### PR DESCRIPTION
When a diver configured different cylinders of the same gas mix (doubles, sidemount, or a back-mount + stage), only the first cylinder of that gas mix appeared in the gas plan, all other same-mix cylinders were silently ignored and never shown in the UI, unless specifically used for a user-planned section.

**Gas planner**
The planner now pools the total gas requirement by mix and redistributes it proportionally across all cylinders of that mix, weighted by each cylinder's capacity. Equal-sized cylinders each receive an equal share. Unequal cylinders (e.g. a 12 L steel back mount paired with an AL63 stage) are weighted by capacity.

**Dive planner**
`DivePlan.decoGasses` is renamed to `DivePlan.cylinders` to reflect that the field holds all user-checked cylinders, not only dedicated deco gases.

**UI: Cylinder details dialog**
The dialog layout is replaced with two tables one for cylinder-specific info and one for total dive required gas. AlertCard now shows specific messages if there are one or multiple cylinders of a given gas mix. Also a small piece of text is added to tell the user how much the selected cylinder accounts towards the total gas for that mix.

**UI: Gas plan**
A new totals table is added below the bar chart, showing available, normal, and emergency gas requirements per mix in liters. The cylinders table is also simplified by removing the cylinder number column.

Fixes: #55