### PR TITLE
Add: CCR tissue loading in the Buhlmann decompression algorithm

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/DecompressionModel.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/DecompressionModel.kt
@@ -47,8 +47,10 @@ interface DecompressionModel {
      * @param endPressure end pressure (depth) in bars (including atmospheric pressure)
      * @param gas the gas being breathe by the diver during this section.
      * @param timeInMinutes the timeInMinutes this section takes.
+     * @param ccrSetpoint the set-point for keeping a constant PPO2 during this pressure change (if
+     * null open-circuit behavior is assumed)
      */
-    fun addPressureChange(startPressure: Pressure, endPressure: Pressure, gas: Gas, timeInMinutes: Int)
+    fun addPressureChange(startPressure: Pressure, endPressure: Pressure, gas: Gas, timeInMinutes: Int, ccrSetpoint: Double? = null)
 
     /**
      * Calculates and returns the current tissue ceiling in bars (including atmospheric pressure)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -61,19 +61,18 @@ class Buhlmann(
     /**
      * Add a descending, ascending or flat section of the dive to tissues.
      *
-     * @param startPressure start depth in meters from the surface.
-     * @param endPressure end depth in meters from the surface.
+     * @param startPressure start pressure (depth) in bars (including atmospheric pressure)
+     * @param endPressure end pressure (depth) in bars (including atmospheric pressure)
      * @param gas the gas being breathe by the diver during this section.
      * @param timeInMinutes the timeInMinutes this section takes.
+     * @param ccrSetpoint the set-point for keeping a constant PPO2 during this pressure change (if
+     * null open-circuit behavior is assumed)
      */
-    override fun addPressureChange(startPressure: Pressure, endPressure: Pressure, gas: Gas, timeInMinutes: Int) {
+    override fun addPressureChange(startPressure: Pressure, endPressure: Pressure, gas: Gas, timeInMinutes: Int, ccrSetpoint: Double?) {
         val fO2 = gas.oxygenFraction
         val fHe = gas.heliumFraction
-
-        var loadChange = 0.0
         tissues.forEach {
-            val tissueChange = it.addPressureChange(startPressure.value, endPressure.value, fO2, fHe, timeInMinutes)
-            loadChange += tissueChange
+            it.addPressureChange(startPressure.value, endPressure.value, fO2, fHe, timeInMinutes, ccrSetpoint)
         }
     }
 
@@ -209,37 +208,27 @@ data class TissueCompartment(
     private var pTotal: Double = pNitrogen + pHelium
 ) {
 
-    fun addPressureChange(startPressure: Double, endPressure: Double, fO2: Double, fHe: Double, timeInMinutes: Int): Double {
-        if (timeInMinutes <= 0) {
-            // A zero or negative duration makes no physical sense (no exposure has occurred), and
-            // would also cause a division by zero in pressureChangeInBarsPerMinute.
-            throw IllegalArgumentException("Invalid duration `$timeInMinutes` for on/off-gassing tissues. The minimum duration must be higher than 0.")
-        }
-        // Calculate nitrogen fraction (by just subtracting oxygen and helium)
-        val fN2 = (1.0 - fO2) - fHe
-        if (fN2 < 0.0) {
-            throw IllegalArgumentException("Invalid gas mix `$fO2/$fHe` for on/off-gassing tissues, oxygen and helium should together never exceed 1.0 (100% of the gas mix).")
+    fun addPressureChange(startPressure: Double, endPressure: Double, fO2: Double, fHe: Double, timeInMinutes: Int, ccrSetpoint: Double? = null): Double {
+        // A zero or negative duration makes no physical sense (no exposure has occurred), and
+        // would also cause a division by zero in pressureChangeInBarsPerMinute.
+        require(timeInMinutes > 0) {
+            "Invalid duration `$timeInMinutes` for on/off-gassing tissues. The minimum duration must be higher than 0."
         }
 
-        // The code below assumes a non-constant partial pressure for oxygen and helium.
-        // However with CCR the oxygen fraction remains constant, causing the nitrogen fraction to
-        // change constantly.
-        // Instead of Schreiners equation for CCR it may make more sens to instead simulate the
-        // constant oxygen fraction by using small time increments at constant pressure.
-        // TODO: Once CCR support is added consider making the time increments smaller (seconds)?
-        // https://thetheoreticaldiver.org/wordpress/index.php/2017/11/30/ccr-schreiner-equation/
+        // Calculate nitrogen fraction (by just subtracting oxygen and helium)
+        val fN2 = (1.0 - fO2) - fHe
+        require(fN2 >= 0.0) {
+            "Invalid gas mix `$fO2/$fHe` for on/off-gassing tissues, oxygen and helium should together never exceed 1.0 (100% of the gas mix)."
+        }
 
         val depthChangeInBarsPerMinute = pressureChangeInBarsPerMinute(startPressure, endPressure, timeInMinutes)
 
-        // Calculate nitrogen loading
-        var gasRate = partialPressure(depthChangeInBarsPerMinute, fN2)
-        var pGas = partialPressure(startPressure, fN2)
-        this.pNitrogen = schreinerEquation(pNitrogen, pGas, timeInMinutes, parameters.n2HalfTime, gasRate)
-
-        // Calculate helium loading
-        gasRate = partialPressure(depthChangeInBarsPerMinute, fHe)
-        pGas = partialPressure(startPressure, fHe)
-        this.pHelium = schreinerEquation(pHelium, pGas, timeInMinutes, parameters.heHalfTime, gasRate)
+        if (ccrSetpoint != null) {
+            addPressureChangeCcr(startPressure, endPressure, fO2, fN2, fHe, timeInMinutes, depthChangeInBarsPerMinute, ccrSetpoint)
+        } else {
+            // oxygen fraction is irrelevant for OC tissue loading
+            addPressureChangeOc(startPressure, fN2, fHe, timeInMinutes, depthChangeInBarsPerMinute)
+        }
 
         val prevTotal = this.pTotal
         // Calculate total loading
@@ -247,6 +236,191 @@ data class TissueCompartment(
 
         // Return the difference of load added.
         return this.pTotal - prevTotal
+    }
+
+    private fun addPressureChangeOc(
+        startPressure: Double,
+        fN2: Double,
+        fHe: Double,
+        timeInMinutes: Int,
+        depthChangeInBarsPerMinute: Double
+    ) {
+        this.pNitrogen = schreinerEquation(
+            initialTissuePressure = pNitrogen,
+            inspiredGasPressure = partialPressure(startPressure, fN2),
+            time = timeInMinutes.toDouble(),
+            halfTime = parameters.n2HalfTime,
+            inspiredGasRate = partialPressure(depthChangeInBarsPerMinute, fN2),
+        )
+        this.pHelium = schreinerEquation(
+            initialTissuePressure = pHelium,
+            inspiredGasPressure = partialPressure(startPressure, fHe),
+            time = timeInMinutes.toDouble(),
+            halfTime = parameters.heHalfTime,
+            inspiredGasRate = partialPressure(depthChangeInBarsPerMinute, fHe),
+        )
+    }
+
+    /**
+     * CCR tissue loading for inert gases (N₂ and He). Internally uses [schreinerEquation] by
+     * computing an effective inspired gas pressure and rate via [ccrSchreinerInputs], which
+     * linearizes the CCR inert gas input so the same Schreiner equation applies to both OC and CCR.
+     *
+     * Three cases are handled (see [ccrSchreinerInputs]:
+     * - No ambient-setpoint transition: a single [schreinerEquation] call covers the full segment.
+     * - Ascent through the setpoint: the segment is split at the point where ambient equals the
+     *   setpoint. Below the setpoint the CCR equation applies, above it the loop is pure oxygen and
+     *   different inspired gas pressure and rate are required (effectively both zero).
+     * - Descent through the setpoint: same split in reverse, pure oxygen first, then normal loading.
+     *
+     * The split is necessary because the setpoint cannot be maintained above the ambient pressure.
+     */
+    private fun addPressureChangeCcr(
+        startPressure: Double,
+        endPressure: Double,
+        fO2: Double,
+        fN2: Double,
+        fHe: Double,
+        timeInMinutes: Int,
+        depthChangeInBarsPerMinute: Double,
+        ccrSetpoint: Double,
+    ) {
+        val setpointEffective = ccrSetpoint + waterVapourPressure
+        val isAscentWhileCrossingSetpoint = startPressure > setpointEffective && endPressure < setpointEffective
+        val isDescentWhileCrossingSetpoint = startPressure < setpointEffective && endPressure > setpointEffective
+
+        if (isAscentWhileCrossingSetpoint) {
+            val timeBelow = (startPressure - setpointEffective) / (startPressure - endPressure) * timeInMinutes
+            val timeAbove = timeInMinutes - timeBelow
+
+            // Sub-segment 1 (below): set-point maintained normally
+            val (inspiredNitrogenPressureCross, inspiredNitrogenRateCross) = ccrSchreinerInputs(
+                startPressure = startPressure,
+                pressureRate = depthChangeInBarsPerMinute,
+                inertFraction = fN2,
+                oxygenFractionDiluent = fO2,
+                setpoint = setpointEffective,
+            )
+            val pN2AtCross = schreinerEquation(
+                initialTissuePressure = pNitrogen,
+                inspiredGasPressure = inspiredNitrogenPressureCross,
+                time = timeBelow,
+                halfTime = parameters.n2HalfTime,
+                inspiredGasRate = inspiredNitrogenRateCross,
+            )
+
+            val (inspiredHeliumPressureCross, inspiredHeliumRateCross) = ccrSchreinerInputs(
+                startPressure = startPressure,
+                pressureRate = depthChangeInBarsPerMinute,
+                inertFraction = fHe,
+                oxygenFractionDiluent = fO2,
+                setpoint = setpointEffective,
+            )
+            val pHeAtCross = schreinerEquation(
+                initialTissuePressure = pHelium,
+                inspiredGasPressure = inspiredHeliumPressureCross,
+                time = timeBelow,
+                halfTime = parameters.heHalfTime,
+                inspiredGasRate = inspiredHeliumRateCross,
+            )
+
+            // Sub-segment 2 (above): ambient above setpoint, setpoint maxes on pure oxygen (no more loading)
+            this.pNitrogen = schreinerEquation(
+                initialTissuePressure = pN2AtCross,
+                inspiredGasPressure = 0.0,
+                time = timeAbove,
+                halfTime = parameters.n2HalfTime,
+                inspiredGasRate = 0.0,
+            )
+            this.pHelium = schreinerEquation(
+                initialTissuePressure = pHeAtCross,
+                inspiredGasPressure = 0.0,
+                time = timeAbove,
+                halfTime = parameters.heHalfTime,
+                inspiredGasRate = 0.0,
+            )
+        } else if (isDescentWhileCrossingSetpoint) {
+            val timeAbove = (setpointEffective - startPressure) / (endPressure - startPressure) * timeInMinutes
+            val timeBelow = timeInMinutes - timeAbove
+
+            // Sub-segment 1 (above): setpoint maxes on pure oxygen (no inert gas loading)
+            val pN2AtCross = schreinerEquation(
+                initialTissuePressure = pNitrogen,
+                inspiredGasPressure = 0.0,
+                time = timeAbove,
+                halfTime = parameters.n2HalfTime,
+                inspiredGasRate = 0.0,
+            )
+            val pHeAtCross = schreinerEquation(
+                initialTissuePressure = pHelium,
+                inspiredGasPressure = 0.0,
+                time = timeAbove,
+                halfTime = parameters.heHalfTime,
+                inspiredGasRate = 0.0,
+            )
+
+            // Sub-segment 2 (below): set-point maintained normally
+            val (inspiredNitrogenPressureBelow, inspiredNitrogenRateBelow) = ccrSchreinerInputs(
+                startPressure = setpointEffective,
+                pressureRate = depthChangeInBarsPerMinute,
+                inertFraction = fN2,
+                oxygenFractionDiluent = fO2,
+                setpoint = setpointEffective,
+            )
+            this.pNitrogen = schreinerEquation(
+                initialTissuePressure = pN2AtCross,
+                inspiredGasPressure = inspiredNitrogenPressureBelow,
+                time = timeBelow,
+                halfTime = parameters.n2HalfTime,
+                inspiredGasRate = inspiredNitrogenRateBelow,
+            )
+
+            val (inspiredHeliumPressureBelow, inspiredHeliumRateBelow) = ccrSchreinerInputs(
+                startPressure = setpointEffective,
+                pressureRate = depthChangeInBarsPerMinute,
+                inertFraction = fHe,
+                oxygenFractionDiluent = fO2,
+                setpoint = setpointEffective,
+            )
+            this.pHelium = schreinerEquation(
+                initialTissuePressure = pHeAtCross,
+                inspiredGasPressure = inspiredHeliumPressureBelow,
+                time = timeBelow,
+                halfTime = parameters.heHalfTime,
+                inspiredGasRate = inspiredHeliumRateBelow,
+            )
+        } else {
+            // No ambient-setpoint transition
+
+            val (inspiredNitrogenPressure, inspiredNitrogenRate) = ccrSchreinerInputs(
+                startPressure = startPressure,
+                pressureRate = depthChangeInBarsPerMinute,
+                inertFraction = fN2,
+                oxygenFractionDiluent = fO2,
+                setpoint = setpointEffective,
+            )
+            this.pNitrogen = schreinerEquation(
+                initialTissuePressure = pNitrogen,
+                inspiredGasPressure = inspiredNitrogenPressure,
+                time = timeInMinutes.toDouble(),
+                halfTime = parameters.n2HalfTime,
+                inspiredGasRate = inspiredNitrogenRate,
+            )
+            val (inspiredHeliumPressure, inspiredHeliumRate) = ccrSchreinerInputs(
+                startPressure = startPressure,
+                pressureRate = depthChangeInBarsPerMinute,
+                inertFraction = fHe,
+                oxygenFractionDiluent = fO2,
+                setpoint = setpointEffective,
+            )
+            this.pHelium = schreinerEquation(
+                initialTissuePressure = pHelium,
+                inspiredGasPressure = inspiredHeliumPressure,
+                time = timeInMinutes.toDouble(),
+                halfTime = parameters.heHalfTime,
+                inspiredGasRate = inspiredHeliumRate,
+            )
+        }
     }
 
     /**

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilities.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilities.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -20,26 +20,30 @@ import kotlin.math.ln
 import kotlin.math.pow
 
 /**
- * Returns the Water Vapour pressure in pascals based on the given temperature in degrees Kelvin.
- * Valid temperature range is 1-374 degrees.
+ * Returns the Water Vapor pressure in pascals based on the given temperature in degrees Kelvin.
+ * Valid temperature range is 1.0-374.0 degrees Celsius (inclusive).
  *
  * Initial implementation is based on:
  * https://github.com/nyxtom/dive/blob/08b182cf7b00ab1878344a19f14d9d1ae9b219d0/lib/core.js#L378
  *
- * However the implementation and constants have been modified to work with SI units instead.
+ * However, the implementation and constants have been modified to work with SI units instead.
  */
 fun waterVapourPressure(degreesKelvin: Double): Double {
     // Below is an implementation of the Antoine Equation:
     // - https://en.wikipedia.org/wiki/Antoine_equation
     // - http://en.wikipedia.org/wiki/Vapour_pressure_of_water */
 
-    // According to Wikipedia the valid range for water goes from 0 to 100 but on the high range
-    // from 99 to 374. So there is some slight overlap between the two ranges. For 99 and 100 the
-    // below code prefers the low range.
-    val temperatureConstants: Array<Double> = when (degreesKelvin.asDegreesKelvinToDegreesCelsius()) {
-        in 1.0..100.0 -> ANTOINE_SI_CONSTANTS_FOR_WATER_1_TO_100
-        in 99.0..374.0 -> ANTOINE_SI_CONSTANTS_FOR_WATER_99_TO_374
-        else -> throw IllegalArgumentException("Temperature provided is outside supported range, use a temperature between 1.0 and 374.0 degrees Celsius.")
+    val degreesCelsius = degreesKelvin.asDegreesKelvinToDegreesCelsius()
+    require(degreesCelsius in 1.0..374.0) {
+        "Temperature provided is outside supported range, use a temperature from 1.0 to 374.0 degrees Celsius (inclusive)."
+    }
+
+    // According to Wikipedia the valid range for water goes from 1 to 100 and from 99 to 374.
+    // The two ranges overlap at 99-100; prefer the low-range constants there.
+    val temperatureConstants = if (degreesCelsius <= 100.0) {
+        ANTOINE_SI_CONSTANTS_FOR_WATER_1_TO_100
+    } else {
+        ANTOINE_SI_CONSTANTS_FOR_WATER_99_TO_374
     }
     val log10P = temperatureConstants[0] - (temperatureConstants[1] / (degreesKelvin + temperatureConstants[2]))
     return 10.0.pow(log10P)
@@ -73,19 +77,93 @@ internal fun pressureChangeInBarsPerMinute(beginPressure: Double, endPressure: D
 }
 
 /**
- * Performs Schreiners Equation for one inert gas type and calculates the inert gas pressure in a
- * compartment given: an initial compartment partial gas pressure [pBegin], the partial pressure of the
- * inert gas at the current depth [pGas], the half-time of this compartment [halfTime] and the rate
- * at which the inert gas partial pressure changes per minute [gasRate].
+ * Performs the Schreiner equation for one inert gas type and calculates the inert gas pressure in a
+ * compartment.
  *
- * @param pBegin the initial partial inert gas pressure for this compartment.
- * @param pGas the partial pressure of the inert gas at the current depth
- * @param halfTime the Log2/half-time for this compartment in minutes.
- * @param gasRate the rate at which the partial inert gas pressure changes per minute (depth change)
+ * **Water vapor pressure**:
+ * This function is unaware of water vapor pressure. The caller must subtract water vapor pressure
+ * from ambient pressure before computing [inspiredGasPressure] and [inspiredGasRate] (see
+ * [TissueCompartment.addPressureChange]).
+ *
+ * @param initialTissuePressure the initial partial inert gas pressure for this compartment.
+ * @param inspiredGasPressure the partial pressure of the inspired inert gas at the current depth.
+ * @param halfTime the half-time for this compartment in minutes.
+ * @param inspiredGasRate the rate at which the inspired inert gas partial pressure changes per
+ * minute (due to depth change).
  *
  * @return the new partial inert gas pressure in this compartment.
  */
-internal fun schreinerEquation(pBegin: Double, pGas: Double, timeInMinutes: Int, halfTime: Double, gasRate: Double): Double {
+internal fun schreinerEquation(initialTissuePressure: Double, inspiredGasPressure: Double, time: Double, halfTime: Double, inspiredGasRate: Double): Double {
     val timeConstant = ln(2.0) / halfTime
-    return (pGas + (gasRate * (timeInMinutes - (1.0 / timeConstant))) - ((pGas - pBegin - (gasRate / timeConstant)) * exp(-timeConstant * timeInMinutes)))
+    return (inspiredGasPressure + (inspiredGasRate * (time - (1.0 / timeConstant))) - ((inspiredGasPressure - initialTissuePressure - (inspiredGasRate / timeConstant)) * exp(-timeConstant * time)))
+}
+
+/**
+ * Computes the effective inspired inert gas pressure and its rate of change for a CCR segment,
+ * for use as drop-in replacements for the OC values passed to [schreinerEquation].
+ *
+ * **Water vapor pressure**:
+ * This function is unaware of water vapor pressure (likewise [schreinerEquation]). The caller must
+ * add water vapor pressure to the setpoint before passing it in.
+ *
+ * **Ambient-setpoint transitions**:
+ * This function assumes the entire segment stays on one side of the setpoint pressure (ambient
+ * stays above or below the setpoint for the full segment). If a segment crosses the setpoint
+ * during ascent or descent, the caller must split it into two sub-segments at the point where
+ * ambient equals the setpoint, and call this function separately for each.
+ *
+ * **Why this works**:
+ * On OC the inspired inert gas fraction is fixed, so the inspired inert gas partial pressure
+ * changes linearly with ambient pressure. On CCR the O₂ partial pressure is held constant at the
+ * setpoint, so the inert gas partial pressure is:
+ *
+ * ```
+ * (ambient - setpoint) * inertFraction / (1 - oxygenFractionDiluent)
+ * ```
+ *
+ * Where `(ambient - setpoint)` is the pressure left for non-O₂ gases. Since `inertFraction` is
+ * defined relative to the whole diluent (including its O₂), dividing by `(1 - oxygenFractionDiluent)`
+ * rescales it to exclude the diluent's O₂, which is already accounted for in the setpoint.
+ *
+ * Since ambient pressure changes linearly during a segment, the inspired inert gas pressure is also
+ * linear in time, with a constant rate of change. The Schreiner equation solves for any linear
+ * input, so the same equation handles both OC and CCR: only the starting value and slope differ.
+ *
+ * Verified by tests against the Helling CCR Schreiner equation and a brute-force iterative Haldane
+ * simulation (see [BuhlmannUtilitiesTest]).
+ *
+ * @param startPressure absolute ambient pressure at segment start
+ * @param pressureRate change in ambient pressure per minute
+ * @param inertFraction fraction of the inert gas (He or N₂) in the diluent
+ * @param oxygenFractionDiluent fraction of O₂ in the diluent
+ * @param setpoint water-vapor-corrected O₂ setpoint
+ *
+ * @return Pair(inspiredGasPressure, inspiredGasRate) for [schreinerEquation], or (0.0, 0.0) when
+ * startPressure < setpoint (ambient is below the setpoint, the loop cannot reach the setpoint and
+ * maxes out at pure O₂, so no inert gas is inspired). When startPressure == setpoint,
+ * inspiredGasPressure is naturally 0 (no diluent in loop yet at this depth) but inspiredGasRate is
+ * non-zero because as the diver descends, ambient pressure will exceed the setpoint and inert gas
+ * begins to appear in the loop.
+ */
+internal fun ccrSchreinerInputs(
+    startPressure: Double,
+    pressureRate: Double,
+    inertFraction: Double,
+    oxygenFractionDiluent: Double,
+    setpoint: Double,
+): Pair<Double, Double> {
+    require(oxygenFractionDiluent < 1.0) {
+        "Diluent should contain at least some inert gas, 100% O₂ is unrealistic for CCR diving"
+    }
+    require(inertFraction in 0.0..1.0) {
+        "Inert fraction must be between 0.0 and 1.0, got: $inertFraction"
+    }
+    if (startPressure < setpoint) {
+        return Pair(0.0, 0.0)
+    }
+    val denominator = 1.0 - oxygenFractionDiluent
+    return Pair(
+        inertFraction * (startPressure - setpoint) / denominator,
+        inertFraction * pressureRate / denominator
+    )
 }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculator.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculator.kt
@@ -20,9 +20,8 @@ import kotlin.math.pow
 
 /**
  * This class contains routines for calculating CNS and OTU loading, it is mostly based on 2 blog
- * posts written by by Robert C. Helling (which again is based on Erik Baker his work) and an
- * open-source implementation of Robert C. Hellings blog posts that is MIT licensed called
- * GasPlanner (by Jiri Pokorny):
+ * posts written by Robert Helling (which again is based on Erik Baker his work) and an open-source
+ * implementation of Helling's blog posts that is MIT licensed called GasPlanner (by Jiri Pokorny):
  *
  * - http://web.archive.org/web/20170708072206/https://www.shearwater.com/wp-content/uploads/2012/08/Oxygen_Toxicity_Calculations.pdf
  * - https://thetheoreticaldiver.org/wordpress/index.php/2019/08/15/calculating-oxygen-cns-toxicity/

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannCcrTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannCcrTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.decompression.algorithm.buhlmann
+
+import org.neotech.app.abysner.domain.core.model.Environment
+import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BuhlmannCcrTest {
+
+    private val environment = Environment.SeaLevelSalt
+
+    private fun createModel(gfLow: Double = 0.6, gfHigh: Double = 0.7) = Buhlmann(
+        version = Buhlmann.Version.ZH16C,
+        environment = environment,
+        gfLow = gfLow,
+        gfHigh = gfHigh,
+    )
+
+    @Test
+    fun ccrCeiling_isLowerThanOcCeilingAtSameDepthAndTime() {
+        val ocModel = createModel()
+        val ccrModel = createModel()
+
+        val depth = depthInMetersToBar(30.0, environment)
+
+        ocModel.addPressureChange(depth, depth, Gas.Air, timeInMinutes = 30)
+        ccrModel.addPressureChange(depth, depth, Gas.Air, timeInMinutes = 30, ccrSetpoint = 1.3)
+
+        val ocCeiling = ocModel.getCeiling()
+        val ccrCeiling = ccrModel.getCeiling()
+
+        // Assert CCR ceiling is lower, since CCR uses a constant PPO2 that is higher than the PPO2
+        // of air at 30 meters it reduces inert gas loading.
+        assertTrue(
+            ccrCeiling.value < ocCeiling.value,
+            "CCR ceiling (${ccrCeiling.value}) should be lower than OC ceiling (${ocCeiling.value})"
+        )
+    }
+
+    @Test
+    fun ccrPerMinuteConsistency_singleCallMatchesMultipleCalls() {
+        val singleCallModel = createModel()
+        val multiCallModel = createModel()
+
+        val depth = depthInMetersToBar(30.0, environment)
+        val gas = Gas.Air
+        val setpoint = 1.3
+
+        // 1 x 30-minute
+        singleCallModel.addPressureChange(depth, depth, gas, timeInMinutes = 30, ccrSetpoint = setpoint)
+
+        // 30 x 1-minute
+        repeat(30) {
+            multiCallModel.addPressureChange(depth, depth, gas, timeInMinutes = 1, ccrSetpoint = setpoint)
+        }
+
+        val singleCeiling = singleCallModel.getCeiling()
+        val multiCeiling = multiCallModel.getCeiling()
+
+        // Verify that the ceiling is above atmospheric
+        assertTrue(singleCeiling.value > environment.atmosphericPressure)
+
+        assertEquals(
+            singleCeiling.value,
+            multiCeiling.value,
+            1e-10,
+            "A single 30-minute CCR call must produce the same ceiling as 30 x 1-minute calls."
+        )
+    }
+
+    /**
+     * Test all three CCR tissue loading cases where ambient pressure crosses the setpoint in a
+     * single dive profile:
+     * 1. Descent through the setpoint (ambient pressure crosses from below to above the setpoint)
+     * 2. Flat at depth (ambient pressure stays above setpoint, no crossing)
+     * 3. Ascent through the setpoint (ambient pressure crosses from above to below setpoint)
+     *
+     * No assertions: this is a smoke test that verifies none of the code paths crash.
+     */
+    @Test
+    fun ccrPressureChange_descentFlatAndAscentDoNotCrash() {
+        val model = createModel()
+
+        val surface = depthInMetersToBar(0.0, environment)
+        val bottom = depthInMetersToBar(20.0, environment)
+        val gas = Gas.Air
+        val setpoint = 1.3
+
+        // 1. Descent: surface to 20m over 2 minutes (crosses setpoint boundary)
+        model.addPressureChange(surface, bottom, gas, timeInMinutes = 2, ccrSetpoint = setpoint)
+
+        // 2. Flat: 5 minutes at 20m
+        model.addPressureChange(bottom, bottom, gas, timeInMinutes = 5, ccrSetpoint = setpoint)
+
+        // 3. Ascent: 20m to surface over 2 minutes (crosses setpoint boundary)
+        model.addPressureChange(bottom, surface, gas, timeInMinutes = 2, ccrSetpoint = setpoint)
+    }
+
+    @Test
+    fun referencePlan6_producesExpectedNoDecompressionLimit() {
+        // TODO once planner is CCR aware, this plan/test should move to DivePlannerTest
+        val model = createModel(gfLow = 0.3, gfHigh = 0.7)
+        val surface = depthInMetersToBar(0.0, environment)
+        val bottom = depthInMetersToBar(30.0, environment)
+        val gas = Gas.Air
+        val setpoint = 1.3
+
+        // Descend from surface to 30m at 5 m/min (6 minutes)
+        model.addPressureChange(surface, bottom, gas, timeInMinutes = 6, ccrSetpoint = setpoint)
+
+        // Load minute by minute at bottom until ceiling appears
+        var minutesAtBottom = 0
+        while (model.getCeiling().value <= environment.atmosphericPressure) {
+            minutesAtBottom++
+            model.addPressureChange(bottom, bottom, gas, timeInMinutes = 1, ccrSetpoint = setpoint)
+            if (minutesAtBottom > 200) break
+        }
+
+        // According to other planning software this should lead to about 13 minutes of bottom time
+        // without hitting deco
+        assertEquals(13, minutesAtBottom)
+    }
+}

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilitiesTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilitiesTest.kt
@@ -12,13 +12,294 @@
 
 package org.neotech.app.abysner.domain.decompression.algorithm.buhlmann
 
+import org.neotech.app.abysner.domain.core.model.Environment
+import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import kotlin.math.exp
+import kotlin.math.ln
+import kotlin.math.max
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class BuhlmannUtilitiesTest {
 
     @Test
     fun waterVapourPressureInBars_returnsExpectedValueAt37Celsius() {
         assertEquals(0.0625993025768047, waterVapourPressureInBars(37.0))
+    }
+
+    /**
+     * A diver ascending from a deco stop with a 1.3 bar setpoint. Once ambient drops below
+     * 1.3 bar (around 3 meters), the setpoint can no longer be maintained and the loop
+     * transitions to pure O₂, so no inert gas is inspired.
+     */
+    @Test
+    fun ccrSchreinerInputs_returnsZeroWhenAmbientBelowSetpoint() {
+        val (inspiredGasPressure, inspiredGasRate) = ccrSchreinerInputs(
+            startPressure = Environment.SeaLevelFresh.atmosphericPressure,
+            pressureRate = 0.3,
+            inertFraction = 0.79,
+            oxygenFractionDiluent = 0.21,
+            setpoint = 1.3,
+        )
+        assertEquals(0.0, inspiredGasPressure)
+        assertEquals(0.0, inspiredGasRate)
+    }
+
+    /**
+     * A diver beginning descent at the surface (assume 1.0 bar) with a 1.0 bar setpoint. Ambient
+     * pressure is exactly equal the setpoint so no diluent is needed yet, giving an
+     * inspiredGasPressure of 0. However, inspiredGasRate should remain non-zero because as the
+     * diver descends further, ambient will exceed the setpoint and inert gas will begin to appear
+     * in the loop.
+     */
+    @Test
+    fun ccrSchreinerInputs_ambientAtSetpointYieldsZeroInspiredPressureButNonZeroRate() {
+        val (inspiredGasPressure, inspiredGasRate) = ccrSchreinerInputs(
+            startPressure = 1.0,
+            pressureRate = 1.8,
+            inertFraction = 0.20,
+            oxygenFractionDiluent = 0.10,
+            setpoint = 1.0,
+        )
+        assertEquals(0.0, inspiredGasPressure)
+        assertEquals(0.20 * 1.8 / (1.0 - 0.10), inspiredGasRate, absoluteTolerance = 1e-15)
+    }
+
+    @Test
+    fun ccrSchreinerInputs_throwsWhenDiluentIsPureOxygen() {
+        assertFailsWith<IllegalArgumentException> {
+            ccrSchreinerInputs(
+                startPressure = 5.0,
+                pressureRate = 1.8,
+                inertFraction = 0.0,
+                oxygenFractionDiluent = 1.0,
+                setpoint = 1.3,
+            )
+        }
+    }
+
+    @Test
+    fun ccrSchreinerInputs_throwsWhenInertFractionOutOfRange() {
+        assertFailsWith<IllegalArgumentException> {
+            ccrSchreinerInputs(
+                startPressure = 5.0,
+                pressureRate = 1.8,
+                inertFraction = 1.1,
+                oxygenFractionDiluent = 0.21,
+                setpoint = 1.3,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ccrSchreinerInputs(
+                startPressure = 5.0,
+                pressureRate = 1.8,
+                inertFraction = -0.1,
+                oxygenFractionDiluent = 0.21,
+                setpoint = 1.3,
+            )
+        }
+    }
+
+    /**
+     * Verifies that [ccrSchreinerInputs] fed into [schreinerEquation] produces the same result as
+     * the independent CCR Schreiner equation, to a high degree of precision.
+     *
+     * The scenario used here is based on the one found in this forum post:
+     * https://scubaboard.com/community/threads/schreiner-equations-for-ccr.554316/post-8154670
+     *
+     * Scenario:
+     * Descent to 90 meter at 18 meter/min using a 10/70 diluent with a 1.0 setpoint
+     *
+     * Note: No water vapor correction, since that responsibility lies elsewhere in the code base.
+     *
+     * Tests the same four ZH-16C N₂ compartments (half-times 5.0, 18.5, 54.3, 635.0 min) as found
+     * in the forum post.
+     */
+    @Test
+    fun ccrSchreinerInputs_matchesHellingEquation() {
+        val oxygenFractionDiluent = 0.10
+        val nitrogenFractionDiluent = 0.20
+        val setpoint = 1.0
+        val surfacePressure = Environment.SeaLevelFresh.atmosphericPressure
+        val endPressure = depthInMetersToBar(90.0, Environment.SeaLevelFresh).value
+        val time = 5.0
+        val pressureRate = (endPressure - surfacePressure) / time
+        val initialNitrogenPressure = 0.79 * surfacePressure
+        val fractionOfInert = nitrogenFractionDiluent / (1.0 - oxygenFractionDiluent)
+
+        val halfTimes = listOf(5.0, 18.5, 54.3, 635.0)
+
+        val (inspiredGasPressure, inspiredGasRate) = ccrSchreinerInputs(
+            startPressure = surfacePressure,
+            pressureRate = pressureRate,
+            inertFraction = nitrogenFractionDiluent,
+            oxygenFractionDiluent = oxygenFractionDiluent,
+            setpoint = setpoint,
+        )
+
+        for (halfTime in halfTimes) {
+            val transformedSchreiner = schreinerEquation(
+                initialTissuePressure = initialNitrogenPressure,
+                inspiredGasPressure = inspiredGasPressure,
+                time = time,
+                halfTime = halfTime,
+                inspiredGasRate = inspiredGasRate,
+            )
+            val helling = hellingCcrEquation(
+                initialTissuePressure = initialNitrogenPressure,
+                fractionOfInert = fractionOfInert,
+                startPressure = surfacePressure,
+                pressureRate = pressureRate,
+                setpoint = setpoint,
+                halfTime = halfTime,
+                time = time,
+            )
+
+            assertEquals(transformedSchreiner, helling, absoluteTolerance = 1e-12)
+        }
+    }
+
+    /**
+     * Verifies that [ccrSchreinerInputs] fed into [schreinerEquation] converges to the
+     * same result as a fine-grained iterative Haldane simulation (60,000 steps/min).
+     *
+     * Same scenario as [ccrSchreinerInputs_matchesHellingEquation].
+     * The iterative approach is an independent numerical method with no shared code.
+     * Agreement to ~1e-5 confirms the analytic CCR transform is correct.
+     */
+    @Test
+    fun ccrSchreinerInputs_matchesIterativeHaldaneGroundTruth() {
+        val oxygenFractionDiluent = 0.10
+        val nitrogenFractionDiluent = 0.20
+        val setpoint = 1.0
+        val surfacePressure = Environment.SeaLevelFresh.atmosphericPressure
+        val endPressure = depthInMetersToBar(90.0, Environment.SeaLevelFresh).value
+        val time = 5.0
+        val pressureRate = (endPressure - surfacePressure) / time
+        val initialNitrogenPressure = 0.79 * surfacePressure
+        val fractionOfInert = nitrogenFractionDiluent / (1.0 - oxygenFractionDiluent)
+
+        val halfTimes = listOf(5.0, 18.5, 54.3, 635.0)
+
+        val (inspiredGasPressure, inspiredGasRate) = ccrSchreinerInputs(
+            startPressure = surfacePressure,
+            pressureRate = pressureRate,
+            inertFraction = nitrogenFractionDiluent,
+            oxygenFractionDiluent = oxygenFractionDiluent,
+            setpoint = setpoint,
+        )
+
+        for (halfTime in halfTimes) {
+            val transformedSchreiner = schreinerEquation(
+                initialTissuePressure = initialNitrogenPressure,
+                inspiredGasPressure = inspiredGasPressure,
+                time = time,
+                halfTime = halfTime,
+                inspiredGasRate = inspiredGasRate,
+            )
+            val iterative = iterativeHaldaneCcr(
+                initialTissuePressure = initialNitrogenPressure,
+                fractionOfInert = fractionOfInert,
+                startPressure = surfacePressure,
+                pressureRate = pressureRate,
+                setpoint = setpoint,
+                halfTime = halfTime,
+                time = time,
+            )
+
+            assertEquals(transformedSchreiner, iterative, absoluteTolerance = 1e-5)
+        }
+    }
+
+    /**
+     * Direct implementation of the Helling blog CCR Schreiner equation. Used to verify
+     * the more indirect form used in code.
+     *
+     * Used as an independent ground truth reference.
+     *
+     * Original blog equation (The Theoretical Diver, Helling, 2017):
+     *
+     * ```
+     * p_t = (f_i / (1 - f_O2)) * (e^(-gamma*t) - 1) * (p_s + (v * g * rho) / gamma)
+     *     + e^(-gamma*t) * (p_0 - (f_i / (1 - f_O2)) * (p_surf + d_0 * g * rho))
+     *     + (f_i / (1 - f_O2)) * (p_surf + d * g * rho)
+     * ```
+     *
+     * Where:
+     *  - p_t = Tissue inert gas pressure after time `t`
+     *  - p_0 = Initial tissue inert gas pressure
+     *  - p_s = Setpoint
+     *  - gamma = Tissue compartment time constant (`ln(2) / halfTime`)
+     *
+     * For my own sanity I'm substituting some of the equation for a more "engineering" naming scheme:
+     *  - [initialTissuePressure] = `p_0`
+     *  - [setpoint] = `p_s`
+     *  - [pressureRate] = `v * g * rho` (bar/min)
+     *  - [startPressure] = `p_surf + d_0 * g * rho` (absolute ambient at start)
+     *  - [fractionOfInert] = `f_i / (1 - f_O2)`
+     *  - [time] = `t`
+     *  - timeConstant = `gamma`
+     *  - exponentialDecay = `e^(-timeConstant * t)`
+     *
+     * This gives the following rewritten form:
+     *
+     * ```
+     * resultTissuePressure = fractionOfInert * (exponentialDecay - 1) * (setpoint + pressureRate / timeConstant)
+     *     + exponentialDecay * (initialTissuePressure - fractionOfInert * startPressure)
+     *     + fractionOfInert * (startPressure + pressureRate * time)
+     * ```
+     *
+     * Water vapor is handled by replacing the setpoint (`p_s`) with `setpoint + waterVaporPressure`,
+     * as stated in the blog update. This function takes the setpoint as-is, it is the callers
+     * responsibility to adjust for waterVaporPressure this is inline with the code base.
+     *
+     * Source: https://thetheoreticaldiver.org/wordpress/index.php/2017/11/30/ccr-schreiner-equation/
+     */
+    private fun hellingCcrEquation(
+        initialTissuePressure: Double,
+        fractionOfInert: Double,
+        startPressure: Double,
+        pressureRate: Double,
+        setpoint: Double,
+        halfTime: Double,
+        time: Double,
+    ): Double {
+        val timeConstant = ln(2.0) / halfTime
+        val exponentialDecay = exp(-timeConstant * time)
+        return (fractionOfInert * (exponentialDecay - 1.0) * (setpoint + pressureRate / timeConstant)
+                + exponentialDecay * (initialTissuePressure - fractionOfInert * startPressure)
+                + fractionOfInert * (startPressure + pressureRate * time))
+    }
+
+    /**
+     * Iterative approach to CCR tissue loading (Haldane approximation). With a sufficiently fine
+     * step size this approximates the analytic solution (the one provided by Helling) closely, but
+     * floating-point accumulation errors prevent true convergence at as steps become too small.
+     *
+     * Used as an independent ground truth reference.
+     */
+    private fun iterativeHaldaneCcr(
+        initialTissuePressure: Double,
+        fractionOfInert: Double,
+        startPressure: Double,
+        pressureRate: Double,
+        setpoint: Double,
+        halfTime: Double,
+        time: Double,
+        stepsPerMinute: Int = 60_000,
+    ): Double {
+        val timeStep = 1.0 / stepsPerMinute
+        val totalSteps = (time * stepsPerMinute).toInt()
+        var tissuePressure = initialTissuePressure
+        val timeConstant = ln(2.0) / halfTime
+
+        for (step in 0 until totalSteps) {
+            val currentPressure = startPressure + pressureRate * step * timeStep
+            val inertGasPressure = max(0.0, currentPressure - setpoint) * fractionOfInert
+            val decayFactor = 1.0 - exp(-timeConstant * timeStep)
+            tissuePressure += (inertGasPressure - tissuePressure) * decayFactor
+        }
+        return tissuePressure
     }
 }


### PR DESCRIPTION
Implement closed-circuit rebreather support by adding a `ccrSchreinerInputs()` function that computes effective inspired gas pressure and rate for CCR segments, allowing the existing Schreiner equation to handle both OC and CCR with different inputs.

A `ccrSetpoint` parameter is added to `TissueCompartment.addPressureChange()` which handles three cases:
- Segment fully below the setpoint (normal CCR setpoint based tissue loading)
- Ascent crossing the setpoint (split into normal CCR + pure O2 sub-segments)
- Descent crossing the setpoint (split into pure O2 + normal CCR sub-segments)

Above the setpoint the loop maxes out on pure oxygen, so no inert gas loading occurs in that portion.

Verified against the CCR Schreiner equation published by Robert Helling ("The Theoretical Diver", 2017) and against a brute-force iterative Haldane simulation.

Required for: #3