### PR TITLE
Fix: PPO2 and density warnings not triggering when they barely exceed the threshold boundary

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
@@ -306,8 +306,8 @@ fun GasLimitsTable(
             Text(modifier = Modifier.weight(0.3f), text = "${gasAtDepth.depth.toInt()}m")
 
             val alertSeverityDensity = when {
-                gasAtDepth.density.higherThenDelta(Gas.MAX_GAS_DENSITY, 0.01) -> AlertSeverity.ERROR
-                gasAtDepth.density.higherThenDelta(Gas.MAX_RECOMMENDED_GAS_DENSITY, 0.01) -> AlertSeverity.WARNING
+                gasAtDepth.density.higherThenDelta(Gas.MAX_GAS_DENSITY, 0.001) -> AlertSeverity.ERROR
+                gasAtDepth.density.higherThenDelta(Gas.MAX_RECOMMENDED_GAS_DENSITY, 0.001) -> AlertSeverity.WARNING
                 else -> AlertSeverity.NONE
             }
             TextAlert(
@@ -316,7 +316,7 @@ fun GasLimitsTable(
                 text = DecimalFormat.format(2, gasAtDepth.density),
             )
 
-            val alertSeverityPPO2 = if (gasAtDepth.ppo2.higherThenDelta(Gas.MAX_PPO2, 0.01)) {
+            val alertSeverityPPO2 = if (gasAtDepth.ppo2.higherThenDelta(Gas.MAX_PPO2, 0.001)) {
                 AlertSeverity.ERROR
             } else {
                 AlertSeverity.NONE


### PR DESCRIPTION
The comparison delta of 0.01 was too large relative to the displayed precision of 2 decimal places, causing values like 1.61 to be treated as equal to a 1.6 threshold. The delta is now reduced to 0.001 to fix this.