### PR TITLE
Add: `CylinderRole` enum for CCR cylinder classification

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
@@ -21,6 +21,7 @@ import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanSet
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
+import org.neotech.app.abysner.domain.diveplanning.model.toAssignedCylinders
 import org.neotech.app.abysner.domain.gasplanning.GasPlanner
 
 object PreviewData {
@@ -48,7 +49,7 @@ object PreviewData {
             configuration = Configuration()
         }.addDive(
             plan = divePlan1Segments,
-            cylinders = divePlan1Cylinders.filter { it.isChecked }.map { it.cylinder },
+            cylinders = divePlan1Cylinders.filter { it.isChecked }.toAssignedCylinders(),
         )
         val gasPlan = GasPlanner().calculateGasPlan(divePlan)
         DivePlanSet(
@@ -86,7 +87,7 @@ object PreviewData {
         ))
             .addDive(
                 plan = divePlan2Segments,
-                cylinders = divePlan2Cylinders.filter { it.isChecked }.map { it.cylinder },
+                cylinders = divePlan2Cylinders.filter { it.isChecked }.toAssignedCylinders(),
         )
         val gasPlan = GasPlanner().calculateGasPlan(divePlan)
         DivePlanSet(

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/DiveEditorViewModelDelegate.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/DiveEditorViewModelDelegate.kt
@@ -15,11 +15,13 @@ package org.neotech.app.abysner.presentation.screens.planner
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.diveplanning.model.CylinderRole
+import org.neotech.app.abysner.domain.diveplanning.model.toggleAvailableForBailout
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanInputModel
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
+import org.neotech.app.abysner.domain.diveplanning.model.ccrDiluentCylinder
 import org.neotech.app.abysner.domain.diveplanning.model.countCheckedGas
-import org.neotech.app.abysner.domain.diveplanning.model.hasGas
 
 /**
  * ViewModel delegate that handles single-dive mutations. Every method accepts a
@@ -55,8 +57,13 @@ object DiveEditorViewModelDelegate {
             set(index, get(index).copy(cylinder = cylinder))
         }
         val newProfile = dive.plannedProfile.map {
-            // Cylinder objects are immutable, if updated, also update the profile sections that use it.
-            if (it.cylinder.uniqueIdentifier == cylinder.uniqueIdentifier) it.copy(cylinder = cylinder) else it
+            // Cylinder objects are immutable, if updated, also update the profile sections that use
+            // it, since the object references will be different.
+            if (it.cylinder.uniqueIdentifier == cylinder.uniqueIdentifier) {
+                it.copy(cylinder = cylinder)
+            } else {
+                it
+            }
         }
         return dive.update(profile = newProfile, cylinders = newCylinders)
     }
@@ -65,22 +72,71 @@ object DiveEditorViewModelDelegate {
         check(dive.cylinders.none { it.cylinder == cylinder && it.isLocked }) {
             "A locked cylinder cannot be removed, the caller must not allow this action."
         }
-        return dive.update(cylinders = dive.cylinders.filterNot { it.cylinder == cylinder })
+        val remainingCylinders = dive.cylinders.filterNot { it.cylinder == cylinder }
+
+        // Reassign any segments that referenced the removed cylinder. In CCR mode this can happen
+        // because bailout cylinders are not locked. A diluent always exists as fallback because
+        // it is locked and cannot be removed.
+        val fallback = remainingCylinders.ccrDiluentCylinder()?.cylinder
+            ?: remainingCylinders.first().cylinder
+        // TODO in theory this will probably impossible given that the interface forbids it, the
+        //      user might be able to orphan a section from a true cylinder, then this could cause
+        //      data restore failures in  DivePlanInputResourceV1.toModel()?
+        //      Perhaps sections should be allowed to have a nullable cylinder? This allows for auto
+        //      selection mode during planning?
+        val updatedProfile = dive.plannedProfile.map { section ->
+            if (section.cylinder == cylinder) {
+                section.copy(cylinder = fallback)
+            } else {
+                section
+            }
+        }
+
+        return dive.update(profile = updatedProfile, cylinders = remainingCylinders)
     }
 
     fun toggleCylinder(dive: DivePlanInputModel, cylinder: Cylinder, enabled: Boolean): DivePlanInputModel {
         check(dive.cylinders.none { it.cylinder == cylinder && it.isLocked } || enabled) {
             "A locked cylinder cannot be disabled, the caller must not allow this action."
         }
-        return dive.update(cylinders = dive.cylinders.map { if (it.cylinder == cylinder) it.copy(isChecked = enabled) else it })
+        return dive.update(
+            cylinders = dive.cylinders.map {
+                if (it.cylinder == cylinder) {
+                    it.copy(isChecked = enabled)
+                } else {
+                    it
+                }
+            }
+        )
+    }
+
+    fun toggleAvailableForBailout(dive: DivePlanInputModel, cylinder: Cylinder, availableForBailout: Boolean): DivePlanInputModel {
+        return dive.update(
+            cylinders = dive.cylinders.map {
+                if (it.cylinder == cylinder) {
+                    it.copy(role = it.role.toggleAvailableForBailout(availableForBailout))
+                } else {
+                    it
+                }
+            }
+        )
     }
 
     fun setContingency(dive: DivePlanInputModel, deeper: Boolean, longer: Boolean, bailout: Boolean): DivePlanInputModel =
         dive.copy(deeper = deeper, longer = longer, bailout = bailout)
 
     /**
-     * Switches the dive mode between OC and CCR, auto-creating the O2 injection cylinder when
-     * switching to CCR and removing it when switching back to OC.
+     * Switches the dive mode between OC and CCR.
+     *
+     * Switch to CCR:
+     * - Oxygen cylinder is automatically added if no [CylinderRole.CCR_OXYGEN] is found.
+     * - Diluent cylinder is taken from the deepest dive segment if no
+     *   [CylinderRole.CCR_DILUENT_AND_BAILOUT] or [CylinderRole.CCR_DILUENT] role is found.
+     *
+     * Switch to OC:
+     *  - Oxygen cylinder is unchecked, role is kept (for round-trip to CCR)
+     *  - Diluent cylinder is unchecked, role is kept (for round-trip to CCR)
+     *  - Note: Both cylinders may be checked and even locked again if they are in use in the profile
      */
     fun setDiveMode(dive: DivePlanInputModel, mode: DiveMode): DivePlanInputModel {
         if (dive.diveMode == mode) {
@@ -89,9 +145,10 @@ object DiveEditorViewModelDelegate {
 
         return when (mode) {
             DiveMode.OPEN_CIRCUIT -> {
-                // Uncheck the oxygen CCR cylinder so it is preserved, but do disable it if possible
+                // Uncheck CCR specific cylinders, but preserve roles for round-trip, they may be
+                // checked and locked again if required by the OC plan (recomputeCylinderState)
                 val updatedCylinders = dive.cylinders.map {
-                    if (it.cylinder.gas == Gas.Oxygen) {
+                    if (it.isCcrOxygen || it.isCcrDiluent) {
                         it.copy(isChecked = false, isLocked = false)
                     } else {
                         it
@@ -100,27 +157,74 @@ object DiveEditorViewModelDelegate {
                 dive.copy(
                     diveMode = DiveMode.OPEN_CIRCUIT,
                     bailout = false,
-                    cylinders = recomputeCylinderState(dive.plannedProfile, updatedCylinders, DiveMode.OPEN_CIRCUIT),
+                    cylinders = recomputeCylinderState(dive.plannedProfile, updatedCylinders, DiveMode.OPEN_CIRCUIT)
                 )
             }
             DiveMode.CLOSED_CIRCUIT -> {
-                // Add an oxygen cylinder if non exists
-                val updatedCylinders = if (dive.cylinders.hasGas(Gas.Oxygen)) {
-                    dive.cylinders
-                } else {
-                    val newOxygenCylinder = PlannedCylinderModel(
+                // Re-enable any existing CCR cylinders
+                var updatedCylinders = dive.cylinders.map {
+                    if (it.isCcrOxygen || it.isCcrDiluent) {
+                        it.copy(isChecked = true)
+                    } else {
+                        it
+                    }
+                }
+
+                // If no oxygen cylinder exists: add one
+                if (updatedCylinders.none { it.isCcrOxygen }) {
+                    updatedCylinders = updatedCylinders + PlannedCylinderModel(
                         cylinder = Cylinder(Gas.Oxygen, pressure = 200.0, waterVolume = 3.0),
                         isChecked = true,
-                        isLocked = true
+                        isLocked = true,
+                        role = CylinderRole.CCR_OXYGEN,
                     )
-                    dive.cylinders + newOxygenCylinder
                 }
-                val recomputed = recomputeCylinderState(dive.plannedProfile, updatedCylinders, DiveMode.CLOSED_CIRCUIT)
+
+                // If no diluent exists: select one from the dive profile or add a default.
+                if (updatedCylinders.none { it.isCcrDiluent }) {
+                    updatedCylinders = ensureDiluent(updatedCylinders, dive.plannedProfile)
+                }
+
                 dive.copy(
                     diveMode = DiveMode.CLOSED_CIRCUIT,
-                    cylinders = recomputed,
+                    cylinders = recomputeCylinderState(dive.plannedProfile, updatedCylinders, DiveMode.CLOSED_CIRCUIT)
                 )
             }
+        }
+    }
+
+    /**
+     * Finds the best diluent candidate from the planned profile and marks it as diluent, or creates
+     * a default Air diluent if no suitable candidate exists.
+     */
+    private fun ensureDiluent(
+        cylinders: List<PlannedCylinderModel>,
+        profile: List<DiveProfileSection>
+    ): List<PlannedCylinderModel> {
+        val diluentGas = profile.maxByOrNull { it.depth }?.cylinder?.gas
+
+        val mostLikelyDiluentCylinder = if (diluentGas != null) {
+            cylinders.filter { it.cylinder.gas == diluentGas && !it.isCcrOxygen }
+                .minByOrNull { it.cylinder.waterVolume }
+        } else {
+            null
+        }
+
+        return if (mostLikelyDiluentCylinder != null) {
+            cylinders.map {
+                if (it == mostLikelyDiluentCylinder) {
+                    it.copy(role = CylinderRole.CCR_DILUENT_AND_BAILOUT, isChecked = true)
+                } else {
+                    it
+                }
+            }
+        } else {
+            cylinders + PlannedCylinderModel(
+                cylinder = Cylinder(Gas.Air, pressure = 200.0, waterVolume = 12.0),
+                isChecked = true,
+                isLocked = true,
+                role = CylinderRole.CCR_DILUENT_AND_BAILOUT,
+            )
         }
     }
 
@@ -134,26 +238,37 @@ object DiveEditorViewModelDelegate {
     fun recomputeCylinderState(segments: List<DiveProfileSection>, cylinders: List<PlannedCylinderModel>, diveMode: DiveMode = DiveMode.OPEN_CIRCUIT): List<PlannedCylinderModel> {
         val gasesInUse = segments.mapTo(mutableSetOf()) { it.cylinder.gas }
 
-        // In closed-circuit mode, pure oxygen must be treated as in-use
-        if (diveMode == DiveMode.CLOSED_CIRCUIT && Gas.Oxygen !in gasesInUse && cylinders.hasGas(Gas.Oxygen)) {
-            gasesInUse += Gas.Oxygen
-        }
-
         val autoChecked = mutableSetOf<Gas>()
         val updated = cylinders.map { planned ->
-            val gas = planned.cylinder.gas
-            val shouldAutoCheck = gas in gasesInUse && cylinders.countCheckedGas(gas) == 0
-            if (shouldAutoCheck && gas !in autoChecked) {
-                autoChecked += gas
+            if (diveMode.isCcr && (planned.isCcrOxygen || planned.isCcrDiluent)) {
                 planned.copy(isChecked = true)
-            } else {
+            } else if (diveMode.isCcr) {
+                // In CCR mode, bailout cylinders are fully managed by the user, no auto-checking.
                 planned
+            } else {
+                // In OC mode, we check cylinders that are in use by a segment
+                val gas = planned.cylinder.gas
+                val shouldAutoCheck = gas in gasesInUse && cylinders.countCheckedGas(gas) == 0
+                if (shouldAutoCheck && gas !in autoChecked) {
+                    autoChecked += gas
+                    planned.copy(isChecked = true)
+                } else {
+                    planned
+                }
             }
         }
+
         return updated.map { planned ->
-            val isUniqueInUse = { updated.countCheckedGas(planned.cylinder.gas) == 1 }
-            val isInUse = { planned.cylinder.gas in gasesInUse }
-            planned.copy(isLocked = planned.isChecked && isInUse() && isUniqueInUse())
+            if (diveMode.isCcr && (planned.isCcrOxygen || planned.isCcrDiluent)) {
+                planned.copy(isLocked = true)
+            } else if (diveMode.isCcr) {
+                // In CCR mode, bailout cylinders are never locked, always removable.
+                planned.copy(isLocked = false)
+            } else {
+                val isUniqueInUse = { updated.countCheckedGas(planned.cylinder.gas) == 1 }
+                val isInUse = { planned.cylinder.gas in gasesInUse }
+                planned.copy(isLocked = planned.isChecked && isInUse() && isUniqueInUse())
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
@@ -42,6 +42,7 @@ import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.diveplanning.model.MultiDivePlanInputModel
 import org.neotech.app.abysner.domain.diveplanning.model.MultiDivePlanSet
 import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
+import org.neotech.app.abysner.domain.diveplanning.model.toAssignedCylinder
 import org.neotech.app.abysner.domain.gasplanning.GasPlanner
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
@@ -105,6 +106,7 @@ class PlanScreenViewModel(
     fun toggleCylinder(cylinder: Cylinder, enabled: Boolean) = mutateDive { DiveEditorViewModelDelegate.toggleCylinder(it, cylinder, enabled) }
     fun setContingency(deeper: Boolean, longer: Boolean, bailout: Boolean) = mutateDive { DiveEditorViewModelDelegate.setContingency(it, deeper, longer, bailout) }
     fun setDiveMode(mode: DiveMode) = mutateDive { DiveEditorViewModelDelegate.setDiveMode(it, mode) }
+    fun toggleAvailableForBailout(cylinder: Cylinder, availableForBailout: Boolean) = mutateDive { DiveEditorViewModelDelegate.toggleAvailableForBailout(it, cylinder, availableForBailout) }
 
     fun selectDive(index: Int) {
         planInput.update { it.copy(selectedDiveIndex = index) }
@@ -228,7 +230,7 @@ class PlanScreenViewModel(
                 }
             }
 
-            val cylinders = diveInput.cylinders.filter { it.isChecked }.map { it.cylinder }
+            val cylinders = diveInput.cylinders.filter { it.isChecked }.map { it.toAssignedCylinder() }
             val divePlan = planner.addDive(
                 plan = segments,
                 cylinders = cylinders,

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
@@ -66,6 +66,7 @@ import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanSet
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
+import org.neotech.app.abysner.domain.diveplanning.model.assign
 import org.neotech.app.abysner.domain.settings.model.SettingsModel
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
 import org.neotech.app.abysner.domain.utilities.format
@@ -443,7 +444,7 @@ fun DecoPlanCardComponentPreview() {
             plan = listOf(
                 DiveProfileSection(16, 45, Cylinder(gas = Gas.Air, pressure = 232.0, waterVolume = 12.0)),
             ),
-            cylinders = listOf(Cylinder.aluminium80Cuft(Gas.Nitrox50)),
+            cylinders = listOf(Cylinder.aluminium80Cuft(Gas.Nitrox50)).assign(),
         )
 
         DecoPlanCardComponent(

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasBarChart.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasBarChart.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.github.koalaplot.core.Symbol
-import io.github.koalaplot.core.legend.FlowLegend
 import io.github.koalaplot.core.legend.FlowLegend2
 import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
 import kotlinx.collections.immutable.persistentListOf
@@ -49,6 +48,7 @@ import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
+import org.neotech.app.abysner.domain.diveplanning.model.assign
 import org.neotech.app.abysner.domain.gasplanning.GasPlanner
 import org.neotech.app.abysner.domain.gasplanning.model.GasPlan
 import org.neotech.app.abysner.domain.gasplanning.model.CylinderGasRequirements
@@ -83,7 +83,7 @@ fun GasBarChartPreview() = PreviewWrapper {
 
     val divePlan = DivePlanner().addDive(
         plan,
-        listOf(Cylinder.aluminium80Cuft(Gas.Nitrox50), Cylinder.aluminium63Cuft(Gas.Nitrox80))
+        listOf(Cylinder.aluminium80Cuft(Gas.Nitrox50), Cylinder.aluminium63Cuft(Gas.Nitrox80)).assign()
     )
 
     val gasPlan = GasPlanner().calculateGasPlan(divePlan)

--- a/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/DiveEditorViewModelDelegateTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/DiveEditorViewModelDelegateTest.kt
@@ -15,15 +15,17 @@ package org.neotech.app.abysner.presentation.screens.planner
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.diveplanning.model.CylinderRole
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanInputModel
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
 import org.neotech.app.abysner.domain.diveplanning.model.countGas
-import org.neotech.app.abysner.domain.diveplanning.model.hasGas
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DiveEditorViewModelDelegateTest {
@@ -68,6 +70,32 @@ class DiveEditorViewModelDelegateTest {
 
         assertEquals(1, result.cylinders.size)
         assertEquals(airCylinder, result.cylinders[0].cylinder)
+    }
+
+    @Test
+    fun removeCylinder_segmentsReferencingRemovedCylinderAreReassigned() {
+        // TODO this test can be removed if segments allow auto cylinder selection (nullable cylinders)
+        //      I need to consider this as something to implement.
+        val dive = createDive(
+            cylinders = listOf(
+                PlannedCylinderModel(
+                    cylinder = airCylinder,
+                    isChecked = true,
+                    isLocked = false,
+                    role = CylinderRole.CCR_DILUENT_AND_BAILOUT
+                ),
+                PlannedCylinderModel(cylinder = nitrox50, isChecked = true, isLocked = false),
+            ),
+            segments = listOf(
+                airSegment,
+                DiveProfileSection(duration = 10, depth = 6, cylinder = nitrox50),
+            ),
+        ).copy(diveMode = DiveMode.CLOSED_CIRCUIT)
+
+        val result = DiveEditorViewModelDelegate.removeCylinder(dive, nitrox50)
+
+        assertEquals(2, result.plannedProfile.size)
+        assertEquals(airCylinder, result.plannedProfile[1].cylinder)
     }
 
     @Test
@@ -134,7 +162,8 @@ class DiveEditorViewModelDelegateTest {
                         waterVolume = 3.0
                     ),
                     isChecked = false,
-                    isLocked = false
+                    isLocked = false,
+                    role = CylinderRole.CCR_OXYGEN,
                 ),
                 PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = false),
             ),
@@ -142,46 +171,50 @@ class DiveEditorViewModelDelegateTest {
 
         val result = DiveEditorViewModelDelegate.recomputeCylinderState(dive)
 
-        val oxygenCylinder = result.cylinders.first { it.cylinder.gas == Gas.Oxygen }
+        val oxygenCylinder = result.cylinders.first { it.isCcrOxygen }
         assertTrue(oxygenCylinder.isChecked)
         assertTrue(oxygenCylinder.isLocked)
     }
 
     @Test
-    fun setDiveMode_ccrSwitchAddsOxygenCylinderIfMissing() {
-        val dive = createDive()
-
-        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
-
-        assertTrue(result.cylinders.hasGas(Gas.Oxygen))
-    }
-
-    @Test
-    fun setDiveMode_ccrSwitchDoesNotDuplicateExistingOxygenCylinder() {
-        val oxygenCylinder = Cylinder(Gas.Oxygen, pressure = 200.0, waterVolume = 3.0)
+    fun setDiveMode_ccrSwitchAddsNewCcrOxygenCylinderIfRoleMissing() {
         val dive = createDive(
             cylinders = listOf(
                 PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = true),
                 PlannedCylinderModel(
-                    cylinder = oxygenCylinder,
+                    cylinder = Cylinder.aluminium63Cuft(Gas.Oxygen),
                     isChecked = false,
-                    isLocked = false
+                    isLocked = false,
                 ),
             )
         )
 
         val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
 
-        assertEquals(1, result.cylinders.countGas(Gas.Oxygen))
+        assertEquals(2, result.cylinders.countGas(Gas.Oxygen))
+        val oxygen = result.cylinders.first { it.isCcrOxygen }
+        assertEquals(CylinderRole.CCR_OXYGEN, oxygen.role)
+        assertTrue(oxygen.isChecked)
+        assertTrue(oxygen.isLocked)
     }
 
     @Test
     fun setDiveMode_ccrOxygenCylinderIsCheckedAndLocked() {
-        val dive = createDive()
+        val dive = createDive(
+            cylinders = listOf(
+                PlannedCylinderModel(cylinder = airCylinder, isChecked = true, isLocked = true),
+                PlannedCylinderModel(
+                    cylinder = Cylinder(gas = Gas.Oxygen, 200.0, 3.0),
+                    isChecked = false,
+                    isLocked = false,
+                    role = CylinderRole.CCR_OXYGEN,
+                ),
+            ),
+        )
 
         val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
 
-        val oxygen = result.cylinders.first { it.cylinder.gas == Gas.Oxygen }
+        val oxygen = result.cylinders.first { it.isCcrOxygen }
         assertTrue(oxygen.isChecked)
         assertTrue(oxygen.isLocked)
     }
@@ -196,14 +229,110 @@ class DiveEditorViewModelDelegateTest {
     }
 
     @Test
-    fun setDiveMode_ocSwitchPreservesOxygenCylinder() {
+    fun setDiveMode_ccrSwitchAssignsDiluentRole() {
+        val dive = createDive()
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
+
+        val diluent = result.cylinders.firstOrNull { it.isCcrDiluent }
+        assertNotNull(diluent)
+        assertTrue(diluent.isChecked)
+        assertTrue(diluent.isLocked)
+    }
+
+    @Test
+    fun setDiveMode_ccrSwitchCreatesDefaultAirDiluentWhenNoSegments() {
+        val dive = createDive(
+            segments = emptyList(),
+            cylinders = listOf(
+                PlannedCylinderModel(cylinder = nitrox50, isChecked = true, isLocked = false),
+                PlannedCylinderModel(
+                    cylinder = Cylinder.steel3LiterOxygen(),
+                    isChecked = false,
+                    isLocked = false,
+                    role = CylinderRole.CCR_OXYGEN,
+                ),
+            ),
+        )
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
+
+        assertEquals(3, result.cylinders.size)
+        val diluent = result.cylinders.first { it.isCcrDiluent }
+        assertEquals(Gas.Air, diluent.cylinder.gas)
+        assertEquals(CylinderRole.CCR_DILUENT_AND_BAILOUT, diluent.role)
+        assertTrue(diluent.isChecked)
+        assertTrue(diluent.isLocked)
+    }
+
+    @Test
+    fun setDiveMode_ccrSwitchReusesExistingDiluentRole() {
+        val dive = createDive(
+            cylinders = listOf(
+                PlannedCylinderModel(
+                    cylinder = airCylinder,
+                    isChecked = true,
+                    isLocked = true,
+                    role = CylinderRole.CCR_DILUENT
+                ),
+                PlannedCylinderModel(
+                    cylinder = Cylinder.steel3LiterOxygen(),
+                    isChecked = false,
+                    isLocked = false,
+                    role = CylinderRole.CCR_OXYGEN,
+                ),
+            ),
+        )
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
+
+        val diluent = result.cylinders.first { it.cylinder == airCylinder }
+        assertEquals(CylinderRole.CCR_DILUENT, diluent.role)
+    }
+
+    @Test
+    fun setDiveMode_ocSwitchPreservesOxygenCylinderAndKeepsRole() {
         val dive = createDive().let {
             DiveEditorViewModelDelegate.setDiveMode(it, DiveMode.CLOSED_CIRCUIT)
         }
 
         val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.OPEN_CIRCUIT)
 
-        assertTrue(result.cylinders.hasGas(Gas.Oxygen))
+        val oxygen = result.cylinders.first { it.cylinder.gas == Gas.Oxygen }
+        assertEquals(CylinderRole.CCR_OXYGEN, oxygen.role)
+        assertFalse(oxygen.isChecked)
+        assertFalse(oxygen.isLocked)
+    }
+
+    @Test
+    fun setDiveMode_ocSwitchPreservesDiluentCylinderAndKeepsRole() {
+        val dive = createDive().let {
+            DiveEditorViewModelDelegate.setDiveMode(it, DiveMode.CLOSED_CIRCUIT)
+        }
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.OPEN_CIRCUIT)
+
+        val diluent = result.cylinders.first { it.cylinder == airCylinder }
+        assertEquals(CylinderRole.CCR_DILUENT_AND_BAILOUT, diluent.role)
+        // These are true since the diluent was used in the segment
+        assertTrue(diluent.isChecked)
+        assertTrue(diluent.isLocked)
+    }
+
+    @Test
+    fun setDiveMode_roundTripPreservesDiluentRole() {
+        val dive = createDive().let {
+            DiveEditorViewModelDelegate.setDiveMode(it, DiveMode.CLOSED_CIRCUIT)
+        }.let {
+            DiveEditorViewModelDelegate.setDiveMode(it, DiveMode.OPEN_CIRCUIT)
+        }
+
+        val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.CLOSED_CIRCUIT)
+
+        val diluent = result.cylinders.first { it.cylinder == airCylinder }
+        assertEquals(CylinderRole.CCR_DILUENT_AND_BAILOUT, diluent.role)
+        assertTrue(diluent.isChecked)
+        assertTrue(diluent.isLocked)
     }
 
     @Test
@@ -222,12 +351,7 @@ class DiveEditorViewModelDelegateTest {
         val dive = createDive().let {
             DiveEditorViewModelDelegate.setDiveMode(it, DiveMode.CLOSED_CIRCUIT)
         }.let {
-            DiveEditorViewModelDelegate.setContingency(
-                dive = it,
-                deeper = false,
-                longer = false,
-                bailout = true
-            )
+            DiveEditorViewModelDelegate.setContingency(dive = it, deeper = false, longer = false, bailout = true)
         }
 
         val result = DiveEditorViewModelDelegate.setDiveMode(dive, DiveMode.OPEN_CIRCUIT)
@@ -246,12 +370,7 @@ class DiveEditorViewModelDelegateTest {
 
     @Test
     fun setContingency_setsAllFlags() {
-        val result = DiveEditorViewModelDelegate.setContingency(
-            dive = createDive(),
-            deeper = true,
-            longer = true,
-            bailout = true
-        )
+        val result = DiveEditorViewModelDelegate.setContingency(dive = createDive(), deeper = true, longer = true, bailout = true)
 
         assertTrue(result.deeper)
         assertTrue(result.longer)
@@ -262,16 +381,54 @@ class DiveEditorViewModelDelegateTest {
     fun setContingency_clearsAllFlags() {
         val dive = createDive().copy(deeper = true, longer = true, bailout = true)
 
-        val result = DiveEditorViewModelDelegate.setContingency(
-            dive,
-            deeper = false,
-            longer = false,
-            bailout = false
-        )
+        val result = DiveEditorViewModelDelegate.setContingency(dive = dive, deeper = false, longer = false, bailout = false)
 
         assertFalse(result.deeper)
         assertFalse(result.longer)
         assertFalse(result.bailout)
+    }
+
+    @Test
+    fun toggleAvailableForBailout_removeBailoutPreservesDiluentRole() {
+        val dive = createDive(
+            cylinders = listOf(
+                PlannedCylinderModel(
+                    cylinder = airCylinder,
+                    isChecked = true,
+                    isLocked = true,
+                    role = CylinderRole.CCR_DILUENT_AND_BAILOUT
+                ),
+                PlannedCylinderModel(cylinder = nitrox50, isChecked = true, isLocked = false),
+            ),
+        ).copy(diveMode = DiveMode.CLOSED_CIRCUIT)
+
+        val result = DiveEditorViewModelDelegate.toggleAvailableForBailout(dive, airCylinder, false)
+
+        assertEquals(CylinderRole.CCR_DILUENT, result.cylinders.first { it.cylinder == airCylinder }.role)
+        assertNull(result.cylinders.first { it.cylinder == nitrox50 }.role)
+    }
+
+    @Test
+    fun toggleAvailableForBailout_addBailoutPreservesDiluentRole() {
+        val dive = createDive(
+            cylinders = listOf(
+                PlannedCylinderModel(
+                    cylinder = airCylinder,
+                    isChecked = true,
+                    isLocked = true,
+                    role = CylinderRole.CCR_DILUENT
+                ),
+                PlannedCylinderModel(cylinder = nitrox50, isChecked = true, isLocked = false),
+            ),
+        ).copy(diveMode = DiveMode.CLOSED_CIRCUIT)
+
+        val result = DiveEditorViewModelDelegate.toggleAvailableForBailout(dive, airCylinder, true)
+
+        assertEquals(
+            CylinderRole.CCR_DILUENT_AND_BAILOUT,
+            result.cylinders.first { it.cylinder == airCylinder }.role
+        )
+        assertTrue(result.cylinders.first { it.cylinder == airCylinder }.isAvailableForBailout)
     }
 
     private fun createDive(

--- a/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraphCoordinatesTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraphCoordinatesTest.kt
@@ -20,6 +20,7 @@ import org.neotech.app.abysner.domain.core.model.Salinity
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
+import org.neotech.app.abysner.domain.diveplanning.model.assign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -46,7 +47,7 @@ class DecoPlanGraphCoordinatesTest {
         )
         return divePlanner.addDive(
             plan = listOf(DiveProfileSection(duration = 30, 30, bottomGas)),
-            cylinders = listOf(decoGas),
+            cylinders = listOf(decoGas).assign(),
         )
     }
 

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
@@ -20,6 +20,7 @@ import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.core.model.Salinity
+import org.neotech.app.abysner.domain.diveplanning.model.CylinderRole
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanInputModel
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.diveplanning.model.MultiDivePlanInputModel
@@ -99,7 +100,8 @@ private fun DiveProfileSection.toResource() = DivePlanInputResourceV1.ProfileSeg
 
 private fun PlannedCylinderModel.toResource() = DivePlanInputResourceV1.CheckableCylinderResource(
     cylinder = cylinder.toResource(),
-    checked = isChecked
+    checked = isChecked,
+    role = role?.preferenceValue,
 )
 
 private fun Cylinder.toResource() = DivePlanInputResourceV1.CylinderResource(
@@ -140,9 +142,9 @@ fun MultiDivePlanInputResourceV1.toModel() = MultiDivePlanInputModel(
 private fun DivePlanInputResourceV1.CheckableCylinderResource.toModel() = PlannedCylinderModel(
     cylinder = cylinder.toModel(),
     isChecked = checked,
-
     // Will be recalculated by the ViewModel
     isLocked = false,
+    role = role?.let { fromString<CylinderRole>(it) },
 )
 
 private fun DivePlanInputResourceV1.ProfileSegmentResource.toModel(cylinder: Cylinder) = DiveProfileSection(

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/resources/DivePlanInputResourceV1.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/resources/DivePlanInputResourceV1.kt
@@ -41,6 +41,7 @@ data class DivePlanInputResourceV1(
     data class CheckableCylinderResource(
         val cylinder: CylinderResource,
         val checked: Boolean,
+        val role: String? = null,
     )
 
     @Serializable

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Cylinder.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Cylinder.kt
@@ -150,6 +150,7 @@ data class Cylinder(
          */
         const val HP80_WATER_VOLUME = 10.2
 
+        fun steel3LiterOxygen(pressure: Double = 200.0) = Cylinder(Gas.Oxygen, pressure, 3.0)
         fun steel10Liter(gas: Gas, pressure: Double = 232.0) = Cylinder(gas, pressure, 10.0)
         fun steel12Liter(gas: Gas, pressure: Double = 232.0) = Cylinder(gas, pressure, 12.0)
         fun aluminium80Cuft(gas: Gas, pressure: Double = 207.0) = Cylinder(gas, pressure, AL80_WATER_VOLUME)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/DiveMode.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/DiveMode.kt
@@ -20,5 +20,8 @@ enum class DiveMode(val humanReadableName: String) : EnumPreference {
     },
     CLOSED_CIRCUIT("CCR") {
         override val preferenceValue: String = "closed-circuit"
-    },
+    };
+
+    val isCcr: Boolean
+        get() = this == CLOSED_CIRCUIT
 }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
@@ -22,8 +22,10 @@ import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.decompression.DecompressionPlanner
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
 import org.neotech.app.abysner.domain.decompression.algorithm.buhlmann.Buhlmann
+import org.neotech.app.abysner.domain.diveplanning.model.AssignedCylinder
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
+import org.neotech.app.abysner.domain.diveplanning.model.isCcrDiluent
 import org.neotech.app.abysner.domain.gasplanning.OxygenToxicityCalculator
 import kotlin.time.Duration
 
@@ -40,18 +42,24 @@ class DivePlanner(
 
     fun addDive(
         plan: List<DiveProfileSection>,
-        cylinders: List<Cylinder>,
+        cylinders: List<AssignedCylinder>,
         diveMode: DiveMode = DiveMode.OPEN_CIRCUIT,
         bailout: Boolean = false,
     ): DivePlan {
 
-        require(!bailout || diveMode == DiveMode.CLOSED_CIRCUIT) {
+        require(!bailout || diveMode.isCcr) {
             "Bailout is only applicable to closed-circuit dives"
         }
 
         val breathingMode = diveMode.breathingMode(configuration.ccrHighSetpoint)
         val descentBreathingMode = diveMode.breathingMode(configuration.ccrLowSetpoint)
         val isCcr = breathingMode is BreathingMode.ClosedCircuit
+
+        val decoCylinders = if(!diveMode.isCcr) {
+            cylinders.map { it.cylinder }
+        } else {
+            cylinders.filter { it.isAvailableForBailout }.map { it.cylinder }
+        }
 
         // TTS is collected during planning and merged into the segments at the end via copy().
         val ttsBySegmentIndex = mutableMapOf<Int, TtsValues>()
@@ -82,10 +90,19 @@ class DivePlanner(
             decompressionPlanner.setDecompressionModelSnapshot(it)
         }
 
-        decompressionPlanner.setDecoGasses(cylinders)
+        decompressionPlanner.setDecoGasses(decoCylinders)
+
+        // In CCR mode, all sections breathe the diluent on the loop regardless of what cylinder
+        // each section was created with.
+        val diluentCylinder = cylinders.firstOrNull { it.isCcrDiluent }?.cylinder
+        val effectivePlan = if (isCcr && diluentCylinder != null) {
+            plan.map { it.copy(cylinder = diluentCylinder) }
+        } else {
+            plan
+        }
 
         var currentDepth = 0.0
-        plan.forEach {
+        effectivePlan.forEach {
             if (it.depth.toDouble() != currentDepth) {
 
                 val difference = currentDepth - it.depth

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/AssignedCylinder.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/AssignedCylinder.kt
@@ -1,0 +1,40 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.diveplanning.model
+
+import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.Gas
+
+data class AssignedCylinder(
+    val cylinder: Cylinder,
+    val role: CylinderRole? = null,
+) {
+    val gas: Gas
+        get() = cylinder.gas
+
+    val isCcrOxygen: Boolean get() = role.isCcrOxygen
+    val isCcrDiluent: Boolean get() = role.isCcrDiluent
+    val isAvailableForBailout: Boolean get() = role.isAvailableForBailout
+}
+
+fun List<AssignedCylinder>.ccrOxygenCylinder(): Cylinder? =
+    firstOrNull { it.isCcrOxygen }?.cylinder
+
+fun Cylinder.assign(
+    role: CylinderRole? = null,
+) = AssignedCylinder(
+    cylinder = this,
+    role = role,
+)
+
+fun List<Cylinder>.assign() = map { it.assign() }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/CylinderRole.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/CylinderRole.kt
@@ -1,0 +1,59 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.diveplanning.model
+
+import org.neotech.app.abysner.domain.persistence.EnumPreference
+
+/**
+ * Defines the role a cylinder plays in a dive. Currently, the roles are limited to what the app
+ * actually needs to know, and exclusively related to closed-circuit planning. Perhaps we should
+ * keep it this way, not too much bloat?
+ */
+enum class CylinderRole : EnumPreference {
+
+    CCR_OXYGEN {
+        override val preferenceValue: String = "ccr-oxygen"
+    },
+
+    CCR_DILUENT {
+        override val preferenceValue: String = "ccr-diluent"
+    },
+
+    /**
+     * In many rebreather setups the diluent cylinder is often also a bailout, this seems to be
+     * common for chest mounted setups for example.
+     */
+    CCR_DILUENT_AND_BAILOUT {
+        override val preferenceValue: String = "ccr-diluent-and-bailout"
+    },
+}
+
+val CylinderRole?.isCcrOxygen: Boolean get() = this == CylinderRole.CCR_OXYGEN
+val CylinderRole?.isCcrDiluent: Boolean get() = this == CylinderRole.CCR_DILUENT || this == CylinderRole.CCR_DILUENT_AND_BAILOUT
+
+/**
+ * True if the cylinder is available for bailout. A cylinder without role is assumed to be
+ * available as well.
+ */
+val CylinderRole?.isAvailableForBailout: Boolean get() = this == null || this == CylinderRole.CCR_DILUENT_AND_BAILOUT
+
+fun CylinderRole?.toggleAvailableForBailout(availableForBailout: Boolean): CylinderRole? =
+    if (this.isCcrDiluent) {
+        if (availableForBailout) {
+            CylinderRole.CCR_DILUENT_AND_BAILOUT
+        } else {
+            CylinderRole.CCR_DILUENT
+        }
+    } else {
+        this
+    }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
@@ -27,11 +27,13 @@ import kotlin.math.ceil
 data class DivePlan(
     val segments: ImmutableList<DiveSegment>,
     val alternativeAccents: ImmutableMap<Int, ImmutableList<DiveSegment>>,
-    val cylinders: ImmutableList<Cylinder>,
+    val cylinders: ImmutableList<AssignedCylinder>,
     val configuration: Configuration,
     val totalCns: Double,
     val totalOtu: Double,
 ) {
+
+    val ccrOxygenCylinder: Cylinder? = cylinders.ccrOxygenCylinder()
 
     /**
      * Minute in which the first deco occurs

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanInputModel.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanInputModel.kt
@@ -34,12 +34,16 @@ data class PlannedCylinderModel(
     val cylinder: Cylinder,
     val isChecked: Boolean,
     /**
-     * True only when this is the last checked cylinder of a gas mix that is referenced in a
-     * planned segment. When true the checkbox and delete controls are disabled/hidden, preventing
-     * the planner from being left without any cylinder of that gas.
+     * If true this cylinder will be locked from disabling or deleting it. Usually a result of
+     * being actively referenced in a dive segment while also being the last of its kind (mix).
      */
     val isLocked: Boolean,
-)
+    val role: CylinderRole? = null,
+) {
+    val isCcrOxygen: Boolean get() = role.isCcrOxygen
+    val isCcrDiluent: Boolean get() = role.isCcrDiluent
+    val isAvailableForBailout: Boolean get() = role.isAvailableForBailout
+}
 
 fun List<PlannedCylinderModel>.hasGas(gas: Gas): Boolean = any { it.cylinder.gas == gas }
 
@@ -47,3 +51,18 @@ fun List<PlannedCylinderModel>.countGas(gas: Gas): Int = count { it.cylinder.gas
 
 fun List<PlannedCylinderModel>.countCheckedGas(gas: Gas): Int = count { it.cylinder.gas == gas && it.isChecked }
 
+fun List<PlannedCylinderModel>.ccrOxygenCylinder(): PlannedCylinderModel? =
+    firstOrNull { it.isCcrOxygen }
+
+fun List<PlannedCylinderModel>.ccrDiluentCylinder(): PlannedCylinderModel? =
+    firstOrNull { it.isCcrDiluent }
+
+fun List<PlannedCylinderModel>.bailoutCylinders(): List<PlannedCylinderModel> =
+    filter { it.isAvailableForBailout && it.isChecked }
+
+fun PlannedCylinderModel.toAssignedCylinder() = AssignedCylinder(
+    cylinder = cylinder,
+    role = role,
+)
+
+fun List<PlannedCylinderModel>.toAssignedCylinders() = map { it.toAssignedCylinder() }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanSet.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlanSet.kt
@@ -28,7 +28,7 @@ data class DivePlanSet(
 
     val isDeeper = deeper != null
     val isLonger = longer != null
-    val isCcr = diveMode == DiveMode.CLOSED_CIRCUIT
+    val isCcr = diveMode.isCcr
 
     val configuration: Configuration = base.configuration
     val isEmpty: Boolean = base.isEmpty

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
@@ -125,7 +125,7 @@ class GasPlanner {
             .filter { (gas, _) -> gas in baseLineOpenCircuitByGas || gas in emergencyOpenCircuitByGas }
             .flatMap { (gas, cylinders) ->
                 distributeProportionally(
-                    cylinders = cylinders,
+                    cylinders = cylinders.map { it.cylinder },
                     totalNormal = baseLineOpenCircuitByGas[gas] ?: 0.0,
                     totalEmergency = emergencyOpenCircuitByGas[gas] ?: 0.0,
                 )
@@ -136,7 +136,8 @@ class GasPlanner {
         }
 
         val closedCircuitResult = ccrSegments.calculateClosedCircuitGasRequirements(
-            cylinders = divePlan.cylinders,
+            cylinders = divePlan.cylinders.map { it.cylinder },
+            oxygenCylinder = divePlan.ccrOxygenCylinder,
             ccrMetabolicOxygenRate = configuration.ccrMetabolicO2LitersPerMinute,
             ccrLoopVolume = configuration.ccrLoopVolumeLiters,
             environment = environment,
@@ -155,7 +156,7 @@ class GasPlanner {
      */
     private fun List<DiveSegment>.calculateClosedCircuitGasRequirements(
         cylinders: List<Cylinder>,
-        oxygenCylinder: Cylinder? = cylinders.firstOrNull { it.gas == Gas.Oxygen },
+        oxygenCylinder: Cylinder? = cylinders.filter { it.gas == Gas.Oxygen }.minByOrNull { it.waterVolume },
         ccrMetabolicOxygenRate: Double,
         ccrLoopVolume: Double,
         environment: Environment,

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
@@ -22,6 +22,7 @@ import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.core.model.Salinity
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
+import org.neotech.app.abysner.domain.diveplanning.model.assign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -79,7 +80,7 @@ class DivePlannerTest {
             DiveProfileSection(duration = 30, 30, bottomGas)
         )
 
-        val divePlan = divePlanner.addDive(plannedSections, listOf(bottomGas, decoGas))
+        val divePlan = divePlanner.addDive(plannedSections, listOf(bottomGas, decoGas).assign())
         val plan = divePlan.segmentsCollapsed
 
         // println(divePlan.toString(compact = false))
@@ -118,7 +119,7 @@ class DivePlannerTest {
 
         val plannedSections = listOf(DiveProfileSection(duration = 15, 45, bottomGas))
 
-        val divePlan = divePlanner.addDive(plannedSections, listOf(decoGas))
+        val divePlan = divePlanner.addDive(plannedSections, listOf(decoGas).assign())
         val plan = divePlan.segmentsCollapsed
 
         // println(divePlan.toString(compact = false))
@@ -157,7 +158,7 @@ class DivePlannerTest {
 
         val plannedSections = listOf(DiveProfileSection(duration = 20, 60, bottomGas))
 
-        val divePlan = divePlanner.addDive(plannedSections, listOf(decoGas))
+        val divePlan = divePlanner.addDive(plannedSections, listOf(decoGas).assign())
         val plan = divePlan.segmentsCollapsed
 
         // println(divePlan.toString(compact = false))
@@ -251,7 +252,7 @@ class DivePlannerTest {
         // list. A switch to that first cylinder should not occur, since the gas mixes are the same.
         val divePlan = planner.addDive(
             plan = listOf(DiveProfileSection(duration = 20, depth = 20, cylinder = cylinder2)),
-            cylinders = listOf(cylinder1, cylinder2),
+            cylinders = listOf(cylinder1, cylinder2).assign(),
         )
 
         val gasSwitchSegments = divePlan.segmentsCollapsed.filter { it.type == DiveSegment.Type.GAS_SWITCH }
@@ -276,7 +277,7 @@ class DivePlannerTest {
 
         val plan = planner.addDive(
             listOf(DiveProfileSection(duration = 30, depth = 30, cylinder = diluent)),
-            listOf(diluent),
+            listOf(diluent).assign(),
             diveMode = DiveMode.CLOSED_CIRCUIT
         )
         val segments = plan.segmentsCollapsed
@@ -320,7 +321,7 @@ class DivePlannerTest {
 
         val plan = planner.addDive(
             listOf(DiveProfileSection(duration = 30, depth = 30, cylinder = diluent)),
-            listOf(diluent),
+            listOf(diluent).assign(),
             diveMode = DiveMode.CLOSED_CIRCUIT,
             bailout = true
         )
@@ -367,7 +368,7 @@ class DivePlannerTest {
 
         val plan = planner.addDive(
             listOf(DiveProfileSection(duration = 20, depth = 60, cylinder = diluent)),
-            listOf(diluent),
+            listOf(diluent).assign(),
             diveMode = DiveMode.CLOSED_CIRCUIT
         )
         val segments = plan.segmentsCollapsed

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/GasSwitchTimeTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/GasSwitchTimeTest.kt
@@ -20,6 +20,7 @@ import org.neotech.app.abysner.domain.core.model.Salinity
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
+import org.neotech.app.abysner.domain.diveplanning.model.assign
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -50,7 +51,7 @@ class GasSwitchTimeTest {
         )
         return divePlanner.addDive(
             listOf(DiveProfileSection(duration = 30, 30, bottomGas)),
-            listOf(decoGas)
+            listOf(decoGas).assign()
         )
     }
 

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
@@ -19,6 +19,8 @@ import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.core.model.Salinity
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
+import org.neotech.app.abysner.domain.diveplanning.model.assign
+import org.neotech.app.abysner.domain.diveplanning.model.CylinderRole
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -80,7 +82,7 @@ class GasPlannerTest {
                 DiveProfileSection(10, 20, bottomGas),
                 DiveProfileSection(30, 20, bottomGas)
             ),
-            cylinders = listOf(bottomGas, decoGas)
+            cylinders = listOf(bottomGas, decoGas).assign()
         )
 
         // at T=10 and D=50.0: TTS=11
@@ -127,7 +129,7 @@ class GasPlannerTest {
                 // +3 + 3 (contingency plan)
                 DiveProfileSection(18, 23, bottomGas),
             ),
-            cylinders = listOf(bottomGas)
+            cylinders = listOf(bottomGas).assign()
         )
 
         // at T=15 and D=10.0: TTS=2
@@ -170,7 +172,7 @@ class GasPlannerTest {
             plan = listOf(
                 DiveProfileSection(30, 50, bottomGas),
             ),
-            cylinders = listOf(bottomGas, decoGas)
+            cylinders = listOf(bottomGas, decoGas).assign()
         )
 
         val gasPlan = GasPlanner().calculateGasPlan(divePlan)
@@ -211,7 +213,7 @@ class GasPlannerTest {
         val gasPlan = GasPlanner().calculateGasPlan(
             DivePlanner(config).addDive(
                 plan = listOf(DiveProfileSection(30, 50, bottomGasOne)),
-                cylinders = listOf(bottomGasOne, bottomGasTwo, decoGas)
+                cylinders = listOf(bottomGasOne, bottomGasTwo, decoGas).assign()
             )
         )
 
@@ -254,7 +256,7 @@ class GasPlannerTest {
 
         val divePlan = DivePlanner(config).addDive(
             plan = listOf(DiveProfileSection(25, 20, backMount)),
-            cylinders = listOf(backMount, stage)
+            cylinders = listOf(backMount, stage).assign()
         )
         val gasPlan = GasPlanner().calculateGasPlan(divePlan)
 
@@ -328,7 +330,10 @@ class GasPlannerTest {
         bailout: Boolean = false,
     ) = DivePlanner(ccrConfiguration).addDive(
         plan = listOf(DiveProfileSection(duration = 30, depth = 30, cylinder = diluentCylinder)),
-        cylinders = listOf(diluentCylinder, oxygenCylinder) + extraCylinders,
+        cylinders = listOf(
+            diluentCylinder.assign(),
+            oxygenCylinder.assign(role = CylinderRole.CCR_OXYGEN),
+        ) + extraCylinders.assign(),
         diveMode = DiveMode.CLOSED_CIRCUIT,
         bailout = bailout,
     )


### PR DESCRIPTION
Introduces `CylinderRole` (`CCR_OXYGEN`, `CCR_DILUENT` and `CCR_DILUENT_AND_BAILOUT`) and `AssignedCylinder` which captures both a `Cylinder` and a `CylinderRole`. This allows for easier identification of CCR cylinders and would allow a user to choose whether a diluent cylinder can also be used as bailout cylinder.