### PR TITLE
feat: Add DiveMode enum for open circuit and CCR planning (#3)

### DIFF
--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
@@ -17,6 +17,7 @@ import org.neotech.app.abysner.data.diveplanning.resources.DivePlanInputResource
 import org.neotech.app.abysner.data.diveplanning.resources.MultiDivePlanInputResourceV1
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.core.model.Salinity
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanInputModel
@@ -73,6 +74,7 @@ fun ConfigurationResourceV1.toModel() = Configuration(
 
 
 fun DivePlanInputModel.toResource() = DivePlanInputResourceV1(
+    diveMode = diveMode.preferenceValue,
     deeper = deeper,
     longer = longer,
     cylinders = cylinders.map { it.toResource() },
@@ -106,6 +108,7 @@ private fun Gas.toResource() = DivePlanInputResourceV1.GasResource(
 fun DivePlanInputResourceV1.toModel(): DivePlanInputModel {
     val cylinders = cylinders.map { it.toModel() }
     return DivePlanInputModel(
+        diveMode = fromString<DiveMode>(diveMode),
         deeper = deeper,
         longer = longer,
         cylinders = cylinders,

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/resources/DivePlanInputResourceV1.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/resources/DivePlanInputResourceV1.kt
@@ -18,6 +18,7 @@ import org.neotech.app.abysner.data.SerializableResource
 @Serializable
 data class DivePlanInputResourceV1(
     val version: Int = 1,
+    val diveMode: String = "open-circuit",
     val deeper: Boolean,
     val longer: Boolean,
     val cylinders: List<CheckableCylinderResource>,

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/DiveMode.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/DiveMode.kt
@@ -1,0 +1,24 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2024-2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.core.model
+
+import org.neotech.app.abysner.domain.persistence.EnumPreference
+
+enum class DiveMode(val humanReadableName: String) : EnumPreference {
+    OPEN_CIRCUIT("Open circuit") {
+        override val preferenceValue: String = "open-circuit"
+    },
+    CLOSED_CIRCUIT("CCR") {
+        override val preferenceValue: String = "closed-circuit"
+    },
+}

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanInputModel.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanInputModel.kt
@@ -14,8 +14,10 @@ package org.neotech.app.abysner.domain.diveplanning.model
 
 import kotlin.time.Duration
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
 
 data class DivePlanInputModel(
+    val diveMode: DiveMode = DiveMode.OPEN_CIRCUIT,
     val deeper: Boolean,
     val longer: Boolean,
     val plannedProfile: List<DiveProfileSection>,


### PR DESCRIPTION
Introduce DiveMode (OPEN_CIRCUIT, CLOSED_CIRCUIT) as a per-dive
property on DivePlanInputModel, with serialization support in the
data layer. Defaults to OPEN_CIRCUIT for backward compatibility.