### PR TITLE
Improve: planner now switches to a less toxic gas on ascent when bottom gas exceeds max PPO2

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -124,6 +124,7 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
         const val MAX_RECOMMENDED_GAS_DENSITY = 5.2
         const val MAX_GAS_DENSITY = 6.2
         const val MAX_PPO2 = 1.6
+        const val MIN_PPO2 = 0.16
 
         val Air = Gas(oxygenFraction = 0.21, heliumFraction = 0.0)
         val Nitrox28 = Gas(oxygenFraction = 0.28, heliumFraction = 0.0)
@@ -167,29 +168,3 @@ private const val DENSITY_N2 = 1.251
  * Density He = 4.00 g/mole x 1 mole/22.4 L = 0.178 g/L
  */
 private const val DENSITY_HE = 0.178
-
-/**
- * Returns the best gas in the list based on MOD and END.
- *
- * @return the best gas for the given depth, salinity, maximum ppo2 and maximum END, this may return
- *         null if no gasses match these criteria. If multiple gasses match the gas with the highest
- *         PPO2 is chosen (to have the maximum off gassing effect).
- */
-fun List<Cylinder>.findBestDecoGas(depth: Double, environment: Environment, maxPPO2: Double, maxEND: Double): Cylinder? {
-    var bestGas: Cylinder? = null
-    forEach { candidateGas ->
-        // TODO be safe and use 'floor' instead of 'round'?
-        val mod = round(candidateGas.gas.oxygenMod(maxPPO2, environment))
-        val end = round(candidateGas.gas.endInMeters(depth, environment))
-        if (depth <= mod && end <= maxEND) {
-            // Gas is usable (todo min-OD check?)
-            if (bestGas == null) {
-                bestGas = candidateGas
-            } else if(bestGas.gas.oxygenFraction < candidateGas.gas.oxygenFraction) {
-                // Prefer the higher oxygen percentage
-                bestGas = candidateGas
-            }
-        }
-    }
-    return bestGas
-}

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/GasSelection.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/GasSelection.kt
@@ -1,0 +1,120 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.core.model
+
+import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import kotlin.math.round
+
+/**
+ * Returns the best gas in the list for the current depth, based on given O2 MOD [maxPPO2] and END
+ * ([maxEND]) constraints.
+ *
+ * This functions tracks two separate best candidates:
+ *  - Ideal: satisfies both O2 MOD and END constraints → highest O2 fraction wins.
+ *  - Fallback: if ideal does not satisfy any gas the END constraint is dropped → highest O2 fraction wins.
+ *
+ * Returns null when no candidate satisfies the O2 MOD. Callers that want automatic fallback
+ * behavior can use [findBetterGasOrFallback] instead.
+ *
+ * A word on density:
+ * Enriched gases (e.g. EANx 50) are inherently denser than air at any given depth, because
+ * O2 is heavier than N2. Including density as a constraint would therefore always bias the
+ * algorithm away from the higher-O2 deco gases that are specifically chosen for their superior
+ * off-gassing effect. In practice this is usually a non-issue: a gas's O2 MOD already limits it to
+ * depths where its density is within safe limits. However, if the user selects a non-ideal gas for
+ * a section of the dive, the decompression ascent planned automatically may ping between different
+ * gases due to the density constraints.
+ *
+ * Regardless, density is surfaced to the user as a warning in the limits table so they can make
+ * informed planning choices, but for the above reasons it does not influence automatic gas
+ * selection at runtime.
+ *
+ * @return the best cylinder for the given depth, or null if no cylinder satisfies the O2 MOD.
+ */
+fun List<Cylinder>.findBestGas(depth: Double, environment: Environment, maxPPO2: Double, maxEND: Double): Cylinder? {
+    var ideal: Cylinder? = null
+    var fallback: Cylinder? = null
+    forEach { candidate ->
+        // TODO be safe and use 'floor' instead of 'round'?
+        val modOk = depth <= round(candidate.gas.oxygenMod(maxPPO2, environment))
+        if (!modOk) {
+            // MOD is not ok, skip this candidate don't botter about checking END.
+            return@forEach
+        }
+
+        val endOk = round(candidate.gas.endInMeters(depth, environment)) <= maxEND
+
+        if (endOk) {
+            if (ideal == null || ideal.gas.oxygenFraction < candidate.gas.oxygenFraction) {
+                ideal = candidate
+            }
+        } else {
+            if (fallback == null || fallback.gas.oxygenFraction < candidate.gas.oxygenFraction) {
+                fallback = candidate
+            }
+        }
+    }
+    return ideal ?: fallback
+}
+
+/**
+ * Last-resort fallback when [findBestGas] returns null (no gas satisfies the O2 MOD at depth). If
+ * any non-hypoxic candidates exist (PPO2 ≥ [minPPO2] at [depth]), the one with the lowest O2
+ * fraction is returned to minimize O2 toxicity. If all candidates are hypoxic, the one with the
+ * highest O2 fraction is returned instead, as it produces the highest PPO2 and is therefore the
+ * least hypoxic option available.
+ *
+ * @return the safest cylinder from an oxygen point of view for the given depth, or null if the list
+ * is empty.
+ */
+internal fun List<Cylinder>.findBreathableFallbackGas(
+    depth: Double,
+    environment: Environment,
+    minPPO2: Double = Gas.MIN_PPO2,
+): Cylinder? {
+    val pressure = depthInMetersToBar(depth, environment).value
+    val nonHypoxic = filter { it.gas.oxygenFraction * pressure >= minPPO2 }
+    return if (nonHypoxic.isNotEmpty()) {
+        nonHypoxic.minByOrNull { it.gas.oxygenFraction }
+    } else {
+        maxByOrNull { it.gas.oxygenFraction }
+    }
+}
+
+/**
+ * Convenience combination of [findBestGas] and [findBreathableFallbackGas]. Returns the best gas
+ * for the given depth. If no gas satisfies the O2 MOD, falls back to [findBreathableFallbackGas],
+ * but only when the fallback gas is genuinely better than [currentCylinder].
+ *
+ * "Better" is defined by the same criteria [findBreathableFallbackGas] uses to rank candidates: if
+ * [currentCylinder] is already an equal or better choice than the fallback, it is returned instead
+ * and no switch occurs.
+ *
+ * @return the best or fallback gas for the given depth, or [currentCylinder] if no switch is
+ * warranted, or null if both the list and [currentCylinder] are null/empty.
+ */
+fun List<Cylinder>.findBetterGasOrFallback(currentCylinder: Cylinder?, depth: Double, environment: Environment, maxPPO2: Double, maxEND: Double, minPPO2: Double = Gas.MIN_PPO2): Cylinder? {
+    val best = findBestGas(depth, environment, maxPPO2, maxEND)
+    if (best != null) {
+        return best
+    } else {
+        val fallback = findBreathableFallbackGas(depth, environment, minPPO2) ?: return currentCylinder
+        // Only switch to the fallback if it is better than the current gas (see findBreathableFallbackGas).
+        return if (currentCylinder == null || fallback.gas.oxygenFraction < currentCylinder.gas.oxygenFraction) {
+            fallback
+        } else {
+            currentCylinder
+        }
+    }
+}
+

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -19,7 +19,7 @@ import kotlinx.collections.immutable.toPersistentMap
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.core.model.Environment
-import org.neotech.app.abysner.domain.core.model.findBestDecoGas
+import org.neotech.app.abysner.domain.core.model.findBetterGasOrFallback
 import org.neotech.app.abysner.domain.core.physics.barToDepthInMeters
 import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
@@ -172,7 +172,7 @@ class DecompressionPlanner(
 
         while (currentDepth > toDepth) {
             // Check if there is a better gas to breath at the current depth
-            val betterDecoGas = decoGasses.findBestDecoGas(currentDepth, environment, maxppO2, maxEND)
+            val betterDecoGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = currentDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
             // Only start using the better gas when we reach a deco increment point
 
             if (betterDecoGas != null && betterDecoGas != gas && currentDepth.toInt() % decoStepSize == 0) {
@@ -193,7 +193,7 @@ class DecompressionPlanner(
             var nextDepth = currentDepth - 1
             var nextDecoGas: Cylinder?
             while(nextDepth >= targetDepth) {
-                nextDecoGas = decoGasses.findBestDecoGas(nextDepth, environment, maxppO2, maxEND)
+                nextDecoGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = nextDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
                 if (nextDecoGas != null && nextDecoGas != gas && nextDepth.toInt() % decoStepSize == 0) {
                     targetDepth = nextDepth //Only carry us up to the point where we can use this better gas.
                     break
@@ -218,7 +218,7 @@ class DecompressionPlanner(
             currentDepth = targetDepth
         }
 
-        val betterDecoGasName = decoGasses.findBestDecoGas(currentDepth, environment, maxppO2, maxEND)
+        val betterDecoGasName = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = currentDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
         if (betterDecoGasName != null && betterDecoGasName != gas && currentDepth.toInt() % decoStepSize == 0) {
             // Gas switch time on the old gas before switching
             addGasSwitch(currentDepth, gas, gasSwitchTime)
@@ -257,14 +257,14 @@ class DecompressionPlanner(
         if(ceiling > fromDepth) {
             // We have to stay at this depth first, do not change depths, but look for better gas.
             ceiling = fromDepth.toInt()
-            val betterGas = decoGasses.findBestDecoGas(fromDepth, environment, maxPpO2, maxEquivalentNarcoticDepth)
+            val betterGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = fromDepth, environment = environment, maxPPO2 = maxPpO2, maxEND = maxEquivalentNarcoticDepth)
             if (betterGas != null && betterGas != gas) {
                 // Gas switch time on the old gas before switching
                 addGasSwitch(fromDepth, gas, gasSwitchTime)
                 gas = betterGas
             }
         } else {
-            val betterGas = decoGasses.findBestDecoGas(fromDepth, environment, maxPpO2, maxEquivalentNarcoticDepth)
+            val betterGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = fromDepth, environment = environment, maxPPO2 = maxPpO2, maxEND = maxEquivalentNarcoticDepth)
             if (betterGas != null && betterGas != gas) {
                 // Gas switch time on the old gas before switching
                 addGasSwitch(fromDepth, gas, gasSwitchTime)

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasSelectionTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasSelectionTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.core.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GasSelectionTest {
+
+    private val environment = Environment.Default
+
+    private fun cylinders(vararg gas: Gas) = gas.map { Cylinder.steel12Liter(it) }
+
+    @Test
+    fun findBestGas_returnsNullWhenAllGasesExceedMaxPPO2() {
+        val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50, Gas.Oxygen)
+        assertNull(cylinders.findBestGas(depth = 70.0, environment = environment, maxPPO2 = 1.6, maxEND = END_UNSPECIFIED))
+    }
+
+    @Test
+    fun findBestGas_returnsHighestOxygenGasWithinModWhenAllSatisfyEnd() {
+        val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50)
+        assertEquals(Gas.Nitrox50, cylinders.findBestGas(depth = 20.0, environment = environment, maxPPO2 = 1.6, maxEND = 40.0)?.gas)
+    }
+
+    @Test
+    fun findBestGas_excludesGasThatExceedsItsMod() {
+        val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50)
+        assertEquals(Gas.Nitrox32, cylinders.findBestGas(depth = 25.0, environment = environment, maxPPO2 = 1.6, maxEND = 40.0)?.gas)
+    }
+
+    @Test
+    fun findBestGas_prefersIdealCandidateOverFallback() {
+        // Air END is 40 meter and exceeds the maxEND, however Trimix2135 is belo the maxEND (about 22 meters)
+        val cylinders = cylinders(Gas.Air, Gas.Trimix2135)
+        assertEquals(Gas.Trimix2135, cylinders.findBestGas(depth = 40.0, environment = environment, maxPPO2 = 1.6, maxEND = 30.0)?.gas)
+    }
+
+    @Test
+    fun findBestGas_returnsHighestOxygenWithinModWhenNoGasSatisfiesEnd() {
+        val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50)
+        assertEquals(Gas.Nitrox32, cylinders.findBestGas(depth = 40.0, environment = environment, maxPPO2 = 1.6, maxEND = 20.0)?.gas)
+    }
+
+    @Test
+    fun findBreathableFallbackGas_returnsLowestOxygenAmongHyperoxicGases() {
+        val cylinders = cylinders(Gas.Nitrox50, Gas.Nitrox32)
+        assertEquals(Gas.Nitrox32, cylinders.findBreathableFallbackGas(depth = 10.0, environment = environment)?.gas)
+    }
+
+    @Test
+    fun findBreathableFallbackGas_returnsHighestOxygenWhenAllGasesAreHypoxic() {
+        val cylinders = cylinders(Gas.Trimix1070, Gas.Trimix1555)
+        assertEquals(Gas.Trimix1555, cylinders.findBreathableFallbackGas(depth = 0.0, environment = environment)?.gas)
+    }
+
+    @Test
+    fun findBreathableFallbackGas_ignoresHypoxicGasesWhenNonHypoxicAvailable() {
+        val cylinders = cylinders(Gas.Trimix1070, Gas.Trimix1555, Gas.Trimix1845, Gas.Trimix2135)
+        assertEquals(Gas.Trimix1845, cylinders.findBreathableFallbackGas(depth = 0.0, environment = environment)?.gas)
+    }
+
+    @Test
+    fun findBreathableFallbackGas_respectsCustomMinPPO2() {
+        val cylinders = cylinders(Gas.Air, Gas.Nitrox50)
+        assertEquals(Gas.Nitrox50, cylinders.findBreathableFallbackGas(depth = 10.0, environment = environment, minPPO2 = 0.50)?.gas)
+    }
+
+    @Test
+    fun findBetterGasOrFallback_returnsBestGasWhenAvailable() {
+        val currentCylinder = Cylinder.steel12Liter(Gas.Air)
+        val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50)
+        assertEquals(Gas.Nitrox50, cylinders.findBetterGasOrFallback(currentCylinder = currentCylinder, depth = 20.0, environment = environment, maxPPO2 = 1.6, maxEND = 40.0)?.gas)
+    }
+
+    @Test
+    fun findBetterGasOrFallback_fallsBackWhenNoBestGasAvailable() {
+        // All gases exceed maxPPO2 at 70 meter, fallback returns Air as the lowest O2 non-hypoxic gas.
+        // Current gas is Nitrox32 (higher O2 than Air), so Air is genuinely a better (less toxic) option.
+        val currentCylinder = Cylinder.steel12Liter(Gas.Nitrox32)
+        val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50, Gas.Oxygen)
+        assertEquals(Gas.Air, cylinders.findBetterGasOrFallback(currentCylinder = currentCylinder, depth = 70.0, environment = environment, maxPPO2 = 1.6, maxEND = END_UNSPECIFIED)?.gas)
+    }
+
+    @Test
+    fun findBetterGasOrFallback_staysOnCurrentGasWhenFallbackIsNotBetter() {
+        // At 30m Nitrox50 is outside its MOD, so findBestGas returns null. The fallback would
+        // return Nitrox50, but Air already has lower O2, so the current gas (Air) is returned.
+        val currentCylinder = Cylinder.steel12Liter(Gas.Air)
+        val cylinders = cylinders(Gas.Nitrox50)
+        assertEquals(Gas.Air, cylinders.findBetterGasOrFallback(currentCylinder = currentCylinder, depth = 30.0, environment = environment, maxPPO2 = 1.6, maxEND = END_UNSPECIFIED)?.gas)
+    }
+}
+
+private const val END_UNSPECIFIED = Double.MAX_VALUE

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
@@ -78,7 +78,7 @@ class DivePlannerTest {
             DiveProfileSection(duration = 30, 30, bottomGas)
         )
 
-        val divePlan = divePlanner.addDive(plannedSections, listOf(decoGas))
+        val divePlan = divePlanner.addDive(plannedSections, listOf(bottomGas, decoGas))
         val plan = divePlan.segmentsCollapsed
 
         // println(divePlan.toString(compact = false))


### PR DESCRIPTION
When a diver is breathing a gas that exceeds the configured max PPO2 (e.g. a user-selected bottom gas that is not within constraints), `findBestGas()` would return null and the ascent planner had no fallback. This left the diver on the sub-optimal gas until a truly ideal gas became available, even if a less toxic breathable alternative was already available at that depth.

**Example:**
A diver runs EAN50 as bottom gas at 40 meters, with the max PPO2 set to 1.4 bar (this is outside constraints). On starting the ascent, EAN32 is available. EAN32 is still outside the 1.4 PPO2 limit at that depth, so `findBestGas()` would return null, but EAN32 is far less toxic than EAN50 at that depth. Previously the planner kept the diver on EAN50 until EAN32's MOD was reached. Now it immediately switches to EAN32 via `findBetterGasOrFallback()`, which picks the lowest-O2 breathable gas when no ideal candidate exists. Once EAN32's MOD is reached, `findBestGas()` takes over normally.