### PR TITLE
Fix: Correctly subtract water vapor pressure from ambient pressure

### DIFF
--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/ShareImageScreenshotTestKt/ShareImageScreenshotTest_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/ShareImageScreenshotTestKt/ShareImageScreenshotTest_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76c7af16ab9d7409635bfc5bc4a062fc2d99671cd8c2199cb1ccc7bbc6337d7a
-size 208246
+oid sha256:76dcf42b6f7bb2051c572378e510ca9ac5e590f85c93876281a3c9492b5ef370
+size 209212

--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenScreenshotTest_d70cdda2_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenScreenshotTest_d70cdda2_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:847094672a1bbc7006874b8ab875df344383eb186e891fce17416fb4307a3481
-size 190391
+oid sha256:cb40aa2399bf5ddc28b61d2aa82b7080844c2aec1fa0d20ab6ba164acc2eb0fb
+size 190336

--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenWithWarningsScreenshotTest_d70cdda2_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenWithWarningsScreenshotTest_d70cdda2_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0e9314be2d25cad1b238d00de295adc62fed1102af7c839b5d3585d03a15d95
-size 220556
+oid sha256:61388523c453a9c4f555b826ecd9c2c9f1fad6cb98d943864f1c9b8215ba0141
+size 220718

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
@@ -203,7 +203,7 @@ data class TissueCompartment(
     /**
      * Initial nitrogen load assumes fully saturated (equilibrium), regardless of atmospheric pressure.
      */
-    private var pNitrogen: Double = partialPressure(environment.atmosphericPressure, 0.79) - waterVapourPressure,
+    private var pNitrogen: Double = partialPressure(environment.atmosphericPressure - waterVapourPressure, 0.79),
     private var pHelium: Double = 0.0,
     private var pTotal: Double = pNitrogen + pHelium
 ) {
@@ -245,16 +245,21 @@ data class TissueCompartment(
         timeInMinutes: Int,
         depthChangeInBarsPerMinute: Double
     ) {
+        // Inspired gas pressure: subtract alveolar water vapor pressure from ambient before
+        // applying gas fractions (water vapor displaces the entire gas mixture, not just one
+        // component).
+        val inspiredPressure = startPressure - waterVapourPressure
+
         this.pNitrogen = schreinerEquation(
             initialTissuePressure = pNitrogen,
-            inspiredGasPressure = partialPressure(startPressure, fN2),
+            inspiredGasPressure = partialPressure(inspiredPressure, fN2),
             time = timeInMinutes.toDouble(),
             halfTime = parameters.n2HalfTime,
             inspiredGasRate = partialPressure(depthChangeInBarsPerMinute, fN2),
         )
         this.pHelium = schreinerEquation(
             initialTissuePressure = pHelium,
-            inspiredGasPressure = partialPressure(startPressure, fHe),
+            inspiredGasPressure = partialPressure(inspiredPressure, fHe),
             time = timeInMinutes.toDouble(),
             halfTime = parameters.heHalfTime,
             inspiredGasRate = partialPressure(depthChangeInBarsPerMinute, fHe),

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannTest.kt
@@ -32,9 +32,9 @@ class BuhlmannTest {
         val depths = listOf(10, 12, 14, 16, 18, 20, 22, 25, 30, 35, 40, 42)
 
         // Expected NDL times
-        val expectedNdlTimes = listOf(294, 150, 95, 71, 55, 42, 34, 25, 16, 12, 9, 8)
+        val expectedNdlTimes = listOf(409, 176, 107, 77, 59, 45, 36, 26, 17, 12, 9, 8)
         // Real PADI values:          219, 147, 98, 72, 56, 45, 37, 29, 20, 14, 9, 8
-        // Difference:                +75, +3,  -3, -1, -1, -3, -3, -4, -4, -2, 0, 0
+        // Difference:                +190, +29, +9, +5, +3,  0, -1, -3, -3, -2, 0, 0
 
         depths.forEachIndexed { index, depth ->
             val ndlTime = model.getNoDecompressionLimit(

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
@@ -83,8 +83,8 @@ class DivePlannerTest {
 
         // println(divePlan.toString(compact = false))
 
-        assertEquals(11.745, divePlan.totalCns, tenthAtDecimalPoint(3))
-        assertEquals(34.761, divePlan.totalOtu, tenthAtDecimalPoint(3))
+        assertEquals(11.526, divePlan.totalCns, tenthAtDecimalPoint(3))
+        assertEquals(34.091, divePlan.totalOtu, tenthAtDecimalPoint(3))
 
         plan.assertSegment(0, DiveSegment.Type.DECENT,     startDepth = 0.0,  endDepth = 30.0, duration = 6,  gas = bottomGas)
         plan.assertSegment(1, DiveSegment.Type.FLAT,       startDepth = 30.0, endDepth = 30.0, duration = 24, gas = bottomGas)
@@ -93,7 +93,7 @@ class DivePlannerTest {
         plan.assertSegment(4, DiveSegment.Type.ASCENT,     startDepth = 21.0, endDepth = 9.0,  duration = 3,  gas = decoGas)
         plan.assertSegment(5, DiveSegment.Type.DECO_STOP,  startDepth = 9.0,  endDepth = 9.0,  duration = 1,  gas = decoGas)
         plan.assertSegment(6, DiveSegment.Type.ASCENT,     startDepth = 9.0,  endDepth = 6.0,  duration = 1,  gas = decoGas)
-        plan.assertSegment(7, DiveSegment.Type.DECO_STOP,  startDepth = 6.0,  endDepth = 6.0,  duration = 11, gas = decoGas)
+        plan.assertSegment(7, DiveSegment.Type.DECO_STOP,  startDepth = 6.0,  endDepth = 6.0,  duration = 10, gas = decoGas)
         plan.assertSegment(8, DiveSegment.Type.ASCENT,     startDepth = 6.0,  endDepth = 0.0,  duration = 2,  gas = decoGas)
     }
 
@@ -122,8 +122,8 @@ class DivePlannerTest {
 
         // println(divePlan.toString(compact = false))
 
-        assertEquals(8.778, divePlan.totalCns, tenthAtDecimalPoint(3))
-        assertEquals(24.495, divePlan.totalOtu, tenthAtDecimalPoint(3))
+        assertEquals(8.614, divePlan.totalCns, tenthAtDecimalPoint(3))
+        assertEquals(24.112, divePlan.totalOtu, tenthAtDecimalPoint(3))
 
         plan.assertSegment(0, DiveSegment.Type.DECENT,     startDepth = 0.0,  endDepth = 45.0, duration = 9, gas = bottomGas)
         plan.assertSegment(1, DiveSegment.Type.FLAT,       startDepth = 45.0, endDepth = 45.0, duration = 6, gas = bottomGas)
@@ -132,7 +132,7 @@ class DivePlannerTest {
         plan.assertSegment(4, DiveSegment.Type.ASCENT,     startDepth = 21.0, endDepth = 6.0,  duration = 3, gas = decoGas)
         plan.assertSegment(5, DiveSegment.Type.DECO_STOP,  startDepth = 6.0,  endDepth = 6.0,  duration = 2, gas = decoGas)
         plan.assertSegment(6, DiveSegment.Type.ASCENT,     startDepth = 6.0,  endDepth = 3.0,  duration = 1, gas = decoGas)
-        plan.assertSegment(7, DiveSegment.Type.DECO_STOP,  startDepth = 3.0,  endDepth = 3.0,  duration = 5, gas = decoGas)
+        plan.assertSegment(7, DiveSegment.Type.DECO_STOP,  startDepth = 3.0,  endDepth = 3.0,  duration = 4, gas = decoGas)
         plan.assertSegment(8, DiveSegment.Type.ASCENT,     startDepth = 3.0,  endDepth = 0.0,  duration = 1, gas = decoGas)
     }
 
@@ -161,26 +161,24 @@ class DivePlannerTest {
 
         // println(divePlan.toString(compact = false))
 
-        assertEquals(15.472, divePlan.totalCns, tenthAtDecimalPoint(3))
-        assertEquals(41.447, divePlan.totalOtu, tenthAtDecimalPoint(3))
+        assertEquals(14.867, divePlan.totalCns, tenthAtDecimalPoint(3))
+        assertEquals(39.917, divePlan.totalOtu, tenthAtDecimalPoint(3))
 
         plan.assertSegment(0,  DiveSegment.Type.DECENT,     startDepth = 0.0,  endDepth = 60.0, duration = 12, gas = bottomGas)
         plan.assertSegment(1,  DiveSegment.Type.FLAT,       startDepth = 60.0, endDepth = 60.0, duration = 8,  gas = bottomGas)
         plan.assertSegment(2,  DiveSegment.Type.ASCENT,     startDepth = 60.0, endDepth = 21.0, duration = 8,  gas = bottomGas)
         plan.assertSegment(3,  DiveSegment.Type.GAS_SWITCH, startDepth = 21.0, endDepth = 21.0, duration = 1,  gas = bottomGas)
-        plan.assertSegment(4,  DiveSegment.Type.ASCENT,     startDepth = 21.0, endDepth = 18.0, duration = 1,  gas = decoGas)
-        plan.assertSegment(5,  DiveSegment.Type.DECO_STOP,  startDepth = 18.0, endDepth = 18.0, duration = 1,  gas = decoGas)
-        plan.assertSegment(6,  DiveSegment.Type.ASCENT,     startDepth = 18.0, endDepth = 15.0, duration = 1,  gas = decoGas)
-        plan.assertSegment(7,  DiveSegment.Type.DECO_STOP,  startDepth = 15.0, endDepth = 15.0, duration = 1,  gas = decoGas)
-        plan.assertSegment(8,  DiveSegment.Type.ASCENT,     startDepth = 15.0, endDepth = 12.0, duration = 1,  gas = decoGas)
-        plan.assertSegment(9,  DiveSegment.Type.DECO_STOP,  startDepth = 12.0, endDepth = 12.0, duration = 1,  gas = decoGas)
-        plan.assertSegment(10, DiveSegment.Type.ASCENT,     startDepth = 12.0, endDepth = 9.0,  duration = 1,  gas = decoGas)
-        plan.assertSegment(11, DiveSegment.Type.DECO_STOP,  startDepth = 9.0,  endDepth = 9.0,  duration = 3,  gas = decoGas)
-        plan.assertSegment(12, DiveSegment.Type.ASCENT,     startDepth = 9.0,  endDepth = 6.0,  duration = 1,  gas = decoGas)
-        plan.assertSegment(13, DiveSegment.Type.DECO_STOP,  startDepth = 6.0,  endDepth = 6.0,  duration = 5,  gas = decoGas)
-        plan.assertSegment(14, DiveSegment.Type.ASCENT,     startDepth = 6.0,  endDepth = 3.0,  duration = 1,  gas = decoGas)
-        plan.assertSegment(15, DiveSegment.Type.DECO_STOP,  startDepth = 3.0,  endDepth = 3.0,  duration = 11, gas = decoGas)
-        plan.assertSegment(16, DiveSegment.Type.ASCENT,     startDepth = 3.0,  endDepth = 0.0,  duration = 1,  gas = decoGas)
+        plan.assertSegment(4,  DiveSegment.Type.ASCENT,     startDepth = 21.0, endDepth = 15.0, duration = 2,  gas = decoGas)
+        plan.assertSegment(5,  DiveSegment.Type.DECO_STOP,  startDepth = 15.0, endDepth = 15.0, duration = 1,  gas = decoGas)
+        plan.assertSegment(6,  DiveSegment.Type.ASCENT,     startDepth = 15.0, endDepth = 12.0, duration = 1,  gas = decoGas)
+        plan.assertSegment(7,  DiveSegment.Type.DECO_STOP,  startDepth = 12.0, endDepth = 12.0, duration = 1,  gas = decoGas)
+        plan.assertSegment(8,  DiveSegment.Type.ASCENT,     startDepth = 12.0, endDepth = 9.0,  duration = 1,  gas = decoGas)
+        plan.assertSegment(9,  DiveSegment.Type.DECO_STOP,  startDepth = 9.0,  endDepth = 9.0,  duration = 3,  gas = decoGas)
+        plan.assertSegment(10, DiveSegment.Type.ASCENT,     startDepth = 9.0,  endDepth = 6.0,  duration = 1,  gas = decoGas)
+        plan.assertSegment(11, DiveSegment.Type.DECO_STOP,  startDepth = 6.0,  endDepth = 6.0,  duration = 5,  gas = decoGas)
+        plan.assertSegment(12, DiveSegment.Type.ASCENT,     startDepth = 6.0,  endDepth = 3.0,  duration = 1,  gas = decoGas)
+        plan.assertSegment(13, DiveSegment.Type.DECO_STOP,  startDepth = 3.0,  endDepth = 3.0,  duration = 11, gas = decoGas)
+        plan.assertSegment(14, DiveSegment.Type.ASCENT,     startDepth = 3.0,  endDepth = 0.0,  duration = 1,  gas = decoGas)
     }
 
     @Test
@@ -211,7 +209,7 @@ class DivePlannerTest {
 
         // println(divePlan.toString(compact = false))
 
-        assertEquals(8.479, divePlan.totalCns, tenthAtDecimalPoint(3))
+        assertEquals(8.480, divePlan.totalCns, tenthAtDecimalPoint(3))
         assertEquals(25.542, divePlan.totalOtu, tenthAtDecimalPoint(3))
 
         plan.assertSegment(0,  DiveSegment.Type.DECENT,    startDepth = 0.0,  endDepth = 40.0, duration = 8,  gas = bottomGas)
@@ -223,9 +221,9 @@ class DivePlannerTest {
         plan.assertSegment(6,  DiveSegment.Type.ASCENT,    startDepth = 40.0, endDepth = 9.0,  duration = 7,  gas = bottomGas)
         plan.assertSegment(7,  DiveSegment.Type.DECO_STOP, startDepth = 9.0,  endDepth = 9.0,  duration = 3,  gas = bottomGas)
         plan.assertSegment(8,  DiveSegment.Type.ASCENT,    startDepth = 9.0,  endDepth = 6.0,  duration = 1,  gas = bottomGas)
-        plan.assertSegment(9,  DiveSegment.Type.DECO_STOP, startDepth = 6.0,  endDepth = 6.0,  duration = 6,  gas = bottomGas)
+        plan.assertSegment(9,  DiveSegment.Type.DECO_STOP, startDepth = 6.0,  endDepth = 6.0,  duration = 5,  gas = bottomGas)
         plan.assertSegment(10, DiveSegment.Type.ASCENT,    startDepth = 6.0,  endDepth = 3.0,  duration = 1,  gas = bottomGas)
-        plan.assertSegment(11, DiveSegment.Type.DECO_STOP, startDepth = 3.0,  endDepth = 3.0,  duration = 15, gas = bottomGas)
+        plan.assertSegment(11, DiveSegment.Type.DECO_STOP, startDepth = 3.0,  endDepth = 3.0,  duration = 14, gas = bottomGas)
         plan.assertSegment(12, DiveSegment.Type.ASCENT,    startDepth = 3.0,  endDepth = 0.0,  duration = 1,  gas = bottomGas)
     }
 

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/GasSwitchTimeTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/GasSwitchTimeTest.kt
@@ -66,7 +66,7 @@ class GasSwitchTimeTest {
         plan.assertSegment(4, DiveSegment.Type.ASCENT,    startDepth = 21.0, endDepth = 9.0,  duration = 3,  gas = decoGas)
         plan.assertSegment(5, DiveSegment.Type.DECO_STOP, startDepth = 9.0,  endDepth = 9.0,  duration = 1,  gas = decoGas)
         plan.assertSegment(6, DiveSegment.Type.ASCENT,    startDepth = 9.0,  endDepth = 6.0,  duration = 1,  gas = decoGas)
-        plan.assertSegment(7, DiveSegment.Type.DECO_STOP, startDepth = 6.0,  endDepth = 6.0,  duration = 11, gas = decoGas)
+        plan.assertSegment(7, DiveSegment.Type.DECO_STOP, startDepth = 6.0,  endDepth = 6.0,  duration = 10, gas = decoGas)
         plan.assertSegment(8, DiveSegment.Type.ASCENT,    startDepth = 6.0,  endDepth = 0.0,  duration = 2,  gas = decoGas)
     }
 

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/SurfaceIntervalTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/SurfaceIntervalTest.kt
@@ -35,10 +35,10 @@ class SurfaceIntervalTest {
         val divePlan2 = divePlanner.addDive(plannedDive, emptyList())
 
 
-        assertEquals(45, divePlan1.runtime)
+        assertEquals(43, divePlan1.runtime)
 
         // Dive plan 2 is the same as dive plan 1, except that it has to take into account tissues
         // from the previous dive (dive plan 1), as the surface interval is short.
-        assertEquals(64, divePlan2.runtime)
+        assertEquals(59, divePlan2.runtime)
     }
 }

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
@@ -61,7 +61,7 @@ class GasPlannerTest {
         // at T=10 and D=50.0: TTS=11
         // at T=11 and D=50.0: TTS=12
         // at T=21 and D=20.0: TTS=6
-        // at T=51 and D=20.0: TTS=14
+        // at T=51 and D=20.0: TTS=13
 
         // TTS at 51 minutes in the dive (20 meters) is longer than the TTS at 11 minutes in the
         // dive, at depth 50 meters! However the depth of 50 meters could still require more gas due
@@ -71,7 +71,7 @@ class GasPlannerTest {
         val ttsWorstCaseScenarios = GasPlanner().findPotentialWorstCaseTtsPoints(divePlan)
         assertEquals(2, ttsWorstCaseScenarios.size)
         assertTrue { ttsWorstCaseScenarios.any { it.end == 11 && it.endDepth == 50.0 && it.ttsAfter == 12 } }
-        assertTrue { ttsWorstCaseScenarios.any { it.end == 51 && it.endDepth == 20.0 && it.ttsAfter == 14 } }
+        assertTrue { ttsWorstCaseScenarios.any { it.end == 51 && it.endDepth == 20.0 && it.ttsAfter == 13 } }
     }
 
     @Test
@@ -107,11 +107,11 @@ class GasPlannerTest {
 
         // at T=15 and D=10.0: TTS=2
         // at T=30 and D=15.0: TTS=3
-        // at T=48 and D=23.0: TTS=15
+        // at T=48 and D=23.0: TTS=12
 
         val ttsWorstCaseScenarios = GasPlanner().findPotentialWorstCaseTtsPoints(divePlan)
         assertEquals(1, ttsWorstCaseScenarios.size)
-        assertTrue { ttsWorstCaseScenarios.any { it.end == 48 && it.endDepth == 23.0 && it.ttsAfter == 15 } }
+        assertTrue { ttsWorstCaseScenarios.any { it.end == 48 && it.endDepth == 23.0 && it.ttsAfter == 12 } }
     }
 
     /**
@@ -150,8 +150,8 @@ class GasPlannerTest {
 
         val gasPlan = GasPlanner().calculateGasPlan(divePlan)
 
-        assertEquals(3769.0, gasPlan[0].totalGasRequirement, tenthAtDecimalPoint(0))
-        assertEquals(4131.0, gasPlan[1].totalGasRequirement, tenthAtDecimalPoint(0))
+        assertEquals(3770.0, gasPlan[0].totalGasRequirement, tenthAtDecimalPoint(0))
+        assertEquals(3824.0, gasPlan[1].totalGasRequirement, tenthAtDecimalPoint(0))
     }
 
     /**

--- a/readme.md
+++ b/readme.md
@@ -177,8 +177,8 @@ plan, see the plan specific tables for those.
 | - | 21m   | 1min     | 33min   | 50/0 |
 | ➚ | 9m    | 3min     | 36min   | 50/0 |
 | ⏹ | 9m    | 1min     | 37min   | 50/0 |
-| ⏹ | 6m    | 12min    | 49min   | 50/0 |
-| ➚ | 0m    | 2min     | 51min   | 50/0 |
+| ⏹ | 6m    | 11min    | 48min   | 50/0 |
+| ➚ | 0m    | 2min     | 50min   | 50/0 |
 **CNS**: 12%  
 **OTU**: 35
 </details>
@@ -248,8 +248,8 @@ plan, see the plan specific tables for those.
 | - | 21m   | 1min     | 21min   | 50/0  |
 | ➚ | 6m    | 3min     | 24min   | 50/0  |
 | ⏹ | 6m    | 2min     | 26min   | 50/0  |
-| ⏹ | 3m    | 6min     | 32min   | 50/0  |
-| ➚ | 0m    | 1min     | 33min   | 50/0  |
+| ⏹ | 3m    | 5min     | 31min   | 50/0  |
+| ➚ | 0m    | 1min     | 32min   | 50/0  |
 **CNS**: 9%  
 **OTU**: 25
 </details>
@@ -283,8 +283,8 @@ plan, see the plan specific tables for those.
 > row's runtime from the current row, to make it consistent with Subsurface and Abysner.
 >
 > DIVESOFT.APP does not appear to include a gas switch time. With gas switch time set to one minute
-> Abysner produces the same total runtime (33min), though the individual stop distributions differ
-> ever so slightly.
+> Abysner produces total runtime of 32min, compared to 33min for DIVESOFT.APP. The individual stop
+> distributions differ ever so slightly.
 
 |   | Depth | Duration | Runtime | Gas   |
 |---|-------|----------|---------|-------|
@@ -318,23 +318,24 @@ plan, see the plan specific tables for those.
 | ➙ | 60m   | 8min     | 20min   | 18/45 |
 | ➚ | 21m   | 8min     | 28min   | 18/45 |
 | - | 21m   | 1min     | 29min   | 50/0  |
-| ⏹ | 18m   | 2min     | 31min   | 50/0  |
-| ⏹ | 15m   | 2min     | 33min   | 50/0  |
-| ⏹ | 12m   | 2min     | 35min   | 50/0  |
-| ⏹ | 9m    | 4min     | 39min   | 50/0  |
-| ⏹ | 6m    | 6min     | 45min   | 50/0  |
-| ⏹ | 3m    | 12min    | 57min   | 50/0  |
-| ➚ | 0m    | 1min     | 58min   | 50/0  |
-**CNS**: 16%  
-**OTU**: 42
+| ➚ | 15m   | 2min     | 31min   | 50/0  |
+| ⏹ | 15m   | 1min     | 32min   | 50/0  |
+| ⏹ | 12m   | 2min     | 34min   | 50/0  |
+| ⏹ | 9m    | 4min     | 38min   | 50/0  |
+| ⏹ | 6m    | 6min     | 44min   | 50/0  |
+| ⏹ | 3m    | 12min    | 56min   | 50/0  |
+| ➚ | 0m    | 1min     | 57min   | 50/0  |
+**CNS**: 15%  
+**OTU**: 40
 </details>
 
 <details>
 <summary>Subsurface</summary>
 
-> **Observations:**  
-> - Subsurface does not show descent to first stop, instead the descent duration is added to the decompression time.
-> - Subsurface seems to calculate altitude pressure differently, Abysner uses 1013 hPa at sea level and calculates the pressure at altitude assuming constant temperature of 15 degrees celsius, this is slightly different compared to Subsurface, however the difference is small and should not impact the plan much.
+> **Observations:**
+> - Atmospheric pressure was set to 900 mbar directly in Subsurface to match Abysner's barometric
+>   formula result for 1000 meter altitude, eliminating it as a variable in the comparison.
+> - The remaining stop-time differences (12m, 6m, 3m) seem to be algorithmic.
 
 |   | Depth | Duration | Runtime | Gas   |
 |---|-------|----------|---------|-------|
@@ -342,15 +343,20 @@ plan, see the plan specific tables for those.
 | ➙ | 60m   | 8min     | 20min   | 18/45 |
 | ➚ | 21m   | 8min     | 28min   | 18/45 |
 | - | 21m   | 1min     | 29min   | 50/0  |
-| ⏹ | 15m   | 3min     | 32min   | 50/0  |
-| ⏹ | 12m   | 2min     | 34min   | 50/0  |
-| ⏹ | 9m    | 5min     | 39min   | 50/0  |
-| ⏹ | 6m    | 8min     | 47min   | 50/0  |
-| ⏹ | 3m    | 14min    | 61min   | 50/0  |
-| ➚ | 0m    | 1min     | 62min   | 50/0  |
-**CNS**: 16%  
-**OTU**: 43  
-*Subsurface (6.0.5214-CICD-release)*
+| ➚ | 15m   | 2min     | 31min   | 50/0  |
+| ⏹ | 15m   | 1min     | 32min   | 50/0  |
+| ➚ | 12m   | 1min     | 33min   | 50/0  |
+| ⏹ | 12m   | 2min     | 35min   | 50/0  |
+| ➚ | 9m    | 1min     | 36min   | 50/0  |
+| ⏹ | 9m    | 3min     | 39min   | 50/0  |
+| ➚ | 6m    | 1min     | 40min   | 50/0  |
+| ⏹ | 6m    | 7min     | 47min   | 50/0  |
+| ➚ | 3m    | 1min     | 48min   | 50/0  |
+| ⏹ | 3m    | 14min    | 62min   | 50/0  |
+| ➚ | 0m    | 1min     | 63min   | 50/0  |
+**CNS**: 17%  
+**OTU**: 46  
+*Subsurface (6.0.5576-CICD-release)*
 </details>
 
 <details>
@@ -422,9 +428,9 @@ Out:
 | ➙ | 40m   | 2min     | 32min   | 21/20 |
 | ➚ | 9m    | 7min     | 39min   | 21/20 |
 | ⏹ | 9m    | 3min     | 42min   | 21/20 |
-| ⏹ | 6m    | 7min     | 49min   | 21/20 |
-| ⏹ | 3m    | 16min    | 65min   | 21/20 |
-| ➚ | 0m    | 1min     | 66min   | 21/20 |
+| ⏹ | 6m    | 6min     | 48min   | 21/20 |
+| ⏹ | 3m    | 15min    | 63min   | 21/20 |
+| ➚ | 0m    | 1min     | 64min   | 21/20 |
 **CNS**: 9%  
 **OTU**: 26
 </details>


### PR DESCRIPTION
Water vapor displaces the entire alveolar gas mixture, not just one component. Two places incorrectly handled this:

1. Initial tissue N2 loading computed `atmosphericPressure x fractionN2 - waterVaporPressure ` instead of `(atmosphericPressure - waterVapourPressure) x fractionN2`.
2. Tissue loading during the dive did not subtract water vapor pressure from the ambient pressure before computing inspired partial pressures for the Schreiner equation.

Both corrections align with the standard Buhlmann formulation, this change does influence the reference plans that compare to other planners ever so slightly, sometimes closer, sometimes further away. The biggest influence can be found in the comparison to the PADI NDL times, however this does make sense since Buhlmann allows for sub-10 meter dives to have extremely long no-decompression limits.