### PR TITLE
Fix: Deep-copy tissue compartments when restoring a snapshot

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/preview/PreviewData.kt
@@ -45,9 +45,7 @@ object PreviewData {
     }
 
     val divePlan1: DivePlanSet by lazy {
-        val divePlan = DivePlanner().apply {
-            configuration = Configuration()
-        }.addDive(
+        val divePlan = DivePlanner().addDive(
             plan = divePlan1Segments,
             cylinders = divePlan1Cylinders.filter { it.isChecked }.toAssignedCylinders(),
         )

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
@@ -206,7 +206,7 @@ class PlanScreenViewModel(
         model: MultiDivePlanInputModel,
         configuration: Configuration,
     ): Result<MultiDivePlanSet?> = try {
-        val planner = DivePlanner().apply { this.configuration = configuration }
+        val planner = DivePlanner(configuration)
         val gasPlanner = GasPlanner()
 
         val sets = model.dives.mapIndexed { index, diveInput ->

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
@@ -438,9 +438,7 @@ private fun RowScope.DecoPlanRow(
 fun DecoPlanCardComponentPreview() {
     AbysnerTheme {
 
-        val divePlan = DivePlanner().apply {
-            configuration = Configuration()
-        }.addDive(
+        val divePlan = DivePlanner().addDive(
             plan = listOf(
                 DiveProfileSection(16, 45, Cylinder(gas = Gas.Air, pressure = 232.0, waterVolume = 12.0)),
             ),

--- a/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraphCoordinatesTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraphCoordinatesTest.kt
@@ -33,8 +33,7 @@ class DecoPlanGraphCoordinatesTest {
     private fun divePlan30m30minWithDecoGas(): DivePlan {
         val bottomGas = Cylinder.steel12Liter(Gas.Air)
         val decoGas = Cylinder.aluminium80Cuft(Gas.Nitrox50)
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
+        val divePlanner = DivePlanner(Configuration(
             maxAscentRate = 5.0,
             maxDescentRate = 5.0,
             gfLow = 0.3, gfHigh = 0.7,
@@ -44,7 +43,7 @@ class DecoPlanGraphCoordinatesTest {
             decoStepSize = 3,
             lastDecoStopDepth = 6,
             gasSwitchTime = 0,
-        )
+        ))
         return divePlanner.addDive(
             plan = listOf(DiveProfileSection(duration = 30, 30, bottomGas)),
             cylinders = listOf(decoGas).assign(),
@@ -56,15 +55,15 @@ class DecoPlanGraphCoordinatesTest {
      */
     private fun divePlan20m20minNoDeco(): DivePlan {
         val bottomGas = Cylinder.steel12Liter(Gas.Air)
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
+        val divePlanner = DivePlanner(Configuration(
             maxAscentRate = 5.0,
             maxDescentRate = 5.0,
-            gfLow = 0.3, gfHigh = 0.7,
+            gfLow = 0.3,
+            gfHigh = 0.7,
             salinity = Salinity.WATER_FRESH,
             algorithm = Algorithm.BUHLMANN_ZH16C,
             altitude = 0.0,
-        )
+        ))
         return divePlanner.addDive(
             plan = listOf(DiveProfileSection(duration = 20, 20, bottomGas)),
             cylinders = emptyList(),

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
@@ -480,21 +480,6 @@ class DecompressionPlanner(
     fun getSegments(): ImmutableList<DiveSegment> {
         return segments.toPersistentList()
     }
-
-    fun setDecompressionModelSnapshot(snapshot: DecompressionModel.Snapshot) {
-        // TODO it could be nicer if the snapshot can modify the model used, basically the
-        //   model is not a static variable for the DecompressionPlanner. There won't be any side
-        //   effects as far as I can see, as tissue are model specific and part of the model.
-        if(!snapshot.model.isInstance(model)) {
-            throw PlanningException("Unable to restore DecompressionModelSnapshot, decompression model (${snapshot.model}) does not equal the current decompression model (${model::class}).")
-        }
-
-        model.reset(snapshot)
-    }
-
-    fun getDecompressionModelSnapshot(): DecompressionModel.Snapshot {
-        return model.snapshot()
-    }
 }
 
 private const val calculateTissueChangesPerMinute: Boolean = true

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
@@ -143,7 +143,7 @@ class Buhlmann(
         }
         this.lowestCeiling = snapshot.lowestCeiling
         this.tissues.clear()
-        this.tissues.addAll(snapshot.tissues)
+        this.tissues.addAll(snapshot.tissues.map { it.copy() })
     }
 
     override fun reset() {
@@ -204,9 +204,13 @@ data class TissueCompartment(
      * Initial nitrogen load assumes fully saturated (equilibrium), regardless of atmospheric pressure.
      */
     private var pNitrogen: Double = partialPressure(environment.atmosphericPressure - waterVapourPressure, 0.79),
+
     private var pHelium: Double = 0.0,
     private var pTotal: Double = pNitrogen + pHelium
 ) {
+
+    val partialHeliumPressure: Double get() = pHelium
+    val partialNitrogenPressure: Double get() = pNitrogen
 
     fun addPressureChange(startPressure: Double, endPressure: Double, fO2: Double, fHe: Double, timeInMinutes: Int, ccrSetpoint: Double? = null): Double {
         // A zero or negative duration makes no physical sense (no exposure has occurred), and

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
@@ -17,7 +17,6 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentList
 import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Configuration
-import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.decompression.DecompressionPlanner
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
@@ -25,7 +24,6 @@ import org.neotech.app.abysner.domain.decompression.algorithm.buhlmann.Buhlmann
 import org.neotech.app.abysner.domain.diveplanning.model.AssignedCylinder
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
-import org.neotech.app.abysner.domain.diveplanning.model.isCcrDiluent
 import org.neotech.app.abysner.domain.gasplanning.OxygenToxicityCalculator
 import kotlin.time.Duration
 
@@ -35,10 +33,30 @@ import kotlin.time.Duration
  * adds multi-level dive handling.
  */
 class DivePlanner(
-    var configuration: Configuration = Configuration()
+    configuration: Configuration = Configuration()
 ) {
 
-    private var decompressionModelSnapshot: DecompressionModel.Snapshot? = null
+    var configuration: Configuration = configuration
+        private set
+
+    private var model: DecompressionModel = createDecompressionModel()
+
+    /**
+     * Updates the configuration. Tissue state accumulated across previous dives is preserved, so
+     * repetitive dive planning continues correctly after the change.
+     */
+    fun updateConfiguration(newConfiguration: Configuration) {
+        val snapshot = model.snapshot()
+        configuration = newConfiguration
+        model = createDecompressionModel()
+        model.reset(snapshot)
+    }
+
+    fun snapshotTissues(): DecompressionModel.Snapshot = model.snapshot()
+
+    fun restoreTissues(snapshot: DecompressionModel.Snapshot) {
+        model.reset(snapshot)
+    }
 
     fun addDive(
         plan: List<DiveProfileSection>,
@@ -84,11 +102,8 @@ class DivePlanner(
             lastDecoStopDepth = configuration.lastDecoStopDepth,
             forceMinimalDecoStopTime = configuration.forceMinimalDecoStopTime,
             gasSwitchTime = configuration.gasSwitchTime,
-            model = createDecompressionModel()
+            model = model
         )
-        decompressionModelSnapshot?.let {
-            decompressionPlanner.setDecompressionModelSnapshot(it)
-        }
 
         decompressionPlanner.setDecoGases(decoCylinders)
 
@@ -197,7 +212,6 @@ class DivePlanner(
             } ?: segment
         }.toPersistentList()
 
-        decompressionModelSnapshot = decompressionPlanner.getDecompressionModelSnapshot()
         return DivePlan(
             segments = segments,
             alternativeAccents = decompressionPlanner.getAlternativeAccents(),
@@ -209,13 +223,7 @@ class DivePlanner(
     }
 
     fun addSurfaceInterval(duration: Duration) {
-        val model = createDecompressionModel()
-
-        model.reset(decompressionModelSnapshot ?: throw PlanningException("Unable to add surface interval, plan a dive first."))
-
         model.addSurfaceInterval(duration.inWholeMinutes.toInt())
-
-        decompressionModelSnapshot = model.snapshot()
     }
 
     private fun createDecompressionModel(): DecompressionModel {

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannTest.kt
@@ -71,6 +71,30 @@ class BuhlmannTest {
     }
 
     @Test
+    fun reset_snapshotIsNotMutatedByLaterTissueLoading() {
+        val environment = Environment.SeaLevelSalt
+        val model = Buhlmann(
+            version = Buhlmann.Version.ZH16C,
+            environment = environment,
+            gfLow = 0.3,
+            gfHigh = 0.7,
+        )
+        val depth = depthInMetersToBar(30.0, environment)
+
+        model.addFlat(depth, Gas.Air, 20)
+        val snapshot = model.snapshot()
+
+        val pNitrogen = snapshot.tissues.first().partialNitrogenPressure
+        val pHelium = snapshot.tissues.first().partialHeliumPressure
+
+        model.reset(snapshot)
+        model.addFlat(depth, Gas.Air, 20)
+
+        assertEquals(pNitrogen, snapshot.tissues.first().partialNitrogenPressure)
+        assertEquals(pHelium, snapshot.tissues.first().partialHeliumPressure)
+    }
+
+    @Test
     fun addPressureChange_throwsForZeroDuration() {
         val environment = Environment.SeaLevelSalt
         val model = Buhlmann(

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
@@ -28,19 +28,65 @@ import kotlin.test.assertEquals
 
 class DivePlannerTest {
 
+    private val baseConfiguration = Configuration()
+
+    @Test
+    fun snapshotTissues_restoredSnapshotIsNotAffectedByLaterDives() {
+        val profile = listOf(
+            DiveProfileSection(
+                duration = 30,
+                depth = 30,
+                cylinder = Cylinder.steel12Liter(Gas.Air)
+            )
+        )
+        val planner = DivePlanner(baseConfiguration)
+        planner.addDive(profile, emptyList())
+
+        val snapshot = planner.snapshotTissues()
+
+        planner.restoreTissues(snapshot)
+        val runtimeAfterFirstRestore = planner.addDive(profile, emptyList()).runtime
+
+        planner.restoreTissues(snapshot)
+        val runtimeAfterSecondRestore = planner.addDive(profile, emptyList()).runtime
+
+        assertEquals(runtimeAfterFirstRestore, runtimeAfterSecondRestore)
+    }
+
+    @Test
+    fun updateConfiguration_preservesTissueStateAcrossConfigChange() {
+        val profile = listOf(
+            DiveProfileSection(
+                duration = 30,
+                depth = 30,
+                cylinder = Cylinder.steel12Liter(Gas.Air)
+            )
+        )
+
+        val planner = DivePlanner(baseConfiguration)
+        planner.addDive(profile, emptyList())
+
+        val snapshotBefore = planner.snapshotTissues()
+        planner.updateConfiguration(baseConfiguration.copy(salinity = Salinity.WATER_SALT))
+        val snapshotAfter = planner.snapshotTissues()
+
+        assertEquals(snapshotBefore, snapshotAfter)
+    }
+
     @Test
     fun referencePlan1_producesExpectedSegments() {
         val bottomGas = Cylinder.steel12Liter(Gas.Air)
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
-            maxAscentRate = 5.0,
-            maxDescentRate = 5.0,
-            gfLow = 0.3, gfHigh = 0.7,
-            salinity = Salinity.WATER_FRESH,
-            algorithm = Algorithm.BUHLMANN_ZH16C,
-            altitude = 0.0,
-            decoStepSize = 3,
-            lastDecoStopDepth = 3
+        val divePlanner = DivePlanner(
+            Configuration(
+                maxAscentRate = 5.0,
+                maxDescentRate = 5.0,
+                gfLow = 0.3, gfHigh = 0.7,
+                salinity = Salinity.WATER_FRESH,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                altitude = 0.0,
+                decoStepSize = 3,
+                lastDecoStopDepth = 3
+            )
         )
 
         val plannedSections = listOf(DiveProfileSection(duration = 20, 20, bottomGas))
@@ -62,18 +108,19 @@ class DivePlannerTest {
     fun referencePlan2_producesExpectedSegments() {
         val bottomGas = Cylinder.steel12Liter(Gas.Air)
         val decoGas = Cylinder.aluminium80Cuft(Gas.Nitrox50)
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
-            maxAscentRate = 5.0,
-            maxDescentRate = 5.0,
-            gfLow = 0.3,
-            gfHigh = 0.7,
-            salinity = Salinity.WATER_SALT,
-            algorithm = Algorithm.BUHLMANN_ZH16C,
-            altitude = 0.0,
-            decoStepSize = 3,
-            lastDecoStopDepth = 6,
-            gasSwitchTime = 1
+        val divePlanner = DivePlanner(
+            Configuration(
+                maxAscentRate = 5.0,
+                maxDescentRate = 5.0,
+                gfLow = 0.3,
+                gfHigh = 0.7,
+                salinity = Salinity.WATER_SALT,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                altitude = 0.0,
+                decoStepSize = 3,
+                lastDecoStopDepth = 6,
+                gasSwitchTime = 1
+            )
         )
 
         val plannedSections = listOf(
@@ -103,18 +150,19 @@ class DivePlannerTest {
     fun referencePlan3_producesExpectedSegments() {
         val bottomGas = Cylinder.steel12Liter(Gas.Trimix2135)
         val decoGas = Cylinder.aluminium80Cuft(Gas.Nitrox50)
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
-            maxAscentRate = 5.0,
-            maxDescentRate = 5.0,
-            gfLow = 0.3,
-            gfHigh = 0.7,
-            salinity = Salinity.WATER_SALT,
-            algorithm = Algorithm.BUHLMANN_ZH16C,
-            altitude = 0.0,
-            decoStepSize = 3,
-            lastDecoStopDepth = 3,
-            gasSwitchTime = 1
+        val divePlanner = DivePlanner(
+            Configuration(
+                maxAscentRate = 5.0,
+                maxDescentRate = 5.0,
+                gfLow = 0.3,
+                gfHigh = 0.7,
+                salinity = Salinity.WATER_SALT,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                altitude = 0.0,
+                decoStepSize = 3,
+                lastDecoStopDepth = 3,
+                gasSwitchTime = 1
+            )
         )
 
         val plannedSections = listOf(DiveProfileSection(duration = 15, 45, bottomGas))
@@ -142,18 +190,19 @@ class DivePlannerTest {
     fun referencePlan4_producesExpectedSegments() {
         val bottomGas = Cylinder.steel12Liter(Gas.Trimix1845)
         val decoGas = Cylinder.aluminium80Cuft(Gas.Nitrox50)
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
-            maxAscentRate = 5.0,
-            maxDescentRate = 5.0,
-            gfLow = 0.4,
-            gfHigh = 0.85,
-            salinity = Salinity.WATER_FRESH,
-            algorithm = Algorithm.BUHLMANN_ZH16C,
-            altitude = 1000.0,
-            decoStepSize = 3,
-            lastDecoStopDepth = 3,
-            gasSwitchTime = 1
+        val divePlanner = DivePlanner(
+            Configuration(
+                maxAscentRate = 5.0,
+                maxDescentRate = 5.0,
+                gfLow = 0.4,
+                gfHigh = 0.85,
+                salinity = Salinity.WATER_FRESH,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                altitude = 1000.0,
+                decoStepSize = 3,
+                lastDecoStopDepth = 3,
+                gasSwitchTime = 1
+            )
         )
 
         val plannedSections = listOf(DiveProfileSection(duration = 20, 60, bottomGas))
@@ -186,17 +235,18 @@ class DivePlannerTest {
     @Test
     fun referencePlan5_producesExpectedSegments() {
         val bottomGas = Cylinder.steel12Liter(Gas(0.21, 0.20))
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
-            maxAscentRate = 5.0,
-            maxDescentRate = 5.0,
-            gfLow = 0.50,
-            gfHigh = 0.80,
-            salinity = Salinity.WATER_FRESH,
-            algorithm = Algorithm.BUHLMANN_ZH16C,
-            altitude = 0.0,
-            decoStepSize = 3,
-            lastDecoStopDepth = 3
+        val divePlanner = DivePlanner(
+            Configuration(
+                maxAscentRate = 5.0,
+                maxDescentRate = 5.0,
+                gfLow = 0.50,
+                gfHigh = 0.80,
+                salinity = Salinity.WATER_FRESH,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                altitude = 0.0,
+                decoStepSize = 3,
+                lastDecoStopDepth = 3
+            )
         )
 
         val plannedSections = listOf(
@@ -262,18 +312,20 @@ class DivePlannerTest {
     @Test
     fun referencePlan6Ccr_producesExpectedSegments() {
         val diluent = Cylinder.aluminium80Cuft(Gas.Air)
-        val planner = DivePlanner(Configuration(
-            maxAscentRate = 5.0,
-            maxDescentRate = 5.0,
-            gfLow = 0.3,
-            gfHigh = 0.7,
-            salinity = Salinity.WATER_SALT,
-            algorithm = Algorithm.BUHLMANN_ZH16C,
-            decoStepSize = 3,
-            lastDecoStopDepth = 3,
-            ccrLowSetpoint = 0.7,
-            ccrHighSetpoint = 1.2,
-        ))
+        val planner = DivePlanner(
+            Configuration(
+                maxAscentRate = 5.0,
+                maxDescentRate = 5.0,
+                gfLow = 0.3,
+                gfHigh = 0.7,
+                salinity = Salinity.WATER_SALT,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                decoStepSize = 3,
+                lastDecoStopDepth = 3,
+                ccrLowSetpoint = 0.7,
+                ccrHighSetpoint = 1.2,
+            )
+        )
 
         val plan = planner.addDive(
             listOf(DiveProfileSection(duration = 30, depth = 30, cylinder = diluent)),
@@ -306,18 +358,20 @@ class DivePlannerTest {
     @Test
     fun referencePlan7CcrBailout_producesExpectedSegments() {
         val diluent = Cylinder.aluminium80Cuft(Gas.Air)
-        val planner = DivePlanner(Configuration(
-            maxAscentRate = 5.0,
-            maxDescentRate = 5.0,
-            gfLow = 0.3,
-            gfHigh = 0.7,
-            salinity = Salinity.WATER_SALT,
-            algorithm = Algorithm.BUHLMANN_ZH16C,
-            decoStepSize = 3,
-            lastDecoStopDepth = 3,
-            ccrLowSetpoint = 0.7,
-            ccrHighSetpoint = 1.2,
-        ))
+        val planner = DivePlanner(
+            Configuration(
+                maxAscentRate = 5.0,
+                maxDescentRate = 5.0,
+                gfLow = 0.3,
+                gfHigh = 0.7,
+                salinity = Salinity.WATER_SALT,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                decoStepSize = 3,
+                lastDecoStopDepth = 3,
+                ccrLowSetpoint = 0.7,
+                ccrHighSetpoint = 1.2,
+            )
+        )
 
         val plan = planner.addDive(
             listOf(DiveProfileSection(duration = 30, depth = 30, cylinder = diluent)),
@@ -353,18 +407,20 @@ class DivePlannerTest {
     @Test
     fun referencePlan8Ccr_producesExpectedSegments() {
         val diluent = Cylinder.steel12Liter(Gas(0.10, 0.70))
-        val planner = DivePlanner(Configuration(
-            maxAscentRate = 5.0,
-            maxDescentRate = 5.0,
-            gfLow = 0.3,
-            gfHigh = 0.7,
-            salinity = Salinity.WATER_SALT,
-            algorithm = Algorithm.BUHLMANN_ZH16C,
-            decoStepSize = 3,
-            lastDecoStopDepth = 3,
-            ccrLowSetpoint = 0.7,
-            ccrHighSetpoint = 1.2,
-        ))
+        val planner = DivePlanner(
+            Configuration(
+                maxAscentRate = 5.0,
+                maxDescentRate = 5.0,
+                gfLow = 0.3,
+                gfHigh = 0.7,
+                salinity = Salinity.WATER_SALT,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                decoStepSize = 3,
+                lastDecoStopDepth = 3,
+                ccrLowSetpoint = 0.7,
+                ccrHighSetpoint = 1.2,
+            )
+        )
 
         val plan = planner.addDive(
             listOf(DiveProfileSection(duration = 20, depth = 60, cylinder = diluent)),

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/GasSwitchTimeTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/GasSwitchTimeTest.kt
@@ -36,8 +36,7 @@ class GasSwitchTimeTest {
      * Based on [DivePlannerTest.referencePlan2] but parameterized by [gasSwitchTime].
      */
     private fun divePlan(gasSwitchTime: Int): DivePlan {
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
+        val divePlanner = DivePlanner(Configuration(
             maxAscentRate = 5.0,
             maxDescentRate = 5.0,
             gfLow = 0.3,
@@ -48,7 +47,7 @@ class GasSwitchTimeTest {
             decoStepSize = 3,
             lastDecoStopDepth = 6,
             gasSwitchTime = gasSwitchTime
-        )
+        ))
         return divePlanner.addDive(
             listOf(DiveProfileSection(duration = 30, 30, bottomGas)),
             listOf(decoGas).assign()

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/SurfaceIntervalTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/SurfaceIntervalTest.kt
@@ -16,8 +16,7 @@ class SurfaceIntervalTest {
     @Test
     fun addSurfaceInterval_increasesSubsequentDiveDecoTime() {
         val bottomGas = Cylinder.steel12Liter(Gas.Air)
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
+        val divePlanner = DivePlanner(Configuration(
             maxAscentRate = 5.0,
             maxDescentRate = 5.0,
             gfLow = 0.85, gfHigh = 0.85,
@@ -26,7 +25,7 @@ class SurfaceIntervalTest {
             altitude = 0.0,
             decoStepSize = 3,
             lastDecoStopDepth = 3
-        )
+        ))
 
         val plannedDive = listOf(DiveProfileSection(duration = 30, 30, bottomGas))
 

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
@@ -58,8 +58,7 @@ class GasPlannerTest {
         val bottomGas = Cylinder.steel12Liter(Gas.Trimix2135)
         val decoGas = Cylinder.aluminium80Cuft(Gas.Nitrox50)
 
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
+        val divePlanner = DivePlanner(Configuration(
             sacRate = 15.0,
             maxPPO2 = 1.4,
             maxPPO2Deco = 1.6,
@@ -74,7 +73,7 @@ class GasPlannerTest {
             salinity = Salinity.WATER_FRESH,
             algorithm = Configuration.Algorithm.BUHLMANN_ZH16C,
             gasSwitchTime = 0
-        )
+        ))
         val divePlan = divePlanner.addDive(
             plan = listOf(
                 DiveProfileSection(10, 50, bottomGas),
@@ -106,8 +105,7 @@ class GasPlannerTest {
 
         val bottomGas = Cylinder.steel12Liter(Gas.Air)
 
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
+        val divePlanner = DivePlanner(Configuration(
             sacRate = 15.0,
             maxPPO2 = 1.4,
             maxPPO2Deco = 1.6,
@@ -121,7 +119,7 @@ class GasPlannerTest {
             lastDecoStopDepth = 3,
             salinity = Salinity.WATER_FRESH,
             algorithm = Configuration.Algorithm.BUHLMANN_ZH16C
-        )
+        ))
         val divePlan = divePlanner.addDive(
             plan = listOf(
                 DiveProfileSection(15, 10, bottomGas),
@@ -151,8 +149,7 @@ class GasPlannerTest {
         val bottomGas = Cylinder.steel12Liter(Gas.Air)
         val decoGas = Cylinder(Gas.Nitrox50, 207, 7)
 
-        val divePlanner = DivePlanner()
-        divePlanner.configuration = Configuration(
+        val divePlanner = DivePlanner(Configuration(
             sacRate = 14.0,
             maxPPO2 = 1.4,
             maxPPO2Deco = 1.6,
@@ -167,7 +164,7 @@ class GasPlannerTest {
             salinity = Salinity.WATER_FRESH,
             algorithm = Configuration.Algorithm.BUHLMANN_ZH16C,
             gasSwitchTime = 0
-        )
+        ))
         val divePlan = divePlanner.addDive(
             plan = listOf(
                 DiveProfileSection(30, 50, bottomGas),


### PR DESCRIPTION
After restoring a snapshot its tissue instances would be shared with the live model, so any tissue loading after the reset would mutate the snapshot. This did not surface in production because snapshots were never reused after a reset, but would break as soon as one is restored twice with tissue loading in between.