### PR TITLE
Add: BreathingMode sealed class and CCR support in DecompressionModel interface

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/BreathingMode.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/BreathingMode.kt
@@ -1,0 +1,31 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.core.model
+
+sealed class BreathingMode {
+
+    data object OpenCircuit : BreathingMode()
+
+    data class ClosedCircuit(val setpoint: Double) : BreathingMode() {
+        init {
+            require(setpoint > 0.0) { "CCR setpoint must be positive, got $setpoint" }
+        }
+    }
+
+    /**
+     * Returns the closed-circuit setpoint or null if the breathing mode is open circuit.
+     */
+    val ccrSetpoint: Double?
+        get() = (this as? ClosedCircuit)?.setpoint
+}
+

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/DecompressionModel.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/DecompressionModel.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -36,8 +36,8 @@ interface DecompressionModel {
      *
      * @see addPressureChange
      */
-    fun addFlat(pressureAtDepth: Pressure, gas: Gas, timeInMinutes: Int) {
-        addPressureChange(pressureAtDepth, pressureAtDepth, gas, timeInMinutes)
+    fun addFlat(pressureAtDepth: Pressure, gas: Gas, timeInMinutes: Int, ccrSetpoint: Double? = null) {
+        addPressureChange(pressureAtDepth, pressureAtDepth, gas, timeInMinutes, ccrSetpoint)
     }
 
     /**
@@ -62,7 +62,7 @@ interface DecompressionModel {
      * gas, with the current tissue loading as starting point. This method will not alter the
      * current tissue loading, after returning tissues will be reset to their original state.
      */
-    fun getNoDecompressionLimit(depth: Pressure, gas: Gas): Int
+    fun getNoDecompressionLimit(depth: Pressure, gas: Gas, ccrSetpoint: Double? = null): Int
 
     /**
      * Reset the model (e.g. in case of Buhlmann this effectively resets all the tissue compartments).

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
@@ -114,14 +114,14 @@ class Buhlmann(
         return currentCeiling
     }
 
-    override fun getNoDecompressionLimit(depth: Pressure, gas: Gas): Int {
+    override fun getNoDecompressionLimit(depth: Pressure, gas: Gas, ccrSetpoint: Double?): Int {
         // Take a snapshot of the tissues to restore at a later moment
         val snapshot = snapshot()
         var minutesAdded = 0
         // Load tissues at given depth minutes by minute until the ceiling is below the surface.
         while(getCeiling().value <= environment.atmosphericPressure) {
             minutesAdded++
-            addFlat(depth, gas, 1)
+            addFlat(depth, gas, 1, ccrSetpoint)
         }
         reset(snapshot)
         return minutesAdded

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2025 Neotech
+ * Copyright (C) 2025-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -12,6 +12,7 @@
 
 package org.neotech.app.abysner.domain.decompression.model
 
+import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.utilities.equalsDelta
 import kotlin.math.max
@@ -47,6 +48,12 @@ data class DiveSegment(
      * and the semantic purpose (deco stop, gas switch).
      */
     val type: Type,
+
+    /**
+     * Whether this segment is breathed open-circuit or closed-circuit (with a specific setpoint).
+     * Used by O₂ toxicity calculations and gas planning to determine the ppO₂ model.
+     */
+    val breathingMode: BreathingMode = BreathingMode.OpenCircuit,
 
     val travelSpeed: Double = (startDepth - endDepth) / duration.toDouble(),
 
@@ -142,7 +149,8 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
             currentSegment.type.isFlat &&
             currentSegment.type == nextSegment.type &&
             currentSegment.endDepth == nextSegment.startDepth &&
-            currentSegment.cylinder == nextSegment.cylinder
+            currentSegment.cylinder == nextSegment.cylinder &&
+            currentSegment.breathingMode == nextSegment.breathingMode
         ) {
             val combinedSegment = currentSegment.copy(
                 duration = currentSegment.duration + nextSegment.duration,
@@ -153,7 +161,8 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
         } else if (
             currentSegment.travelSpeed.equalsDelta(nextSegment.travelSpeed, maxTravelSpeedDelta) &&
             currentSegment.endDepth == nextSegment.startDepth &&
-            currentSegment.cylinder == nextSegment.cylinder
+            currentSegment.cylinder == nextSegment.cylinder &&
+            currentSegment.breathingMode == nextSegment.breathingMode
         ) {
             val combinedSegment = currentSegment.copy(
                 endDepth = nextSegment.endDepth,
@@ -194,6 +203,7 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
                 cylinder = nextSegment.cylinder,
                 gfCeilingAtEnd = nextSegment.gfCeilingAtEnd,
                 type = nextSegment.type,
+                breathingMode = nextSegment.breathingMode,
             )
             this[i] = combinedSegment
             this.removeAt(i + 1)

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannCcrTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannCcrTest.kt
@@ -43,7 +43,7 @@ class BuhlmannCcrTest {
         val ocCeiling = ocModel.getCeiling()
         val ccrCeiling = ccrModel.getCeiling()
 
-        // Assert CCR ceiling is lower, since CCR uses a constant PPO2 that is higher than the PPO2
+        // Assert CCR ceiling is lower, since CCR uses a constant ppO2 that is higher than the ppO2
         // of air at 30 meters it reduces inert gas loading.
         assertTrue(
             ccrCeiling.value < ocCeiling.value,
@@ -133,5 +133,36 @@ class BuhlmannCcrTest {
         // According to other planning software this should lead to about 13 minutes of bottom time
         // without hitting deco
         assertEquals(13, minutesAtBottom)
+    }
+
+    @Test
+    fun getNoDecompressionLimit_ccrIsLongerThanOc() {
+        val ocModel = createModel()
+        val ccrModel = createModel()
+
+        val depth = depthInMetersToBar(30.0, environment)
+
+        val ocNdl = ocModel.getNoDecompressionLimit(depth, Gas.Air)
+        val ccrNdl = ccrModel.getNoDecompressionLimit(depth, Gas.Air, ccrSetpoint = 1.3)
+
+        // At 30m with air the OC ppO2 is about 0.84 bar, so a 1.3 bar setpoint displaces
+        // significantly more inert gas with O2, resulting in slower tissue loading and a longer
+        // NDL. This would not hold if the setpoint were below the OC ppO2.
+        assertTrue(
+            ccrNdl > ocNdl,
+            "CCR NDL ($ccrNdl min) should be longer than OC NDL ($ocNdl min) at the same depth"
+        )
+    }
+
+    @Test
+    fun getNoDecompressionLimit_ccrDoesNotAlterTissueState() {
+        val model = createModel()
+        val depth = depthInMetersToBar(30.0, environment)
+
+        val ceilingBefore = model.getCeiling()
+        model.getNoDecompressionLimit(depth, Gas.Air, ccrSetpoint = 1.3)
+        val ceilingAfter = model.getCeiling()
+
+        assertEquals(ceilingBefore.value, ceilingAfter.value)
     }
 }

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/model/CompactSimilarSegmentsTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/model/CompactSimilarSegmentsTest.kt
@@ -12,6 +12,7 @@
 
 package org.neotech.app.abysner.domain.decompression.model
 
+import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.assertSegment
@@ -30,6 +31,7 @@ class CompactSimilarSegmentsTest {
         type: DiveSegment.Type = DiveSegment.Type.FLAT,
         cylinder: Cylinder = airCylinder,
         gfCeilingAtEnd: Double = 0.0,
+        breathingMode: BreathingMode = BreathingMode.OpenCircuit,
     ) = DiveSegment(
         start = start,
         duration = duration,
@@ -38,6 +40,7 @@ class CompactSimilarSegmentsTest {
         cylinder = cylinder,
         gfCeilingAtEnd = gfCeilingAtEnd,
         type = type,
+        breathingMode = breathingMode,
     )
 
     private fun travelSegment(
@@ -47,6 +50,7 @@ class CompactSimilarSegmentsTest {
         duration: Int,
         cylinder: Cylinder = airCylinder,
         gfCeilingAtEnd: Double = 0.0,
+        breathingMode: BreathingMode = BreathingMode.OpenCircuit,
     ) = DiveSegment(
         start = start,
         duration = duration,
@@ -55,6 +59,7 @@ class CompactSimilarSegmentsTest {
         cylinder = cylinder,
         gfCeilingAtEnd = gfCeilingAtEnd,
         type = if (startDepth < endDepth) DiveSegment.Type.DECENT else DiveSegment.Type.ASCENT,
+        breathingMode = breathingMode,
     )
 
     @Test
@@ -201,6 +206,49 @@ class CompactSimilarSegmentsTest {
         assertEquals(2, result.size, "Expected ascent to be folded into the shallower gas switch")
         result.assertSegment(0, DiveSegment.Type.DECO_STOP,  startDepth = 9.0, endDepth = 9.0, duration = 5, gas = airCylinder)
         result.assertSegment(1, DiveSegment.Type.GAS_SWITCH, startDepth = 6.0, endDepth = 6.0, duration = 2, gas = nitroxCylinder)
+    }
+
+    @Test
+    fun compactSimilarSegments_doesNotMergeFlatSegmentsOfDifferentBreathingMode() {
+        val segments = mutableListOf(
+            flatSegment(start = 0, depth = 9.0, duration = 3, breathingMode = BreathingMode.OpenCircuit),
+            flatSegment(start = 3, depth = 9.0, duration = 2, breathingMode = BreathingMode.ClosedCircuit(1.3)),
+        )
+        val result = segments.compactSimilarSegments()
+        assertEquals(2, result.size, "Expected segments with different breathing modes to remain separate")
+    }
+
+    @Test
+    fun compactSimilarSegments_mergesFlatSegmentsOfSameBreathingMode() {
+        val ccr = BreathingMode.ClosedCircuit(1.3)
+        val segments = mutableListOf(
+            flatSegment(start = 0, depth = 9.0, duration = 3, breathingMode = ccr),
+            flatSegment(start = 3, depth = 9.0, duration = 2, breathingMode = ccr),
+        )
+        val result = segments.compactSimilarSegments()
+        assertEquals(1, result.size, "Expected CCR segments with same setpoint to be merged")
+        assertEquals(5, result[0].duration)
+        assertEquals(ccr, result[0].breathingMode)
+    }
+
+    @Test
+    fun compactSimilarSegments_doesNotMergeTravelSegmentsOfDifferentBreathingMode() {
+        val segments = mutableListOf(
+            travelSegment(start = 0, startDepth = 9.0, endDepth = 6.0, duration = 1, breathingMode = BreathingMode.ClosedCircuit(1.3)),
+            travelSegment(start = 1, startDepth = 6.0, endDepth = 3.0, duration = 1, breathingMode = BreathingMode.OpenCircuit),
+        )
+        val result = segments.compactSimilarSegments()
+        assertEquals(2, result.size, "Expected travel segments with different breathing modes to remain separate")
+    }
+
+    @Test
+    fun compactSimilarSegments_doesNotMergeFlatSegmentsWithDifferentSetpoints() {
+        val segments = mutableListOf(
+            flatSegment(start = 0, depth = 9.0, duration = 3, breathingMode = BreathingMode.ClosedCircuit(0.7)),
+            flatSegment(start = 3, depth = 9.0, duration = 2, breathingMode = BreathingMode.ClosedCircuit(1.3)),
+        )
+        val result = segments.compactSimilarSegments()
+        assertEquals(2, result.size, "Expected CCR segments with different setpoints to remain separate")
     }
 }
 


### PR DESCRIPTION
Added `BreathingMode` (`OpenCircuit` or `ClosedCircuit` with `setpoint`) in `DiveSegment`. The `DecompressionModel` interface `addFlat` and `getNoDecompressionLimit` have been modified to accept a setpoint, in preparation of CCR support in `DecompressionPlanner`.

`compactSimilarSegments` now considers the `DiveSegment.breathingMode` when merging, preventing segments with different modes or `setpoints` from being combined.