### PR TITLE
Add: DiveMode and bailout support to the plan screen ViewModel

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
@@ -15,6 +15,7 @@ package org.neotech.app.abysner.presentation.preview
 import kotlinx.collections.immutable.persistentListOf
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanSet
@@ -54,6 +55,8 @@ object PreviewData {
             base = divePlan,
             deeper = null,
             longer = null,
+            bailout = false,
+            diveMode = DiveMode.OPEN_CIRCUIT,
             gasPlan = gasPlan
         )
     }
@@ -90,6 +93,8 @@ object PreviewData {
             base = divePlan,
             deeper = null,
             longer = null,
+            bailout = false,
+            diveMode = DiveMode.OPEN_CIRCUIT,
             gasPlan = gasPlan
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/DiveEditorViewModelDelegate.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/DiveEditorViewModelDelegate.kt
@@ -13,10 +13,13 @@
 package org.neotech.app.abysner.presentation.screens.planner
 
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanInputModel
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
+import org.neotech.app.abysner.domain.diveplanning.model.countCheckedGas
+import org.neotech.app.abysner.domain.diveplanning.model.hasGas
 
 /**
  * ViewModel delegate that handles single-dive mutations. Every method accepts a
@@ -26,71 +29,121 @@ import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
  */
 object DiveEditorViewModelDelegate {
 
-    fun addSegment(dive: DivePlanInputModel, section: DiveProfileSection): DivePlanInputModel {
-        val updatedProfile = dive.plannedProfile + section
-        return dive.copy(plannedProfile = updatedProfile, cylinders = recomputeCylinderState(updatedProfile, dive.cylinders))
-    }
+    fun addSegment(dive: DivePlanInputModel, section: DiveProfileSection): DivePlanInputModel =
+        dive.update(profile = dive.plannedProfile + section)
 
     fun updateSegment(dive: DivePlanInputModel, index: Int, section: DiveProfileSection): DivePlanInputModel {
         val updatedProfile = dive.plannedProfile.toMutableList().apply { set(index, section) }
-        return dive.copy(plannedProfile = updatedProfile, cylinders = recomputeCylinderState(updatedProfile, dive.cylinders))
+        return dive.update(profile = updatedProfile)
     }
 
     fun removeSegment(dive: DivePlanInputModel, index: Int): DivePlanInputModel {
         val updatedProfile = dive.plannedProfile.toMutableList().apply { removeAt(index) }
-        return dive.copy(plannedProfile = updatedProfile, cylinders = recomputeCylinderState(updatedProfile, dive.cylinders))
+        return dive.update(profile = updatedProfile)
     }
 
     fun addCylinder(dive: DivePlanInputModel, cylinder: Cylinder): DivePlanInputModel {
-        val updatedCylinders = (dive.cylinders + PlannedCylinderModel(cylinder, isChecked = false, isLocked = false))
+        val newCylinder = PlannedCylinderModel(cylinder, isChecked = false, isLocked = false)
+        val updatedCylinders = (dive.cylinders + newCylinder)
             .sortedBy { it.cylinder.gas.oxygenFraction }
-        return dive.copy(cylinders = recomputeCylinderState(dive.plannedProfile, updatedCylinders))
+        return dive.update(cylinders = updatedCylinders)
     }
 
     fun updateCylinder(dive: DivePlanInputModel, cylinder: Cylinder): DivePlanInputModel {
-        val indexToUpdate = dive.cylinders.indexOfFirst { it.cylinder.uniqueIdentifier == cylinder.uniqueIdentifier }
-        val newCylinders = dive.cylinders.toMutableList().apply { set(indexToUpdate, get(indexToUpdate).copy(cylinder = cylinder)) }
+        val newCylinders = dive.cylinders.toMutableList().apply {
+            val index = indexOfFirst { it.cylinder.uniqueIdentifier == cylinder.uniqueIdentifier }
+            set(index, get(index).copy(cylinder = cylinder))
+        }
         val newProfile = dive.plannedProfile.map {
             // Cylinder objects are immutable, if updated, also update the profile sections that use it.
-            if (it.cylinder.uniqueIdentifier == cylinder.uniqueIdentifier) { it.copy(cylinder = cylinder) } else { it }
+            if (it.cylinder.uniqueIdentifier == cylinder.uniqueIdentifier) it.copy(cylinder = cylinder) else it
         }
-        return dive.copy(plannedProfile = newProfile, cylinders = recomputeCylinderState(newProfile, newCylinders))
+        return dive.update(profile = newProfile, cylinders = newCylinders)
     }
 
     fun removeCylinder(dive: DivePlanInputModel, cylinder: Cylinder): DivePlanInputModel {
         check(dive.cylinders.none { it.cylinder == cylinder && it.isLocked }) {
             "A locked cylinder cannot be removed, the caller must not allow this action."
         }
-        val updatedCylinders = dive.cylinders.filterNot { it.cylinder == cylinder }
-        return dive.copy(cylinders = recomputeCylinderState(dive.plannedProfile, updatedCylinders))
+        return dive.update(cylinders = dive.cylinders.filterNot { it.cylinder == cylinder })
     }
 
     fun toggleCylinder(dive: DivePlanInputModel, cylinder: Cylinder, enabled: Boolean): DivePlanInputModel {
         check(dive.cylinders.none { it.cylinder == cylinder && it.isLocked } || enabled) {
             "A locked cylinder cannot be disabled, the caller must not allow this action."
         }
-        val updatedCylinders = dive.cylinders.map { if (it.cylinder == cylinder) { it.copy(isChecked = enabled) } else { it } }
-        return dive.copy(cylinders = recomputeCylinderState(dive.plannedProfile, updatedCylinders))
+        return dive.update(cylinders = dive.cylinders.map { if (it.cylinder == cylinder) it.copy(isChecked = enabled) else it })
     }
 
-    fun setContingency(dive: DivePlanInputModel, deeper: Boolean, longer: Boolean): DivePlanInputModel =
-        dive.copy(deeper = deeper, longer = longer)
+    fun setContingency(dive: DivePlanInputModel, deeper: Boolean, longer: Boolean, bailout: Boolean): DivePlanInputModel =
+        dive.copy(deeper = deeper, longer = longer, bailout = bailout)
+
+    /**
+     * Switches the dive mode between OC and CCR, auto-creating the O2 injection cylinder when
+     * switching to CCR and removing it when switching back to OC.
+     */
+    fun setDiveMode(dive: DivePlanInputModel, mode: DiveMode): DivePlanInputModel {
+        if (dive.diveMode == mode) {
+            return dive
+        }
+
+        return when (mode) {
+            DiveMode.OPEN_CIRCUIT -> {
+                // Uncheck the oxygen CCR cylinder so it is preserved, but do disable it if possible
+                val updatedCylinders = dive.cylinders.map {
+                    if (it.cylinder.gas == Gas.Oxygen) {
+                        it.copy(isChecked = false, isLocked = false)
+                    } else {
+                        it
+                    }
+                }
+                dive.copy(
+                    diveMode = DiveMode.OPEN_CIRCUIT,
+                    bailout = false,
+                    cylinders = recomputeCylinderState(dive.plannedProfile, updatedCylinders, DiveMode.OPEN_CIRCUIT),
+                )
+            }
+            DiveMode.CLOSED_CIRCUIT -> {
+                // Add an oxygen cylinder if non exists
+                val updatedCylinders = if (dive.cylinders.hasGas(Gas.Oxygen)) {
+                    dive.cylinders
+                } else {
+                    val newOxygenCylinder = PlannedCylinderModel(
+                        cylinder = Cylinder(Gas.Oxygen, pressure = 200.0, waterVolume = 3.0),
+                        isChecked = true,
+                        isLocked = true
+                    )
+                    dive.cylinders + newOxygenCylinder
+                }
+                val recomputed = recomputeCylinderState(dive.plannedProfile, updatedCylinders, DiveMode.CLOSED_CIRCUIT)
+                dive.copy(
+                    diveMode = DiveMode.CLOSED_CIRCUIT,
+                    cylinders = recomputed,
+                )
+            }
+        }
+    }
 
     /**
      * Recomputes [PlannedCylinderModel.isLocked] for a single dive. Call this for every dive
      * after loading persisted data (e.g. via `model.dives.map { recomputeCylinderState(it) }`).
      */
     fun recomputeCylinderState(dive: DivePlanInputModel): DivePlanInputModel =
-        dive.copy(cylinders = recomputeCylinderState(dive.plannedProfile, dive.cylinders))
+        dive.copy(cylinders = recomputeCylinderState(dive.plannedProfile, dive.cylinders, dive.diveMode))
 
-    private fun recomputeCylinderState(segments: List<DiveProfileSection>, cylinders: List<PlannedCylinderModel>): List<PlannedCylinderModel> {
+    fun recomputeCylinderState(segments: List<DiveProfileSection>, cylinders: List<PlannedCylinderModel>, diveMode: DiveMode = DiveMode.OPEN_CIRCUIT): List<PlannedCylinderModel> {
         val gasesInUse = segments.mapTo(mutableSetOf()) { it.cylinder.gas }
-        val autoChecked = mutableSetOf<Gas>()
 
+        // In closed-circuit mode, pure oxygen must be treated as in-use
+        if (diveMode == DiveMode.CLOSED_CIRCUIT && Gas.Oxygen !in gasesInUse && cylinders.hasGas(Gas.Oxygen)) {
+            gasesInUse += Gas.Oxygen
+        }
+
+        val autoChecked = mutableSetOf<Gas>()
         val updated = cylinders.map { planned ->
             val gas = planned.cylinder.gas
-            val shouldAutoCheck = gas in gasesInUse && gas !in autoChecked && cylinders.count { it.cylinder.gas == gas && it.isChecked } == 0
-            if (shouldAutoCheck) {
+            val shouldAutoCheck = gas in gasesInUse && cylinders.countCheckedGas(gas) == 0
+            if (shouldAutoCheck && gas !in autoChecked) {
                 autoChecked += gas
                 planned.copy(isChecked = true)
             } else {
@@ -98,9 +151,17 @@ object DiveEditorViewModelDelegate {
             }
         }
         return updated.map { planned ->
-            val isUniqueInUse = { updated.count { it.cylinder.gas == planned.cylinder.gas && it.isChecked } == 1 }
+            val isUniqueInUse = { updated.countCheckedGas(planned.cylinder.gas) == 1 }
             val isInUse = { planned.cylinder.gas in gasesInUse }
             planned.copy(isLocked = planned.isChecked && isInUse() && isUniqueInUse())
         }
     }
+
+    private fun DivePlanInputModel.update(
+        profile: List<DiveProfileSection> = plannedProfile,
+        cylinders: List<PlannedCylinderModel> = this.cylinders,
+    ): DivePlanInputModel = copy(
+        plannedProfile = profile,
+        cylinders = recomputeCylinderState(profile, cylinders, diveMode)
+    )
 }

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
@@ -96,7 +96,7 @@ fun PlannerScreen(
         onAddSegment = { viewModel.addSegment(it) },
         onUpdateSegment = { index, segment -> viewModel.updateSegment(index, segment) },
         onRemoveSegment = { viewModel.removeSegment(it) },
-        onContingencyInputChanged = { deeper, longer -> viewModel.setContingency(deeper, longer) },
+        onContingencyInputChanged = { deeper, longer -> viewModel.setContingency(deeper, longer, bailout = false) },
         onSelectDive = { viewModel.selectDive(it) },
         onAddDive = { viewModel.addDive(it) },
         onRemoveDive = { viewModel.removeDive(it) },

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.diveplanning.PlanningRepository
@@ -102,7 +103,8 @@ class PlanScreenViewModel(
     fun updateCylinder(cylinder: Cylinder) = mutateDive { DiveEditorViewModelDelegate.updateCylinder(it, cylinder) }
     fun removeCylinder(cylinder: Cylinder) = mutateDive { DiveEditorViewModelDelegate.removeCylinder(it, cylinder) }
     fun toggleCylinder(cylinder: Cylinder, enabled: Boolean) = mutateDive { DiveEditorViewModelDelegate.toggleCylinder(it, cylinder, enabled) }
-    fun setContingency(deeper: Boolean, longer: Boolean) = mutateDive { DiveEditorViewModelDelegate.setContingency(it, deeper, longer) }
+    fun setContingency(deeper: Boolean, longer: Boolean, bailout: Boolean) = mutateDive { DiveEditorViewModelDelegate.setContingency(it, deeper, longer, bailout) }
+    fun setDiveMode(mode: DiveMode) = mutateDive { DiveEditorViewModelDelegate.setDiveMode(it, mode) }
 
     fun selectDive(index: Int) {
         planInput.update { it.copy(selectedDiveIndex = index) }
@@ -184,6 +186,7 @@ class PlanScreenViewModel(
             dives = input.model.dives,
             segments = selectedDive.plannedProfile,
             availableGas = selectedDive.cylinders,
+            diveMode = selectedDive.diveMode,
             isCalculatingDivePlan = isCalc,
             multiDivePlanSet = plan,
             selectedDivePlanSet = plan.map { it?.divePlanSets?.getOrNull(input.selectedDiveIndex) },
@@ -196,8 +199,6 @@ class PlanScreenViewModel(
         started = SharingStarted.WhileSubscribed(),
         initialValue = UiState()
     )
-
-    // ── Calculation ──────────────────────────────────────────────────────────
 
     private fun calculateMultiDivePlan(
         model: MultiDivePlanInputModel,
@@ -228,12 +229,19 @@ class PlanScreenViewModel(
             }
 
             val cylinders = diveInput.cylinders.filter { it.isChecked }.map { it.cylinder }
-            val divePlan = planner.addDive(plan = segments, cylinders = cylinders)
+            val divePlan = planner.addDive(
+                plan = segments,
+                cylinders = cylinders,
+                diveMode = diveInput.diveMode,
+                bailout = diveInput.bailout,
+            )
 
             DivePlanSet(
                 base = divePlan,
                 deeper = deeper,
                 longer = longer,
+                bailout = diveInput.bailout,
+                diveMode = diveInput.diveMode,
                 gasPlan = gasPlanner.calculateGasPlan(divePlan),
             )
         }
@@ -250,6 +258,7 @@ class PlanScreenViewModel(
         val dives: List<DivePlanInputModel> = listOf(defaultDivePlanInputModel),
         val segments: List<DiveProfileSection> = defaultProfile,
         val availableGas: List<PlannedCylinderModel> = defaultCylinders,
+        val diveMode: DiveMode = DiveMode.OPEN_CIRCUIT,
         val multiDivePlanSet: Result<MultiDivePlanSet?> = Result.success(null),
         val selectedDivePlanSet: Result<DivePlanSet?> = Result.success(null),
         val isCalculatingDivePlan: Boolean = false,
@@ -291,8 +300,10 @@ private val defaultProfile = listOf(
 )
 
 private val defaultDivePlanInputModel = DivePlanInputModel(
+    diveMode = DiveMode.OPEN_CIRCUIT,
     deeper = false,
     longer = false,
+    bailout = false,
     plannedProfile = defaultProfile,
     cylinders = defaultCylinders,
     surfaceIntervalBefore = null,

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
@@ -57,6 +57,7 @@ import kotlinx.collections.immutable.toImmutableList
 import org.jetbrains.compose.resources.painterResource
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.decompression.model.compactSimilarSegments
@@ -435,7 +436,7 @@ fun DecoPlanCardComponentPreview() {
         )
 
         DecoPlanCardComponent(
-            divePlanSet = DivePlanSet(base = divePlan, deeper = null, longer = null, gasPlan = persistentListOf()),
+            divePlanSet = DivePlanSet(base = divePlan, deeper = null, longer = null, bailout = false, diveMode = DiveMode.OPEN_CIRCUIT, gasPlan = persistentListOf()),
             settings = SettingsModel(),
             planningException = null,
             isLoading = false,

--- a/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/DiveEditorViewModelDelegateTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/DiveEditorViewModelDelegateTest.kt
@@ -13,10 +13,13 @@
 package org.neotech.app.abysner.presentation.screens.planner
 
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanInputModel
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
+import org.neotech.app.abysner.domain.diveplanning.model.countGas
+import org.neotech.app.abysner.domain.diveplanning.model.hasGas
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertEquals
@@ -28,19 +31,6 @@ class DiveEditorViewModelDelegateTest {
     private val airCylinder = Cylinder.steel12Liter(gas = Gas.Air, pressure = 232.0)
     private val nitrox50 = Cylinder.aluminium80Cuft(gas = Gas.Nitrox50, pressure = 207.0)
     private val airSegment = DiveProfileSection(duration = 30, depth = 25, cylinder = airCylinder)
-
-    private fun createDive(
-        segments: List<DiveProfileSection> = listOf(airSegment),
-        cylinders: List<PlannedCylinderModel> = listOf(
-            PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = true),
-        ),
-    ) = DivePlanInputModel(
-        deeper = false,
-        longer = false,
-        plannedProfile = segments,
-        cylinders = cylinders,
-        surfaceIntervalBefore = null
-    )
 
     @Test
     fun addSegment_referencedCylinderIsLocked() {
@@ -57,7 +47,7 @@ class DiveEditorViewModelDelegateTest {
     }
 
     @Test
-    fun removeCylinder_whenLockedThrows() {
+    fun removeCylinder_lockedCylinderThrows() {
         val dive = createDive()
         assertFailsWith<IllegalStateException> {
             DiveEditorViewModelDelegate.removeCylinder(dive, airCylinder)
@@ -65,7 +55,7 @@ class DiveEditorViewModelDelegateTest {
     }
 
     @Test
-    fun removeCylinder_whenUnlockedCylinderIsRemoved() {
+    fun removeCylinder_unlockedCylinderIsRemoved() {
         val dive = createDive(
             cylinders = listOf(
                 PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = false),
@@ -81,7 +71,7 @@ class DiveEditorViewModelDelegateTest {
     }
 
     @Test
-    fun toggleCylinder_whenNonLockedCylinderIsEnabled() {
+    fun toggleCylinder_uncheckedCylinderIsEnabled() {
         val dive = createDive(
             cylinders = listOf(
                 PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = true),
@@ -96,21 +86,15 @@ class DiveEditorViewModelDelegateTest {
     }
 
     @Test
-    fun toggleCylinder_whenLockedThrows() {
-        val dive = createDive(
-            cylinders = listOf(
-                PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = true),
-            ),
-            segments = listOf(airSegment)
-        )
-
+    fun toggleCylinder_lockedCylinderThrows() {
+        val dive = createDive()
         assertFailsWith<IllegalStateException> {
             DiveEditorViewModelDelegate.toggleCylinder(dive, airCylinder, enabled = false)
         }
     }
 
     @Test
-    fun toggleCylinder_whenNonLockedCylinderIsDisabled() {
+    fun toggleCylinder_checkedUnlockedCylinderIsDisabled() {
         val dive = createDive(
             cylinders = listOf(
                 PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = false),
@@ -133,12 +117,175 @@ class DiveEditorViewModelDelegateTest {
             ),
             segments = listOf(airSegment)
         )
+        val result = DiveEditorViewModelDelegate.recomputeCylinderState(dive)
+
+        assertTrue(result.cylinders[0].isLocked)
+        assertFalse(result.cylinders[1].isLocked)
+    }
+
+    @Test
+    fun recomputeCylinderState_ccrOxygenCylinderIsAutoCheckedAndLocked() {
+        val dive = createDive(
+            cylinders = listOf(
+                PlannedCylinderModel(
+                    cylinder = Cylinder(
+                        gas = Gas.Oxygen,
+                        pressure = 200.0,
+                        waterVolume = 3.0
+                    ),
+                    isChecked = false,
+                    isLocked = false
+                ),
+                PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = false),
+            ),
+        ).copy(diveMode = DiveMode.CLOSED_CIRCUIT)
 
         val result = DiveEditorViewModelDelegate.recomputeCylinderState(dive)
 
-        // Cylinder with air must be locked, since it is referenced by a segment.
-        assertTrue(result.cylinders[0].isLocked)
-        // Cylinder with nitrox should not be locked, since it is not referenced by a segment.
-        assertFalse(result.cylinders[1].isLocked)
+        val oxygenCylinder = result.cylinders.first { it.cylinder.gas == Gas.Oxygen }
+        assertTrue(oxygenCylinder.isChecked)
+        assertTrue(oxygenCylinder.isLocked)
     }
+
+    @Test
+    fun setDiveMode_ccrSwitchAddsOxygenCylinderIfMissing() {
+        val dive = createDive()
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
+
+        assertTrue(result.cylinders.hasGas(Gas.Oxygen))
+    }
+
+    @Test
+    fun setDiveMode_ccrSwitchDoesNotDuplicateExistingOxygenCylinder() {
+        val oxygenCylinder = Cylinder(Gas.Oxygen, pressure = 200.0, waterVolume = 3.0)
+        val dive = createDive(
+            cylinders = listOf(
+                PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = true),
+                PlannedCylinderModel(
+                    cylinder = oxygenCylinder,
+                    isChecked = false,
+                    isLocked = false
+                ),
+            )
+        )
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
+
+        assertEquals(1, result.cylinders.countGas(Gas.Oxygen))
+    }
+
+    @Test
+    fun setDiveMode_ccrOxygenCylinderIsCheckedAndLocked() {
+        val dive = createDive()
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
+
+        val oxygen = result.cylinders.first { it.cylinder.gas == Gas.Oxygen }
+        assertTrue(oxygen.isChecked)
+        assertTrue(oxygen.isLocked)
+    }
+
+    @Test
+    fun setDiveMode_ccrSwitchUpdatesDiveMode() {
+        val dive = createDive()
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
+
+        assertEquals(DiveMode.CLOSED_CIRCUIT, result.diveMode)
+    }
+
+    @Test
+    fun setDiveMode_ocSwitchPreservesOxygenCylinder() {
+        val dive = createDive().let {
+            DiveEditorViewModelDelegate.setDiveMode(it, DiveMode.CLOSED_CIRCUIT)
+        }
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.OPEN_CIRCUIT)
+
+        assertTrue(result.cylinders.hasGas(Gas.Oxygen))
+    }
+
+    @Test
+    fun setDiveMode_ocSwitchUpdatesDiveMode() {
+        val dive = createDive().let {
+            DiveEditorViewModelDelegate.setDiveMode(it, DiveMode.CLOSED_CIRCUIT)
+        }
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.OPEN_CIRCUIT)
+
+        assertEquals(DiveMode.OPEN_CIRCUIT, result.diveMode)
+    }
+
+    @Test
+    fun setDiveMode_ocSwitchResetsBailout() {
+        val dive = createDive().let {
+            DiveEditorViewModelDelegate.setDiveMode(it, DiveMode.CLOSED_CIRCUIT)
+        }.let {
+            DiveEditorViewModelDelegate.setContingency(
+                dive = it,
+                deeper = false,
+                longer = false,
+                bailout = true
+            )
+        }
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.OPEN_CIRCUIT)
+
+        assertFalse(result.bailout)
+    }
+
+    @Test
+    fun setDiveMode_sameModeIsNoOp() {
+        val dive = createDive()
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.OPEN_CIRCUIT)
+
+        assertEquals(dive, result)
+    }
+
+    @Test
+    fun setContingency_setsAllFlags() {
+        val result = DiveEditorViewModelDelegate.setContingency(
+            dive = createDive(),
+            deeper = true,
+            longer = true,
+            bailout = true
+        )
+
+        assertTrue(result.deeper)
+        assertTrue(result.longer)
+        assertTrue(result.bailout)
+    }
+
+    @Test
+    fun setContingency_clearsAllFlags() {
+        val dive = createDive().copy(deeper = true, longer = true, bailout = true)
+
+        val result = DiveEditorViewModelDelegate.setContingency(
+            dive,
+            deeper = false,
+            longer = false,
+            bailout = false
+        )
+
+        assertFalse(result.deeper)
+        assertFalse(result.longer)
+        assertFalse(result.bailout)
+    }
+
+    private fun createDive(
+        segments: List<DiveProfileSection> = listOf(airSegment),
+        cylinders: List<PlannedCylinderModel> = listOf(
+            PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = true),
+        ),
+    ) = DivePlanInputModel(
+        diveMode = DiveMode.OPEN_CIRCUIT,
+        deeper = false,
+        longer = false,
+        bailout = false,
+        plannedProfile = segments,
+        cylinders = cylinders,
+        surfaceIntervalBefore = null
+    )
 }

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
@@ -85,6 +85,7 @@ fun DivePlanInputModel.toResource() = DivePlanInputResourceV1(
     diveMode = diveMode.preferenceValue,
     deeper = deeper,
     longer = longer,
+    bailout = bailout,
     cylinders = cylinders.map { it.toResource() },
     profile = plannedProfile.map { it.toResource() },
     surfaceIntervalBeforeMinutes = surfaceIntervalBefore?.inWholeMinutes?.toInt(),
@@ -119,6 +120,7 @@ fun DivePlanInputResourceV1.toModel(): DivePlanInputModel {
         diveMode = fromString<DiveMode>(diveMode),
         deeper = deeper,
         longer = longer,
+        bailout = bailout,
         cylinders = cylinders,
         plannedProfile = profile.map {
             it.toModel(cylinders.find { cylinder -> cylinder.cylinder.uniqueIdentifier == it.cylinderIdentifier }!!.cylinder)

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/resources/DivePlanInputResourceV1.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/resources/DivePlanInputResourceV1.kt
@@ -18,12 +18,15 @@ import org.neotech.app.abysner.data.SerializableResource
 @Serializable
 data class DivePlanInputResourceV1(
     val version: Int = 1,
+    // Added after 1.0.8-beta
     val diveMode: String = "open-circuit",
     val deeper: Boolean,
     val longer: Boolean,
+    // Added after 1.0.8-beta
+    val bailout: Boolean = false,
     val cylinders: List<CheckableCylinderResource>,
     val profile: List<ProfileSegmentResource>,
-    // Version 1.0.8-beta did not have this field yet, for migration this field defaults to null
+    // Added after 1.0.8-beta
     val surfaceIntervalBeforeMinutes: Int? = null,
 ): SerializableResource {
 

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanInputModel.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanInputModel.kt
@@ -15,11 +15,13 @@ package org.neotech.app.abysner.domain.diveplanning.model
 import kotlin.time.Duration
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.DiveMode
+import org.neotech.app.abysner.domain.core.model.Gas
 
 data class DivePlanInputModel(
-    val diveMode: DiveMode = DiveMode.OPEN_CIRCUIT,
+    val diveMode: DiveMode,
     val deeper: Boolean,
     val longer: Boolean,
+    val bailout: Boolean,
     val plannedProfile: List<DiveProfileSection>,
     val cylinders: List<PlannedCylinderModel>,
     /**
@@ -38,3 +40,10 @@ data class PlannedCylinderModel(
      */
     val isLocked: Boolean,
 )
+
+fun List<PlannedCylinderModel>.hasGas(gas: Gas): Boolean = any { it.cylinder.gas == gas }
+
+fun List<PlannedCylinderModel>.countGas(gas: Gas): Int = count { it.cylinder.gas == gas }
+
+fun List<PlannedCylinderModel>.countCheckedGas(gas: Gas): Int = count { it.cylinder.gas == gas && it.isChecked }
+

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanSet.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanSet.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -13,17 +13,22 @@
 package org.neotech.app.abysner.domain.diveplanning.model
 
 import org.neotech.app.abysner.domain.core.model.Configuration
+import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.gasplanning.model.GasPlan
 
+// TODO: Find a better name, now it implies a collection of plans. Maybe DivePlanResult or ComputedDivePlan?
 data class DivePlanSet(
     val base: DivePlan,
     val deeper: Int?,
     val longer: Int?,
+    val bailout: Boolean,
+    val diveMode: DiveMode,
     val gasPlan: GasPlan,
 ) {
 
     val isDeeper = deeper != null
     val isLonger = longer != null
+    val isCcr = diveMode == DiveMode.CLOSED_CIRCUIT
 
     val configuration: Configuration = base.configuration
     val isEmpty: Boolean = base.isEmpty


### PR DESCRIPTION
Added `setDiveMode()` to `DiveEditorViewModelDelegate`, which handles switching between open-circuit and closed-circuit dive modes. Also added a `bailout` parameter to `setContingency()` to allow a bailout closed-circuit plan to be calculated instead a normal closed-circuit dive.

Required for: #3