### PR TITLE
Change: rename gas plan categories from Normal/Emergency to Used/Reserve

### DIFF
--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/ShareImageScreenshotTestKt/ShareImageScreenshotTest_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/ShareImageScreenshotTestKt/ShareImageScreenshotTest_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76dcf42b6f7bb2051c572378e510ca9ac5e590f85c93876281a3c9492b5ef370
-size 209212
+oid sha256:4c7afed54c9a23f616ffd52f071d25ca7e5a4e84aa2245b1625463e0f9c38201
+size 204016

--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenScreenshotTest_d70cdda2_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenScreenshotTest_d70cdda2_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb40aa2399bf5ddc28b61d2aa82b7080844c2aec1fa0d20ab6ba164acc2eb0fb
-size 190336
+oid sha256:34e6da461e928d80f7050f28c78604b269eaa12d993f1f85a92ef6421471ddf6
+size 187308

--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenWithWarningsScreenshotTest_d70cdda2_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenWithWarningsScreenshotTest_d70cdda2_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61388523c453a9c4f555b826ecd9c2c9f1fad6cb98d943864f1c9b8215ba0141
-size 220718
+oid sha256:fbf66aea134100f7e4b638b7377231ffd65da2f90f6403a8a7ba1261f8560fb8
+size 218195

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPropertiesComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPropertiesComponent.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -80,7 +80,7 @@ fun GasPropertiesComponent(
                 val name = gas?.diveIndustryName() ?: EMPTY_PLACEHOLDER
                 BigNumberDisplay(
                     modifier = Modifier.weight(0.4f),
-                    size = BigNumberSize.SMALL,
+                    size = BigNumberSize.LARGE,
                     value = name,
                     label = "Type"
                 )

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/Table.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/Table.kt
@@ -141,8 +141,9 @@ private fun TableHeader(
     content: @Composable RowScope.() -> Unit
 ) {
     Row(
-        modifier = modifier
+        modifier = Modifier
             .background(MaterialTheme.colorScheme.secondaryContainer)
+            .then(modifier)
     ) {
         CompositionLocalProvider(LocalTextStyle provides textStyle) {
             content()

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
@@ -102,7 +103,17 @@ fun DecoPlanCardComponent(
                         .padding(horizontal = 16.dp)
                         .padding(bottom = 16.dp),
                     style = MaterialTheme.typography.titleLarge,
-                    text = "Deco plan"
+                    text = buildAnnotatedString {
+                        append("Deco plan")
+                        withStyle(MaterialTheme.typography.titleSmall.toSpanStyle()) {
+                            if (divePlanSet?.isDeeper == true) {
+                                append(" +${divePlanSet.deeper}m")
+                            }
+                            if (divePlanSet?.isLonger == true) {
+                                append(" +${divePlanSet.longer}min")
+                            }
+                        }
+                    }
                 )
 
                 if ((divePlanSet == null || divePlanSet.isEmpty)) {
@@ -342,9 +353,9 @@ fun DecoPlanTable(
                 text = "Depth",
                 icon = ColorPainter(Color.Transparent),
             )
-            Text(modifier = Modifier.weight(0.2f), text = "Runtime")
-            Text(modifier = Modifier.weight(0.2f), text = "Duration")
-            Text(modifier = Modifier.weight(0.15f), text = "Gas")
+            Text(modifier = Modifier.weight(0.25f), text = "Runtime")
+            Text(modifier = Modifier.weight(0.25f), text = "Duration")
+            Text(modifier = Modifier.weight(0.25f), text = "Gas")
         }
     ) {
         val segments = divePlan.segmentsCollapsed
@@ -408,16 +419,16 @@ private fun RowScope.DecoPlanRow(
         icon = painterResource(resource = typeIcon)
     )
     Text(
-        modifier = Modifier.weight(0.2f),
+        modifier = Modifier.weight(0.25f),
         text = runtime.toString(),
     )
     Text(
-        modifier = Modifier.weight(0.2f),
+        modifier = Modifier.weight(0.25f),
         text = "+${diveSegment.duration}",
     )
     Text(
-        modifier = Modifier.weight(0.15f),
         text = gas.toString(),
+        modifier = Modifier.weight(0.25f),
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasBarChart.kt
@@ -107,8 +107,8 @@ fun GasPlanBarChart(
             label = {
                 val label = when (it) {
                     0 -> "Unused"
-                    1 -> "Emergency"
-                    2 -> "Normal"
+                    1 -> "Reserve"
+                    2 -> "Used"
                     else -> error("Unknown legend index")
                 }
                 Text(text = label, style = MaterialTheme.typography.bodySmall)
@@ -227,7 +227,7 @@ fun GasPlanBarChart(
                             if (it.pressureLeft == null) {
                                 val alertMessage = buildAnnotatedString {
                                     appendIcon(IconFont.WARNING)
-                                    append("critical gas shortage")
+                                    append(" Critical gas shortage")
                                 }
 
                                 TextAlert(
@@ -238,7 +238,7 @@ fun GasPlanBarChart(
                             } else if(it.pressureLeftWithEmergency == null) {
                                 val alertMessage = buildAnnotatedString {
                                     appendIcon(IconFont.WARNING)
-                                    append("gas shortage")
+                                    append(" Insufficient reserve")
                                 }
 
                                 TextAlert(
@@ -284,21 +284,21 @@ fun GasUsageBar(
 
     val values = persistentListOf(
 
-        // Gas left
+        // Unused gas
         BarSection(
             value = pressureLeftWithEmergency,
             color = Brush.horizontalGradient(colors = blueShades),
             textColor = SolidColor(blueForeground),
             textStyle = MaterialTheme.typography.labelSmall.copy(textAlign = TextAlign.Left)
         ),
-        // Gas used with emergency
+        // Reserve
         BarSection(
             value = pressureLeftWithoutEmergency - pressureLeftWithEmergency,
             color = Brush.horizontalGradient(colors = redShades),
             textColor = SolidColor(redForeground),
             textStyle = MaterialTheme.typography.labelSmall.copy(textAlign = TextAlign.Center)
         ),
-        // Gas normally used
+        // Usage
         BarSection(
             value = cylinderGasRequirements.cylinder.pressure.toFloat() - pressureLeftWithoutEmergency,
             color = SolidColor(MaterialTheme.colorScheme.outlineVariant),

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
@@ -128,7 +128,7 @@ fun GasPlanCardComponent(
                     Text(
                         modifier = Modifier.padding(top = 16.dp, bottom = 4.dp)
                             .padding(horizontal = 16.dp),
-                        text = "Totals (ℓ)",
+                        text = "Totals",
                         style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
                     )
 
@@ -164,18 +164,18 @@ fun GasPlanCardComponent(
 
                     val explanationText = buildAnnotatedString {
                         appendBoldLine("Notes on the gas plan:")
-                        appendLine("The gas plan calculates cylinder pressures based on real-world gas behavior, rather than relying on simplified gas law assumptions. The bar chart divides gas usage into three key categories:")
+                        appendLine("The gas plan calculates cylinder pressures based on real-world gas behavior, rather than relying on simplified gas law assumptions. The gas plan divides gas into three categories:")
                         appendBulletPoint {
-                            appendBold("Normal: ")
-                            append("The pressure required (in bars) for a single diver to complete the planned dive under normal conditions.")
+                            appendBold("Used: ")
+                            append("The gas required for a single diver to complete the planned dive under normal conditions.")
                         }
                         appendBulletPoint {
-                            appendBold("Emergency: ")
-                            append("This reserve pressure ensures a safe ascent if a buddy loses one or more gas mixes at the worst point in the dive. It assumes buddy breathing is possible for all cylinders, including during decompression stops.")
+                            appendBold("Reserve: ")
+                            append("Extra gas to ensure a safe ascent if a buddy loses one or more gas mixes at the worst point in the dive. It assumes buddy breathing is possible for all cylinders, including during decompression stops.")
                         }
                         appendBulletPoint {
                             appendBold("Unused: ")
-                            append("Any remaining pressure after accounting for both Normal and Emergency requirements.\n")
+                            append("Any remaining gas after accounting for both Used and Reserve requirements.\n")
                         }
                         appendIcon(IconFont.WARNING)
                         appendBold(" Always plan your cylinders carefully, considering the “minimum functional pressure” of your regulators.")
@@ -203,7 +203,7 @@ fun CylindersTable(
         header = {
             Text(modifier = Modifier.weight(0.3f), text = "Mix")
             Text(modifier = Modifier.weight(0.3f), text = "Size (ℓ)")
-            Text(modifier = Modifier.weight(0.4f), text = "Usage (bar)")
+            Text(modifier = Modifier.weight(0.4f), text = "Pressure (bar)")
         }
     ) {
         rows(divePlanSet.gasPlan, key = { it.cylinder.uniqueIdentifier }) { usage ->
@@ -223,18 +223,14 @@ fun CylindersTable(
 
             var alertSeverity: AlertSeverity = AlertSeverity.NONE
             val pressureText = buildAnnotatedString {
-                if (endPressureBase == null && endPressure == null) {
+                if (endPressureBase == null) {
                     alertSeverity = AlertSeverity.ERROR
                     append("$startPressure > empty")
-                    appendIcon(IconFont.WARNING)
-                } else if (endPressure == null && endPressureBase != null) {
-                    alertSeverity = AlertSeverity.WARNING
-                    append("$startPressure > ${endPressureBase.format(0)} (")
-                    appendIcon(IconFont.WARNING)
-                    append("0)")
                 } else {
-                    alertSeverity = AlertSeverity.NONE
-                    append("$startPressure > ${endPressureBase!!.format(0)} (${endPressure!!.format(0)})")
+                    if (endPressure == null) {
+                        alertSeverity = AlertSeverity.WARNING
+                    }
+                    append("$startPressure > ${endPressureBase.format(0)}")
                 }
             }
 
@@ -256,29 +252,39 @@ fun GasTotalsTable(
         modifier = modifier,
         header = {
             Text(modifier = Modifier.weight(0.17f), text = "Mix")
-            Text(modifier = Modifier.weight(0.29f), text = "Available")
-            Text(modifier = Modifier.weight(0.19f), text = "Normal")
-            Text(modifier = Modifier.weight(0.27f), text = "Emergency")
+            Text(modifier = Modifier.weight(0.32f), text = "Available (ℓ)")
+            Text(modifier = Modifier.weight(0.26f), text = "Used (ℓ)")
+            Text(modifier = Modifier.weight(0.25f), text = "Reserve (ℓ)")
         }
     ) {
         rows(gasPlan.groupBy { it.cylinder.gas }.toList(), key = { (gas, _) -> gas }) { (gas, entries) ->
-            val totalNormal = entries.sumOf { it.normalRequirement }
-            val totalRequired = entries.sumOf { it.totalGasRequirement }
+            val totalUsage = entries.sumOf { it.normalRequirement }
+            val totalReserve = entries.sumOf { it.extraEmergencyRequirement }
+            val totalRequired = totalUsage + totalReserve
             val totalCapacity = entries.sumOf { it.cylinder.capacity() }
 
-            val alertSeverity = when {
-                totalNormal > totalCapacity -> AlertSeverity.ERROR
+            val alertSeverityUsage = when {
+                totalUsage > totalCapacity -> AlertSeverity.ERROR
+                else -> AlertSeverity.NONE
+            }
+
+            val alertSeverityReserve = when {
+                totalUsage > totalCapacity -> AlertSeverity.ERROR
                 totalRequired > totalCapacity -> AlertSeverity.WARNING
                 else -> AlertSeverity.NONE
             }
 
             Text(modifier = Modifier.weight(0.17f), text = gas.toString())
-            Text(modifier = Modifier.weight(0.29f), text = DecimalFormat.format(0, totalCapacity))
-            Text(modifier = Modifier.weight(0.19f), text = "-${DecimalFormat.format(0, totalNormal)}")
+            Text(modifier = Modifier.weight(0.32f), text = DecimalFormat.format(0, totalCapacity))
             TextAlert(
-                modifier = Modifier.weight(0.27f),
-                alertSeverity = alertSeverity,
-                text = "-${DecimalFormat.format(0, totalRequired)}",
+                modifier = Modifier.weight(0.26f),
+                alertSeverity = alertSeverityUsage,
+                text = DecimalFormat.format(0, totalUsage),
+            )
+            TextAlert(
+                modifier = Modifier.weight(0.25f),
+                alertSeverity = alertSeverityReserve,
+                text = DecimalFormat.format(0, totalReserve),
             )
         }
     }
@@ -336,6 +342,30 @@ private fun GasPlanCardComponentPreview() {
     AbysnerTheme {
         GasPlanCardComponent(
             divePlanSet = PreviewData.divePlan1,
+            planningException = null,
+            isLoading = false
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun GasPlanCardComponentWithWarningsPreview() {
+    AbysnerTheme {
+        GasPlanCardComponent(
+            divePlanSet = PreviewData.divePlan2,
+            planningException = null,
+            isLoading = false
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun GasPlanCardComponentEmptyPreview() {
+    AbysnerTheme {
+        GasPlanCardComponent(
+            divePlanSet = null,
             planningException = null,
             isLoading = false
         )

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasUsageDetailsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasUsageDetailsDialog.kt
@@ -109,44 +109,46 @@ fun GasUsageDetailsDialog(
                     row {
                         Text(
                             modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
-                            text = "Available gas", fontWeight = FontWeight.Bold
+                            text = "Capacity", fontWeight = FontWeight.Bold
                         )
                         Text(modifier = Modifier.weight(1f), text = "${capacity.format(0)} ℓ")
                     }
                 }
 
-                val totalNormal = sameMixCylinders.sumOf { it.normalRequirement }
-                val totalRequired = sameMixCylinders.sumOf { it.totalGasRequirement }
+                val totalUsage = sameMixCylinders.sumOf { it.normalRequirement }
+                val totalReserve = sameMixCylinders.sumOf { it.extraEmergencyRequirement }
+                val totalRequired = totalUsage + totalReserve
                 val totalCapacity = sameMixCylinders.sumOf { it.cylinder.capacity() }
 
                 val showTotals = sameMixCylinders.size > 1
 
                 Text(
                     modifier = Modifier.padding(top = 16.dp, bottom = 4.dp),
-                    text = "Required for dive",
+                    text = "Total for dive",
                     style = MaterialTheme.typography.titleLarge
                 )
                 Table(striped = false, defaultRowModifier = Modifier.padding(vertical = 1.dp)) {
                     row {
                         Text(
                             modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
-                            text = "Normal", fontWeight = FontWeight.Bold
+                            text = "Used", fontWeight = FontWeight.Bold
                         )
-                        Text(modifier = Modifier.weight(1f), text = "${totalNormal.format(0)} ℓ")
+                        Text(modifier = Modifier.weight(1f), text = "${totalUsage.format(0)} ℓ")
                     }
                     row {
                         Text(
                             modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
-                            text = "Emergency", fontWeight = FontWeight.Bold
+                            text = "Reserve", fontWeight = FontWeight.Bold
                         )
-                        Text(modifier = Modifier.weight(1f), text = "${totalRequired.format(0)} ℓ")
+                        Text(modifier = Modifier.weight(1f), text = "${totalReserve.format(0)} ℓ")
                     }
                     row {
                         Text(
                             modifier = Modifier.uniformLabelWidth(labelWidthState).padding(end = 8.dp),
-                            text = "Available", fontWeight = FontWeight.Bold
+                            text = "Unused", fontWeight = FontWeight.Bold
                         )
-                        Text(modifier = Modifier.weight(1f), text = "${totalCapacity.format(0)} ℓ")
+                        val totalUnused = totalCapacity - totalRequired
+                        Text(modifier = Modifier.weight(1f), text = "${totalUnused.format(0)} ℓ")
                     }
                 }
 
@@ -167,7 +169,7 @@ fun GasUsageDetailsDialog(
                 // Bar pressure for a single cylinder (what divers read on gauges), liters for
                 // multiple cylinders (no meaningful single pressure to show).
                 val unusedNormalFormatted = if (showTotals) {
-                    "${(totalCapacity - totalNormal).format(0)} ℓ"
+                    "${(totalCapacity - totalUsage).format(0)} ℓ"
                 } else {
                     "${cylinderGasRequirements.pressureLeft?.format(0)} bar"
                 }
@@ -178,7 +180,7 @@ fun GasUsageDetailsDialog(
                 }
 
                 val severity = when {
-                    totalNormal > totalCapacity -> AlertSeverity.ERROR
+                    totalUsage > totalCapacity -> AlertSeverity.ERROR
                     totalRequired > totalCapacity -> AlertSeverity.WARNING
                     else -> AlertSeverity.POSITIVE
                 }
@@ -189,28 +191,28 @@ fun GasUsageDetailsDialog(
                             if (showTotals) appendBoldLine("Together, these ${sameMixCylinders.size} cylinders have a critical gas shortage!")
                             else appendBoldLine("This cylinder has a critical gas shortage!")
                             append("You need at least ")
-                            appendBold("${totalNormal.format(0)} ℓ")
+                            appendBold("${totalUsage.format(0)} ℓ")
                             append(if (showTotals) " for the dive, but only have a combined " else " for the dive, but only have ")
                             appendBold(totalCapacityFormatted)
                             append(".")
                         }
                         AlertSeverity.WARNING -> {
-                            if (showTotals) appendBoldLine("Together, these ${sameMixCylinders.size} cylinders have a gas shortage!")
-                            else appendBoldLine("This cylinder has a gas shortage!")
+                            if (showTotals) appendBoldLine("Together, these ${sameMixCylinders.size} cylinders have insufficient reserve!")
+                            else appendBoldLine("This cylinder has insufficient reserve!")
                             append("You need ")
                             appendBold("${totalRequired.format(0)} ℓ")
-                            append(if (showTotals) " in case of an emergency, but only have a combined " else " in case of an emergency, but only have ")
+                            append(if (showTotals) " including reserve, but only have a combined " else " including reserve, but only have ")
                             appendBold(totalCapacityFormatted)
-                            append(". Without emergencies, there is enough gas.")
+                            append(". Without accounting for reserve, there is enough gas.")
                         }
                         AlertSeverity.POSITIVE, AlertSeverity.NONE -> {
-                            if (showTotals) appendBoldLine("Together, these ${sameMixCylinders.size} cylinders have enough gas for the dive, even in an emergency.")
-                            else appendBoldLine("This cylinder has enough gas for the dive, even in an emergency.")
+                            if (showTotals) appendBoldLine("Together, these ${sameMixCylinders.size} cylinders have enough gas, even if the reserve is needed.")
+                            else appendBoldLine("This cylinder has enough gas, even if the reserve is needed.")
                             append("After a normal dive about ")
                             appendBold(unusedNormalFormatted)
                             append(" remains, and about ")
                             appendBold(unusedEmergencyFormatted)
-                            append(" after an emergency.")
+                            append(" after using the reserve.")
                         }
                     }
                 }


### PR DESCRIPTION
The gas plan bar chart, totals table, cylinders table, and details dialog now use `Used`, `Reserve`, and `Unused` as category labels. Reserve shows only the extra emergency gas requirement, not the cumulative total.

This also includes some other UX improvements:
- Added: The `Used` column in the totals table is highlighted red when usage exceeds capacity.
- Removed: reserve pressure in brackets from the cylinders table, it was just noise.
- Changed: Bar chart and dialog warning text from "gas shortage" to "insufficient reserve".
- Added: deeper/longer annotations to the deco plan title.
- Fixed: `TableHeader` modifier ordering so background renders without padding applied.
- Changed: Gas type is now the same height as gas mix in the cylinder picker.