### PR TITLE
Add: `DiveMode.CLOSED_CIRCUIT` support to `DivePlanner`

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/BreathingMode.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/BreathingMode.kt
@@ -22,10 +22,7 @@ sealed class BreathingMode {
         }
     }
 
-    /**
-     * Returns the closed-circuit setpoint or null if the breathing mode is open circuit.
-     */
-    val ccrSetpoint: Double?
+    val ccrSetpointOrNull: Double?
         get() = (this as? ClosedCircuit)?.setpoint
 }
 

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -42,7 +42,17 @@ data class Configuration(
     val contingencyLonger: Int = 3,
     val salinity: Salinity = Salinity.WATER_FRESH,
     val altitude: Double = 0.0,
-    val algorithm: Algorithm = Algorithm.BUHLMANN_ZH16C
+    val algorithm: Algorithm = Algorithm.BUHLMANN_ZH16C,
+    /**
+     * CCR low O₂ setpoint (bar) used during descent. Kept low to provide a safety buffer
+     * against hypoxia and reduce solenoid firing during depth changes.
+     */
+    val ccrLowSetpoint: Double = 0.7,
+    /**
+     * CCR high O₂ setpoint (bar) used during bottom time and the entire ascent. A higher
+     * setpoint reduces inert gas loading and improves decompression efficiency.
+     */
+    val ccrHighSetpoint: Double = 1.2,
 ) {
 
     val environment = Environment(salinity, altitudeToPressure(altitude))

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
@@ -16,6 +16,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
+import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.core.model.Environment
@@ -75,46 +76,46 @@ class DecompressionPlanner(
     }
 
 
-    fun addFlat(depth: Double, gas: Cylinder, timeInMinutes: Int) {
-        return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.FLAT)
+    fun addFlat(depth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
+        return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.FLAT, breathingMode)
     }
 
-    private fun addDecoStop(depth: Double, gas: Cylinder, timeInMinutes: Int) {
-        return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.DECO_STOP)
+    private fun addDecoStop(depth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
+        return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.DECO_STOP, breathingMode)
     }
 
-    private fun addGasSwitch(depth: Double, gas: Cylinder, timeInMinutes: Int) {
+    private fun addGasSwitch(depth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
         // A 0-duration segment is still emitted when gasSwitchTime = 0 so the instruction table
         // can consistently show a gas switch row regardless of the configured switch time.
-        return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.GAS_SWITCH)
+        return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.GAS_SWITCH, breathingMode)
     }
 
-    fun addDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int) {
+    fun addDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
         require(startDepth != endDepth) { "Use addFlat() for flat segments, startDepth and endDepth must differ." }
         val type = if (startDepth < endDepth) DiveSegment.Type.DECENT else DiveSegment.Type.ASCENT
-        return addDepthChangeInternal(startDepth, endDepth, gas, timeInMinutes, type)
+        return addDepthChangeInternal(startDepth, endDepth, gas, timeInMinutes, type, breathingMode)
     }
 
-    private fun addDepthChangeInternal(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type) {
+    private fun addDepthChangeInternal(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode) {
         if(timeInMinutes > 0 && calculateTissueChangesPerMinute && !isCalculatingTts) {
             val diff = startDepth - endDepth
             repeat(timeInMinutes) {
                 val statDepthForThisMinute = startDepth - (diff * ((it) / timeInMinutes.toDouble()))
                 val endDepthForThisMinute = startDepth - (diff * ((it + 1) / timeInMinutes.toDouble()))
-                addDepthChange(statDepthForThisMinute, endDepthForThisMinute, gas, 1, type)
+                addDepthChange(statDepthForThisMinute, endDepthForThisMinute, gas, 1, type, breathingMode)
             }
         } else {
-            addDepthChange(startDepth, endDepth, gas, timeInMinutes, type)
+            addDepthChange(startDepth, endDepth, gas, timeInMinutes, type, breathingMode)
         }
     }
 
-    private fun addDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type) {
+    private fun addDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode) {
 
         val startPressure = depthInMetersToBar(startDepth, environment)
         val endPressure = depthInMetersToBar(endDepth, environment)
 
         if (timeInMinutes > 0) {
-            model.addPressureChange(startPressure, endPressure, gas.gas, timeInMinutes)
+            model.addPressureChange(startPressure, endPressure, gas.gas, timeInMinutes, breathingMode.ccrSetpointOrNull)
         }
 
         val ceiling = barToDepthInMeters(model.getCeiling(), environment)
@@ -129,13 +130,14 @@ class DecompressionPlanner(
                 cylinder = gas,
                 type = type,
                 gfCeilingAtEnd = ceiling,
+                breathingMode = breathingMode,
                 ttsAfter = -1
             )
         )
         this.runtime += timeInMinutes
     }
 
-    fun calculateTimeToSurface(): Int {
+    fun calculateTimeToSurface(breathingMode: BreathingMode): Int {
         // TODO this is not an ideal method to acquire this information, as we generate a lot
         //      of info we don't need.
 
@@ -150,7 +152,7 @@ class DecompressionPlanner(
         var alternativeAscentSegments: List<DiveSegment> = emptyList()
         val start = runtime
         val result = resetAfter {
-            calculateDecompression(toDepth = 0).sumOf { it.duration }.also {
+            calculateDecompression(toDepth = 0, breathingMode = breathingMode).sumOf { it.duration }.also {
                 alternativeAscentSegments = segments.subList(start).toList()
             }
         }
@@ -162,40 +164,47 @@ class DecompressionPlanner(
     /**
      * Move diver from [fromDepth] to the next ceiling depth [toDepth]. During which a gas change
      * may occur as the diver reaches depths at which a different gas may be better to breath.
+     * Gas switching is skipped when [breathingMode] is [BreathingMode.ClosedCircuit], since the
+     * diver stays on the loop.
      */
-    private fun addDecoDepthChange(fromDepth: Double, toDepth: Double, maxppO2: Double, maxEND: Double, fromGas: Cylinder, ascentRateInMetersPerMinute: Double): Cylinder {
+    private fun addDecoDepthChange(fromDepth: Double, toDepth: Double, maxppO2: Double, maxEND: Double, fromGas: Cylinder, ascentRateInMetersPerMinute: Double, breathingMode: BreathingMode): Cylinder {
+        val isCcr = breathingMode is BreathingMode.ClosedCircuit
         var gas = fromGas
         var currentDepth = fromDepth
 
         while (currentDepth > toDepth) {
-            // Check if there is a better gas to breath at the current depth
-            val betterDecoGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = currentDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
-            // Only start using the better gas when we reach a deco increment point
+            if (!isCcr) {
+                // Check if there is a better gas to breath at the current depth
+                val betterDecoGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = currentDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
+                // Only start using the better gas when we reach a deco increment point
 
-            if (betterDecoGas != null && betterDecoGas.gas != gas.gas && currentDepth.toInt() % decoStepSize == 0) {
-                // Gas switch time is spent on the old gas: the diver is still breathing the
-                // previous gas while preparing to switch (grabbing regulator, purging, etc.).
-                // The actual switch to the new gas happens after the gas switch time.
-                addGasSwitch(currentDepth, gas, gasSwitchTime)
-                gas = betterDecoGas
+                if (betterDecoGas != null && betterDecoGas.gas != gas.gas && currentDepth.toInt() % decoStepSize == 0) {
+                    // Gas switch time is spent on the old gas: the diver is still breathing the
+                    // previous gas while preparing to switch (grabbing regulator, purging, etc.).
+                    // The actual switch to the new gas happens after the gas switch time.
+                    addGasSwitch(currentDepth, gas, gasSwitchTime, breathingMode)
+                    gas = betterDecoGas
+                }
             }
 
             // targetDepth is to toDepth, unless there's a better gas to switch to on the way up,
             // then the target depth may be something between currentDepth and toDepth.
             var targetDepth = toDepth
 
-            // Figure out if before we reach the targetDepth anything needs to happen (gas switch)
-            // We do this by descending with increments of 1 meter and checking if there is a better
-            // gas available at each depth.
-            var nextDepth = currentDepth - 1
-            var nextDecoGas: Cylinder?
-            while(nextDepth >= targetDepth) {
-                nextDecoGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = nextDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
-                if (nextDecoGas != null && nextDecoGas.gas != gas.gas && nextDepth.toInt() % decoStepSize == 0) {
-                    targetDepth = nextDepth //Only carry us up to the point where we can use this better gas.
-                    break
+            if (!isCcr) {
+                // Figure out if before we reach the targetDepth anything needs to happen (gas switch)
+                // We do this by descending with increments of 1 meter and checking if there is a better
+                // gas available at each depth.
+                var nextDepth = currentDepth - 1
+                var nextDecoGas: Cylinder?
+                while(nextDepth >= targetDepth) {
+                    nextDecoGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = nextDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
+                    if (nextDecoGas != null && nextDecoGas.gas != gas.gas && nextDepth.toInt() % decoStepSize == 0) {
+                        targetDepth = nextDepth //Only carry us up to the point where we can use this better gas.
+                        break
+                    }
+                    nextDepth--
                 }
-                nextDepth--
             }
 
             // At this point we are either at the target depth, or our target depth has changed due to a gas switch that needs to happen.
@@ -210,16 +219,18 @@ class DecompressionPlanner(
             val duration = max(1, ceil(depthChange / ascentRateInMetersPerMinute).toInt())
 
             // println("Moving diver from $fromDepth to $targetDepth on gas $gas over $duration minutes.")
-            addDepthChange(currentDepth, targetDepth, gas, duration)
+            addDepthChange(currentDepth, targetDepth, gas, duration, breathingMode)
 
             currentDepth = targetDepth
         }
 
-        val betterDecoGasName = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = currentDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
-        if (betterDecoGasName != null && betterDecoGasName.gas != gas.gas && currentDepth.toInt() % decoStepSize == 0) {
-            // Gas switch time on the old gas before switching
-            addGasSwitch(currentDepth, gas, gasSwitchTime)
-            gas = betterDecoGasName
+        if (!isCcr) {
+            val betterDecoGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = currentDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
+            if (betterDecoGas != null && betterDecoGas.gas != gas.gas && currentDepth.toInt() % decoStepSize == 0) {
+                // Gas switch time on the old gas before switching
+                addGasSwitch(currentDepth, gas, gasSwitchTime, breathingMode)
+                gas = betterDecoGas
+            }
         }
 
         return gas
@@ -227,7 +238,9 @@ class DecompressionPlanner(
 
     fun calculateDecompression(
         toDepth: Int,
+        breathingMode: BreathingMode,
     ): List<DiveSegment> {
+        val isCcr = breathingMode is BreathingMode.ClosedCircuit
         var gas: Cylinder
         val fromDepth: Double
         if (this.segments.isEmpty()) {
@@ -242,31 +255,49 @@ class DecompressionPlanner(
         }
         val segmentSizeStart = this.segments.size
 
+        // For bailout (transitioning from CCR to OC), select the best available bailout cylinder
+        // and emit a GAS_SWITCH with duration 1 (a minimal problem-solving time for coming off the
+        // loop and switching to the bailout regulator).
+        // TODO: Should this be configurable, or even tied to the existing Configuration.gasSwitchTime?
+        val isBailout = !isCcr && segments.last().breathingMode is BreathingMode.ClosedCircuit
+        if (isBailout) {
+            val bestBailoutGas = decoGasses.findBetterGasOrFallback(
+                currentCylinder = null,
+                depth = fromDepth,
+                environment = environment,
+                maxPPO2 = maxPpO2,
+                maxEND = maxEquivalentNarcoticDepth
+            )
+            if (bestBailoutGas != null) {
+                addGasSwitch(fromDepth, gas, 1, breathingMode)
+                gas = bestBailoutGas
+            }
+        }
+
         if(toDepth > fromDepth) {
             throw IllegalArgumentException("Cannot calculate decompression as the target depth ($toDepth meter) is deeper then the current depth ($fromDepth meter). Add an descending depth change first!")
         }
 
         // Get the current ceiling:
-        var ceiling = findFirstDecoCeiling(fromDepth, decoStepSize, lastDecoStopDepth, maxPpO2, maxEquivalentNarcoticDepth, gas, ascentRate)
+        var ceiling = findFirstDecoCeiling(fromDepth, decoStepSize, lastDecoStopDepth, maxPpO2, maxEquivalentNarcoticDepth, gas, ascentRate, breathingMode)
+
+        // Check if there is a better gas to switch to at the current depth before
+        // ascending. Gas switching is skipped in CCR mode (diver stays on the loop).
+        if (!isCcr) {
+            val betterGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = fromDepth, environment = environment, maxPPO2 = maxPpO2, maxEND = maxEquivalentNarcoticDepth)
+            if (betterGas != null && betterGas.gas != gas.gas) {
+                // Gas switch time on the old gas before switching
+                addGasSwitch(fromDepth, gas, gasSwitchTime, breathingMode)
+                gas = betterGas
+            }
+        }
 
         // Don't allow ceiling below start depth
         // TODO get this depth from the previous section endDepth?
         if(ceiling > fromDepth) {
-            // We have to stay at this depth first, do not change depths, but look for better gas.
+            // We have to stay at this depth first, do not change depths.
             ceiling = fromDepth.toInt()
-            val betterGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = fromDepth, environment = environment, maxPPO2 = maxPpO2, maxEND = maxEquivalentNarcoticDepth)
-            if (betterGas != null && betterGas.gas != gas.gas) {
-                // Gas switch time on the old gas before switching
-                addGasSwitch(fromDepth, gas, gasSwitchTime)
-                gas = betterGas
-            }
         } else {
-            val betterGas = decoGasses.findBetterGasOrFallback(currentCylinder = gas, depth = fromDepth, environment = environment, maxPPO2 = maxPpO2, maxEND = maxEquivalentNarcoticDepth)
-            if (betterGas != null && betterGas.gas != gas.gas) {
-                // Gas switch time on the old gas before switching
-                addGasSwitch(fromDepth, gas, gasSwitchTime)
-                gas = betterGas
-            }
             // Move the diver to the first ceiling (this may already be the surface)
 
             gas = addDecoDepthChange(
@@ -275,7 +306,8 @@ class DecompressionPlanner(
                 maxPpO2,
                 maxEquivalentNarcoticDepth,
                 gas,
-                ascentRate
+                ascentRate,
+                breathingMode
             )
         }
         // Keep making deco stops until the deco ceiling is above the surface
@@ -318,7 +350,7 @@ class DecompressionPlanner(
                 var stopTime = 0
                 while (ceiling > nextDecoDepth && ceiling > toDepth || (forceMinimalDecoStopTime && stopTime < 1)) {
                     // Add 1 minute of decompression and test the ceiling again, until the ceiling is higher.
-                    this.addDecoStop(currentDepth, gas, 1)
+                    this.addDecoStop(currentDepth, gas, 1, breathingMode)
                     stopTime++
 
                     // TODO: Should we calculate the gf based on the current stop depth, or the next stop depth we want to reach?
@@ -342,7 +374,7 @@ class DecompressionPlanner(
                     }
                 }
             }
-            gas = this.addDecoDepthChange(currentDepth, ceiling.toDouble(), maxPpO2, maxEquivalentNarcoticDepth, gas, ascentRate)
+            gas = this.addDecoDepthChange(currentDepth, ceiling.toDouble(), maxPpO2, maxEquivalentNarcoticDepth, gas, ascentRate, breathingMode)
         }
 
         return if(segments.size == segmentSizeStart) {
@@ -360,7 +392,8 @@ class DecompressionPlanner(
         maxPpO2: Double,
         maxEquivalentNarcoticDepth: Double,
         gas: Cylinder,
-        ascentRate: Double
+        ascentRate: Double,
+        breathingMode: BreathingMode,
     ): Int {
 
         var ceiling: Int = getDecoCeiling(decoStepSize, lastDecoStopDepth)
@@ -382,7 +415,8 @@ class DecompressionPlanner(
                     maxPpO2,
                     maxEquivalentNarcoticDepth,
                     gas,
-                    ascentRate
+                    ascentRate,
+                    breathingMode
                 )
 
                 // Check new ceiling (could already be higher)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
@@ -58,9 +58,21 @@ data class DiveSegment(
     val travelSpeed: Double = (startDepth - endDepth) / duration.toDouble(),
 
     /**
-     * TODO: This is better removed out of this model, since it is not always available and modifiable.
+     * Time to surface (in minutes) at the end of this segment, using the dive's own breathing
+     * mode (OC for OC dives, CCR for CCR dives). A value of -1 means TTS was not calculated
+     * for this segment.
+     *
+     * TODO: This is better moved out of this model, since it is not always available and not immutable.
      */
     var ttsAfter: Int = -1,
+
+    /**
+     * Time to surface in open-circuit mode, only populated for CCR dives. Represents the time to
+     * surface if the diver bails out to open circuit at this point.
+     *
+     * TODO: This is better moved out of this model, since it is not always available and not immutable.
+     */
+    var ttsBailoutAfter: Int = -1,
 ) {
 
     val end = start + duration

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
@@ -15,8 +15,10 @@ package org.neotech.app.abysner.domain.diveplanning
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentList
+import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.decompression.DecompressionPlanner
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
 import org.neotech.app.abysner.domain.decompression.algorithm.buhlmann.Buhlmann
@@ -39,7 +41,17 @@ class DivePlanner(
     fun addDive(
         plan: List<DiveProfileSection>,
         cylinders: List<Cylinder>,
+        diveMode: DiveMode = DiveMode.OPEN_CIRCUIT,
+        bailout: Boolean = false,
     ): DivePlan {
+
+        require(!bailout || diveMode == DiveMode.CLOSED_CIRCUIT) {
+            "Bailout is only applicable to closed-circuit dives"
+        }
+
+        val breathingMode = diveMode.breathingMode(configuration.ccrHighSetpoint)
+        val descentBreathingMode = diveMode.breathingMode(configuration.ccrLowSetpoint)
+        val isCcr = breathingMode is BreathingMode.ClosedCircuit
 
         if(plan.isEmpty()) {
             return DivePlan(
@@ -88,10 +100,10 @@ class DivePlanner(
                         // Only allow the listed bottom gas to get to this segment
                         // This is similar to what MultiDeco does
                         decompressionPlanner.setDecoGasses(listOf(it.cylinder))
-                        decompressionPlanner.calculateDecompression(toDepth = it.depth)
+                        decompressionPlanner.calculateDecompression(toDepth = it.depth, breathingMode = breathingMode)
                         decompressionPlanner.setDecoGasses(gasses)
                     } else {
-                        decompressionPlanner.calculateDecompression(toDepth = it.depth)
+                        decompressionPlanner.calculateDecompression(toDepth = it.depth, breathingMode = breathingMode)
                     }
 
                     val timeSpend = decompressionPlanner.runtime - runtime
@@ -105,9 +117,10 @@ class DivePlanner(
                             it.depth.toDouble(),
                             it.cylinder,
                             timeLeftAtPlannedDepth,
+                            breathingMode,
                         )
                     }
-                    decompressionPlanner.getSegments().last().ttsAfter = decompressionPlanner.calculateTimeToSurface()
+                    decompressionPlanner.assignTts(breathingMode, isCcr)
 
                 } else {
                     // Descending
@@ -120,6 +133,7 @@ class DivePlanner(
                         it.depth.toDouble(),
                         it.cylinder,
                         timeToChange,
+                        descentBreathingMode,
                     )
 
                     // TODO allow 0? And just not add the flat?
@@ -130,9 +144,10 @@ class DivePlanner(
                             it.depth.toDouble(),
                             it.cylinder,
                             timeLeftAtPlannedDepth,
+                            breathingMode,
                         )
                     }
-                    decompressionPlanner.getSegments().last().ttsAfter = decompressionPlanner.calculateTimeToSurface()
+                    decompressionPlanner.assignTts(breathingMode, isCcr)
                 }
                 currentDepth = it.depth.toDouble()
             } else {
@@ -140,14 +155,21 @@ class DivePlanner(
                     it.depth.toDouble(),
                     it.cylinder,
                     it.duration,
+                    breathingMode,
                 )
-                decompressionPlanner.getSegments().last().ttsAfter = decompressionPlanner.calculateTimeToSurface()
+                decompressionPlanner.assignTts(breathingMode, isCcr)
                 currentDepth = it.depth.toDouble()
             }
         }
 
-        // Bring diver to surface
-        decompressionPlanner.calculateDecompression(toDepth = 0)
+        // Bring diver to surface. For bailout, the final ascent is OC. The bailout detection in
+        // calculateDecompression will select the best OC (bailout) gas.
+        val ascentBreathingMode = if (bailout && isCcr) {
+            BreathingMode.OpenCircuit
+        } else {
+            breathingMode
+        }
+        decompressionPlanner.calculateDecompression(toDepth = 0, breathingMode = ascentBreathingMode)
 
         val segments = decompressionPlanner.getSegments()
 
@@ -185,6 +207,22 @@ class DivePlanner(
             gfLow = configuration.gfLow,
             gfHigh = configuration.gfHigh,
         )
+    }
+
+    private fun DiveMode.breathingMode(setpoint: Double): BreathingMode = when (this) {
+        DiveMode.OPEN_CIRCUIT -> BreathingMode.OpenCircuit
+        DiveMode.CLOSED_CIRCUIT -> BreathingMode.ClosedCircuit(setpoint)
+    }
+
+    private fun DecompressionPlanner.assignTts(breathingMode: BreathingMode, isCcr: Boolean) {
+        val lastSegment = getSegments().last()
+        lastSegment.ttsAfter = calculateTimeToSurface(breathingMode)
+        if (isCcr) {
+            // OC bailout TTS: time to surface if the diver comes off the loop now. This second call
+            // overwrites the alternative ascent stored for this timestamp, which is intentional:
+            // the OC bailout ascent is the one that matters for emergency gas planning.
+            lastSegment.ttsBailoutAfter = calculateTimeToSurface(BreathingMode.OpenCircuit)
+        }
     }
 
     open class PlanningException(message: String? = null) : Exception(message)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
@@ -49,6 +49,8 @@ data class DivePlan(
 
     val maxTimeToSurface: DiveSegment? = segments.maxByOrNull { it.ttsAfter }
 
+    val maxTimeToSurfaceBailout: DiveSegment? = segments.filter { it.ttsBailoutAfter != -1 }.maxByOrNull { it.ttsBailoutAfter }
+
     val totalDeco = segmentsCollapsed.totalDeco()
     val averageDepth = segmentsCollapsed.calculateAverageDepth()
 

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
@@ -13,9 +13,11 @@
 package org.neotech.app.abysner.domain.diveplanning
 
 
+import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Configuration.Algorithm
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.core.model.Salinity
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
@@ -256,6 +258,149 @@ class DivePlannerTest {
         val gasSwitchSegments = divePlan.segmentsCollapsed.filter { it.type == DiveSegment.Type.GAS_SWITCH }
         assertEquals(0, gasSwitchSegments.size, "Expected no GAS_SWITCH between identical gas mixes, found switch(es) at: ${gasSwitchSegments.map { "${it.endDepth}m" }}")
     }
+
+    @Test
+    fun referencePlan6Ccr_producesExpectedSegments() {
+        val diluent = Cylinder.aluminium80Cuft(Gas.Air)
+        val planner = DivePlanner(Configuration(
+            maxAscentRate = 5.0,
+            maxDescentRate = 5.0,
+            gfLow = 0.3,
+            gfHigh = 0.7,
+            salinity = Salinity.WATER_SALT,
+            algorithm = Algorithm.BUHLMANN_ZH16C,
+            decoStepSize = 3,
+            lastDecoStopDepth = 3,
+            ccrLowSetpoint = 0.7,
+            ccrHighSetpoint = 1.2,
+        ))
+
+        val plan = planner.addDive(
+            listOf(DiveProfileSection(duration = 30, depth = 30, cylinder = diluent)),
+            listOf(diluent),
+            diveMode = DiveMode.CLOSED_CIRCUIT
+        )
+        val segments = plan.segmentsCollapsed
+
+        // println(plan.toString(compact = false))
+
+        assertEquals(6.754, plan.totalCns, tenthAtDecimalPoint(3))
+        assertEquals(20.510, plan.totalOtu, tenthAtDecimalPoint(3))
+
+        val low = BreathingMode.ClosedCircuit(0.7)
+        val high = BreathingMode.ClosedCircuit(1.2)
+
+        segments.assertSegment(0, DiveSegment.Type.DECENT,    startDepth = 0.0,  endDepth = 30.0, duration = 6,  gas = diluent, breathingMode = low)
+        segments.assertSegment(1, DiveSegment.Type.FLAT,      startDepth = 30.0, endDepth = 30.0, duration = 24, gas = diluent, breathingMode = high)
+        segments.assertSegment(2, DiveSegment.Type.ASCENT,    startDepth = 30.0, endDepth = 6.0,  duration = 5,  gas = diluent, breathingMode = high)
+        segments.assertSegment(3, DiveSegment.Type.DECO_STOP, startDepth = 6.0,  endDepth = 6.0,  duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(4, DiveSegment.Type.ASCENT,    startDepth = 6.0,  endDepth = 3.0,  duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(5, DiveSegment.Type.DECO_STOP, startDepth = 3.0,  endDepth = 3.0,  duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(6, DiveSegment.Type.ASCENT,    startDepth = 3.0,  endDepth = 0.0,  duration = 1,  gas = diluent, breathingMode = high)
+    }
+
+    /**
+     * Same setup as reference plan 6 but with open-circuit bailout for the final ascent. The bottom
+     * portion stays on the loop, the ascent switches to OC and uses the best available gas(es).
+     */
+    @Test
+    fun referencePlan7CcrBailout_producesExpectedSegments() {
+        val diluent = Cylinder.aluminium80Cuft(Gas.Air)
+        val planner = DivePlanner(Configuration(
+            maxAscentRate = 5.0,
+            maxDescentRate = 5.0,
+            gfLow = 0.3,
+            gfHigh = 0.7,
+            salinity = Salinity.WATER_SALT,
+            algorithm = Algorithm.BUHLMANN_ZH16C,
+            decoStepSize = 3,
+            lastDecoStopDepth = 3,
+            ccrLowSetpoint = 0.7,
+            ccrHighSetpoint = 1.2,
+        ))
+
+        val plan = planner.addDive(
+            listOf(DiveProfileSection(duration = 30, depth = 30, cylinder = diluent)),
+            listOf(diluent),
+            diveMode = DiveMode.CLOSED_CIRCUIT,
+            bailout = true
+        )
+        val segments = plan.segmentsCollapsed
+
+        // println(plan.toString(compact = false))
+
+        assertEquals(7.139, plan.totalCns, tenthAtDecimalPoint(3))
+        assertEquals(21.450, plan.totalOtu, tenthAtDecimalPoint(3))
+
+        val low = BreathingMode.ClosedCircuit(0.7)
+        val high = BreathingMode.ClosedCircuit(1.2)
+        val oc = BreathingMode.OpenCircuit
+
+        // Bottom portion stays on the loop (identical to reference plan 6)
+        segments.assertSegment(0, DiveSegment.Type.DECENT,     startDepth = 0.0,  endDepth = 30.0, duration = 6,  gas = diluent, breathingMode = low)
+        segments.assertSegment(1, DiveSegment.Type.FLAT,       startDepth = 30.0, endDepth = 30.0, duration = 24, gas = diluent, breathingMode = high)
+        // Bailout: 1-minute problem-solving time, then OC ascent with more deco than CCR
+        segments.assertSegment(2, DiveSegment.Type.GAS_SWITCH, startDepth = 30.0, endDepth = 30.0, duration = 1,  gas = diluent, breathingMode = oc)
+        segments.assertSegment(3, DiveSegment.Type.ASCENT,     startDepth = 30.0, endDepth = 9.0,  duration = 5,  gas = diluent, breathingMode = oc)
+        segments.assertSegment(4, DiveSegment.Type.DECO_STOP,  startDepth = 9.0,  endDepth = 9.0,  duration = 1,  gas = diluent, breathingMode = oc)
+        segments.assertSegment(5, DiveSegment.Type.ASCENT,     startDepth = 9.0,  endDepth = 6.0,  duration = 1,  gas = diluent, breathingMode = oc)
+        segments.assertSegment(6, DiveSegment.Type.DECO_STOP,  startDepth = 6.0,  endDepth = 6.0,  duration = 3,  gas = diluent, breathingMode = oc)
+        segments.assertSegment(7, DiveSegment.Type.ASCENT,     startDepth = 6.0,  endDepth = 3.0,  duration = 1,  gas = diluent, breathingMode = oc)
+        segments.assertSegment(8, DiveSegment.Type.DECO_STOP,  startDepth = 3.0,  endDepth = 3.0,  duration = 7,  gas = diluent, breathingMode = oc)
+        segments.assertSegment(9, DiveSegment.Type.ASCENT,     startDepth = 3.0,  endDepth = 0.0,  duration = 1,  gas = diluent, breathingMode = oc)
+    }
+
+    @Test
+    fun referencePlan8Ccr_producesExpectedSegments() {
+        val diluent = Cylinder.steel12Liter(Gas(0.10, 0.70))
+        val planner = DivePlanner(Configuration(
+            maxAscentRate = 5.0,
+            maxDescentRate = 5.0,
+            gfLow = 0.3,
+            gfHigh = 0.7,
+            salinity = Salinity.WATER_SALT,
+            algorithm = Algorithm.BUHLMANN_ZH16C,
+            decoStepSize = 3,
+            lastDecoStopDepth = 3,
+            ccrLowSetpoint = 0.7,
+            ccrHighSetpoint = 1.2,
+        ))
+
+        val plan = planner.addDive(
+            listOf(DiveProfileSection(duration = 20, depth = 60, cylinder = diluent)),
+            listOf(diluent),
+            diveMode = DiveMode.CLOSED_CIRCUIT
+        )
+        val segments = plan.segmentsCollapsed
+
+        // println(plan.toString(compact = false))
+
+        assertEquals(2.764, plan.totalCns, tenthAtDecimalPoint(3))
+        assertEquals(6.113, plan.totalOtu, tenthAtDecimalPoint(3))
+
+        val low = BreathingMode.ClosedCircuit(0.7)
+        val high = BreathingMode.ClosedCircuit(1.2)
+
+        segments.assertSegment(0,  DiveSegment.Type.DECENT,    startDepth = 0.0,  endDepth = 60.0, duration = 12, gas = diluent, breathingMode = low)
+        segments.assertSegment(1,  DiveSegment.Type.FLAT,      startDepth = 60.0, endDepth = 60.0, duration = 8,  gas = diluent, breathingMode = high)
+        segments.assertSegment(2,  DiveSegment.Type.ASCENT,    startDepth = 60.0, endDepth = 24.0, duration = 8,  gas = diluent, breathingMode = high)
+        segments.assertSegment(3,  DiveSegment.Type.DECO_STOP, startDepth = 24.0, endDepth = 24.0, duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(4,  DiveSegment.Type.ASCENT,    startDepth = 24.0, endDepth = 21.0, duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(5,  DiveSegment.Type.DECO_STOP, startDepth = 21.0, endDepth = 21.0, duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(6,  DiveSegment.Type.ASCENT,    startDepth = 21.0, endDepth = 18.0, duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(7,  DiveSegment.Type.DECO_STOP, startDepth = 18.0, endDepth = 18.0, duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(8,  DiveSegment.Type.ASCENT,    startDepth = 18.0, endDepth = 15.0, duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(9,  DiveSegment.Type.DECO_STOP, startDepth = 15.0, endDepth = 15.0, duration = 2,  gas = diluent, breathingMode = high)
+        segments.assertSegment(10, DiveSegment.Type.ASCENT,    startDepth = 15.0, endDepth = 12.0, duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(11, DiveSegment.Type.DECO_STOP, startDepth = 12.0, endDepth = 12.0, duration = 4,  gas = diluent, breathingMode = high)
+        segments.assertSegment(12, DiveSegment.Type.ASCENT,    startDepth = 12.0, endDepth = 9.0,  duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(13, DiveSegment.Type.DECO_STOP, startDepth = 9.0,  endDepth = 9.0,  duration = 5,  gas = diluent, breathingMode = high)
+        segments.assertSegment(14, DiveSegment.Type.ASCENT,    startDepth = 9.0,  endDepth = 6.0,  duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(15, DiveSegment.Type.DECO_STOP, startDepth = 6.0,  endDepth = 6.0,  duration = 7,  gas = diluent, breathingMode = high)
+        segments.assertSegment(16, DiveSegment.Type.ASCENT,    startDepth = 6.0,  endDepth = 3.0,  duration = 1,  gas = diluent, breathingMode = high)
+        segments.assertSegment(17, DiveSegment.Type.DECO_STOP, startDepth = 3.0,  endDepth = 3.0,  duration = 12, gas = diluent, breathingMode = high)
+        segments.assertSegment(18, DiveSegment.Type.ASCENT,    startDepth = 3.0,  endDepth = 0.0,  duration = 1,  gas = diluent, breathingMode = high)
+    }
 }
 
 fun List<DiveSegment>.assertSegment(
@@ -264,7 +409,8 @@ fun List<DiveSegment>.assertSegment(
     startDepth: Double,
     endDepth: Double,
     duration: Int,
-    gas: Cylinder
+    gas: Cylinder,
+    breathingMode: BreathingMode = BreathingMode.OpenCircuit,
 ) {
     val actual = this[index]
     assertEquals(type, actual.type, "Segment $index: type mismatch")
@@ -272,4 +418,5 @@ fun List<DiveSegment>.assertSegment(
     assertEquals(endDepth, actual.endDepth, "Segment $index: endDepth mismatch")
     assertEquals(duration, actual.duration, "Segment $index: duration mismatch")
     assertEquals(gas, actual.cylinder, "Segment $index: gas mismatch")
+    assertEquals(breathingMode, actual.breathingMode, "Segment $index: breathingMode mismatch")
 }


### PR DESCRIPTION
This makes the `DivePlanner` CCR-aware as it now takes a `DiveMode` as input. Based on the `DiveMode` a correct `BreathingMode` is selected for the `DecompressionPlanner`. Gas switching is skipped while planning decompression in `BreathingMode.ClosedCircuit` and TTS is now calculated for both bailout (`DiveSegment.ttsBailoutAfter`) as well as the normal dive mode (`DiveSegment.ttsAfter`).

Required for: #3