### PR TITLE
chore: Add Dockerfile for JVM test builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+**/build/
+.gradle/
+.kotlin/
+.idea/
+*.iml
+.DS_Store
+xcuserdata/
+*.xcodeproj/
+*.xcworkspace/
+iosApp/
+androidApp/src/
+composeApp/release/
+keystore.properties
+abysner-release.p12
+local.properties
+store-art/
+resources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM eclipse-temurin:21-jdk
+
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+# Disable file system watching, the Gradle daemon and warnings for disabled Kotlin targets
+RUN mkdir -p /root/.gradle && cat <<EOF > /root/.gradle/gradle.properties
+org.gradle.vfs.watch=false
+org.gradle.daemon=false
+kotlin.native.ignoreDisabledTargets=true
+EOF
+
+WORKDIR /project
+
+# Copy Gradle wrapper first for layer caching
+COPY gradlew gradle.properties ./
+COPY gradle/wrapper/ gradle/wrapper/
+RUN ./gradlew --version
+
+# Copy version catalog and buildSrc (custom Gradle plugins)
+COPY gradle/libs.versions.toml gradle/
+COPY buildSrc/ buildSrc/
+
+# Copy build files for dependency resolution
+COPY settings.gradle.kts ./
+COPY build.gradle.kts ./
+COPY domain/build.gradle.kts domain/
+COPY data/build.gradle.kts data/
+COPY composeApp/build.gradle.kts composeApp/
+COPY androidApp/build.gradle.kts androidApp/
+
+# Create directories expected by build scripts
+RUN mkdir -p iosApp/Configuration
+
+# Pre-fetch all dependencies into a cached layer
+RUN ./gradlew dependencies
+
+# Copy git metadata for version info task
+COPY .git/ .git/
+
+# Copy source code
+COPY domain/src/ domain/src/
+COPY data/src/ data/src/
+COPY composeApp/src/ composeApp/src/
+COPY composeApp/compose-stability.conf composeApp/


### PR DESCRIPTION
Add a Dockerfile and .dockerignore for building and testing JVM targets without a local JDK.

Includes optimizations suggested by @Rolf-Smit in #114:
- Gradle properties for Docker (no daemon, no filesystem watching, ignore disabled native targets)
- Copy only gradle/wrapper/ and libs.versions.toml separately for better layer caching
- Pre-fetch dependencies into a cached layer
- Copy compose-stability.conf with source code
- Expanded .dockerignore with local.properties, store-art/, resources/