### PR TITLE
Change: Treat CCR bailout gas as the emergency reserve gas in gas planning

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
@@ -89,6 +89,23 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
         return round(densityMod(maxAllowedDensity, environment)).toInt()
     }
 
+    /**
+     * Returns the CCR loop gas composition for the given setpoint and ambient pressure, when this
+     * gas is used as diluent. The O2 fraction is the setpoint divided by the ambient pressure, He
+     * and N2 scale proportionally in the remaining fraction. No water vapor correction is applied,
+     * since this models not the lungs but rather the loop composition.
+     */
+    fun inspiredGas(ambientPressure: Double, setpoint: Double): Gas {
+        val inspiredOxygenFraction = (setpoint / ambientPressure).coerceIn(oxygenFraction, 1.0)
+        val inertScale = if (oxygenFraction < 1.0) {
+            (1.0 - inspiredOxygenFraction) / (1.0 - oxygenFraction)
+        } else {
+            0.0
+        }
+        val inspiredHe = heliumFraction * inertScale
+        return Gas(oxygenFraction = inspiredOxygenFraction, heliumFraction = inspiredHe)
+    }
+
     fun diveIndustryName(): String {
 
         // Neox and Hydreliox, Hydrox are not supported, since this app does not support hydrogen, argon or neon as a gas.

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilities.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilities.kt
@@ -88,7 +88,7 @@ internal fun pressureChangeInBarsPerMinute(beginPressure: Double, endPressure: D
  * @param inspiredGasRate the rate at which the inspired inert gas partial pressure changes per
  * minute (due to depth change).
  */
-internal fun schreinerEquation(initialTissuePressure: Double, inspiredGasPressure: Double, time: Double, halfTime: Double, inspiredGasRate: Double): Double {
+fun schreinerEquation(initialTissuePressure: Double, inspiredGasPressure: Double, time: Double, halfTime: Double, inspiredGasRate: Double): Double {
     val timeConstant = ln(2.0) / halfTime
     return (inspiredGasPressure + (inspiredGasRate * (time - (1.0 / timeConstant))) - ((inspiredGasPressure - initialTissuePressure - (inspiredGasRate / timeConstant)) * exp(-timeConstant * time)))
 }
@@ -128,7 +128,7 @@ internal fun schreinerEquation(initialTissuePressure: Double, inspiredGasPressur
  * @return (inspiredGasPressure, inspiredGasRate) for [schreinerEquation], or (0.0, 0.0) when
  * ambient is below the setpoint (loop maxes out on pure O2, no inert gas inspired).
  */
-internal fun ccrSchreinerInputs(
+fun ccrSchreinerInputs(
     startPressure: Double,
     pressureRate: Double,
     inertFraction: Double,

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DiveProfileSection.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DiveProfileSection.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -16,7 +16,7 @@ import org.neotech.app.abysner.domain.core.model.Cylinder
 
 data class DiveProfileSection(
     /**
-     * Duration is minutes.
+     * Duration in minutes.
      */
     val duration: Int,
     /**
@@ -28,3 +28,26 @@ data class DiveProfileSection(
      */
     val cylinder: Cylinder
 )
+
+/**
+ * Truncates the profile sections so that the dive ends at the given [runtime].
+ */
+fun List<DiveProfileSection>.truncateAtRuntime(runtime: Int): List<DiveProfileSection> {
+    val result = mutableListOf<DiveProfileSection>()
+    var elapsed = 0
+    for (section in this) {
+        if (elapsed >= runtime) {
+            break
+        }
+        val remaining = runtime - elapsed
+        if (section.duration <= remaining) {
+            result.add(section)
+            elapsed += section.duration
+        } else {
+            result.add(section.copy(duration = remaining))
+            break
+        }
+    }
+    return result
+}
+

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
@@ -14,6 +14,7 @@ package org.neotech.app.abysner.domain.gasplanning
 
 import kotlinx.collections.immutable.toImmutableList
 import org.neotech.app.abysner.domain.core.model.BreathingMode
+import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
@@ -22,50 +23,56 @@ import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.gasplanning.model.GasPlan
 import org.neotech.app.abysner.domain.gasplanning.model.CylinderGasRequirements
-import org.neotech.app.abysner.domain.utilities.mergeInto
 import org.neotech.app.abysner.domain.utilities.updateOrInsert
 import kotlin.math.max
 
 class GasPlanner {
 
     /**
-     * Given a [DivePlan] find the potential worst-case spots to ascend from, by comparing TTS values
-     * at various depths. This returns a List of [DiveSegments][DiveSegment] with the highest TTS
-     * values, as well as spots during the dive that have a lower TTS value but are deeper.
+     * Returns [DiveSegment] that are candidates for the worst-case ascent to the surface, based on
+     * TTS. Segments are eliminated as candidate if another segment exists that is both deeper and
+     * has a longer TTS, since this would for sure produce a higher gas requirement. However, a
+     * segment is not eliminated if the other segment is deeper but has a shorter TTS, since the
+     * shallower segment may require more gas (since its TTS is longer).
+     *
+     * Note: TTS is used as a filter to narrow down candidates, the true worst case still requires
+     * calculating the actual gas usage for each ascent.
      */
-    fun findPotentialWorstCaseTtsPoints(divePlan: DivePlan): List<DiveSegment> {
+    fun findWorstCaseAscentCandidates(divePlan: DivePlan, bailout: Boolean = false): List<DiveSegment> {
+        val tts: (DiveSegment) -> Int? = if (bailout) { it -> it.ttsBailoutAfter } else { it -> it.ttsAfter }
 
-        // Find all segments with a TTS value
-        val ttsValues = divePlan.segments.filter { it.ttsAfter != null }.toMutableList()
+        // Check only segments that have a TTS value to begin with
+        val remaining = divePlan.segments.mapNotNull { segment -> tts(segment)?.let { segment to it } }.toMutableList()
 
         val candidates = mutableListOf<DiveSegment>()
-        var segmentIndex = 0
-        while (segmentIndex < ttsValues.size) {
-            val segment = ttsValues[segmentIndex++]
-            val segmentTts = segment.ttsAfter!!
-            var isCandidate = true
+        var index = 0
+        while (index < remaining.size) {
+            val (segment, segmentTts) = remaining[index++]
+            var eliminated = false
 
-            val iterator = ttsValues.listIterator()
+            val iterator = remaining.listIterator()
             while (iterator.hasNext()) {
-                val other = iterator.next()
-                if (other !== segment) {
-                    val otherTts = other.ttsAfter!!
-                    if (other.endDepth >= segment.endDepth && otherTts >= segmentTts) {
-                        // Found segment at same or deeper depth with an equal or longer TTS, thus this segment cannot be the worst case gas scenario.
-                        isCandidate = false
+                val (other, otherTts) = iterator.next()
+                when {
+                    other === segment -> continue
+                    other.endDepth >= segment.endDepth && otherTts >= segmentTts -> {
+                        // Found a segment at the same or deeper depth with an equal or longer TTS,
+                        // so this segment cannot be the worst case.
+                        eliminated = true
                         break
-                    } else if (otherTts < segmentTts && other.endDepth < segment.endDepth) {
-                        // Found segment that is also not a worst case scenario, since it is shallower and has a shorter TTS.
-                        // We can already remove this segment, as an optimization (no need to check this segment again).
-                        // Correct main loop index if the removal happens before the current segment
-                        if(iterator.previousIndex() < segmentIndex) {
-                            segmentIndex--
+                    }
+                    other.endDepth < segment.endDepth && otherTts < segmentTts -> {
+                        // This other segment is shallower and has a shorter TTS, so it can never be
+                        // the worst case either. Remove it early so we don't check it again.
+                        // Adjust the main loop index if the removal shifts elements before it.
+                        if (iterator.previousIndex() < index) {
+                            index--
                         }
                         iterator.remove()
                     }
                 }
             }
-            if (isCandidate) {
+            if (!eliminated) {
                 candidates.add(segment)
             }
         }
@@ -79,61 +86,78 @@ class GasPlanner {
 
         val ccrSegments = segments.filter { it.breathingMode is BreathingMode.ClosedCircuit }
         val isCcr = ccrSegments.isNotEmpty()
-        val hasOcSegments = segments.any { it.breathingMode is BreathingMode.OpenCircuit }
 
-        val baseLineOpenCircuit = segments.calculateOpenCircuitGasRequirements(configuration.sacRate, environment)
+        return if (isCcr) {
+            calculateCcrGasPlan(divePlan, configuration, environment, ccrSegments)
+        } else {
+            calculateOcGasPlan(divePlan, configuration, environment, segments)
+        }
+    }
 
-        // Only calculated for open-circuit, you wouldn't share a closed-circuit loop with a buddy.
-        val emergencyOpenCircuit = mutableMapOf<Cylinder, Double>()
-        if (hasOcSegments) {
-            val outOfAirScenarios = findPotentialWorstCaseTtsPoints(divePlan).map { maxTtsSegment ->
-                val ascent = divePlan.alternativeAccents[maxTtsSegment.end]
-                ascent?.calculateOpenCircuitGasRequirements(configuration.sacRateOutOfAir, environment) ?: error("DivePlan does not have alternative ascent for T=${maxTtsSegment.end}, this should not happen and is a developer mistake.")
+    private fun calculateOcGasPlan(
+        divePlan: DivePlan,
+        configuration: Configuration,
+        environment: Environment,
+        segments: List<DiveSegment>,
+    ): GasPlan {
+
+        val normalByGas = mutableMapOf<Gas, Double>()
+        segments.calculateOpenCircuitGasRequirements(configuration.sacRate, environment).forEach { (cylinder, requirement) ->
+            normalByGas.updateOrInsert(cylinder.gas, requirement, Double::plus)
+        }
+
+        // Calculate reserves for an out-of-air buddy using the panic SAC rate
+        val reserveByGas = mutableMapOf<Gas, Double>()
+        val outOfAirScenarios = findWorstCaseAscentCandidates(divePlan).map { maxTtsSegment ->
+            val ascent = divePlan.alternativeAccents[maxTtsSegment.end]
+            ascent?.calculateOpenCircuitGasRequirements(configuration.sacRateOutOfAir, environment)
+                ?: error("DivePlan does not have alternative ascent for T=${maxTtsSegment.end}, this should not happen and is a developer mistake.")
+        }
+
+        // Take the highest gas requirement per cylinder across all scenarios
+        outOfAirScenarios.forEach { scenario ->
+            scenario.forEach { (cylinder, requirement) ->
+                reserveByGas.updateOrInsert(cylinder.gas, requirement) { existing, new -> max(existing, new) }
             }
-            outOfAirScenarios.forEach { scenario ->
-                scenario.mergeInto(emergencyOpenCircuit, ::max)
+        }
+
+        return distributeByGas(divePlan, normalByGas, reserveByGas).toImmutableList()
+    }
+
+    private fun calculateCcrGasPlan(
+        divePlan: DivePlan,
+        configuration: Configuration,
+        environment: Environment,
+        ccrSegments: List<DiveSegment>,
+    ): GasPlan {
+
+        // In closed-circuit gas mode no reserves are calculated for an out-of-air buddy. Generally
+        // speaking if your closed-circuit rebreather fails, you bail out to your own gas supply.
+        // Perhaps if your diluent tank is also your bailout (recreational rebreather setup) then
+        // you might need your buddies bailout, but if you assume that buddy dives the same setup,
+        // you should be just fine with that bailout? It would also be quite complex to account for
+        // all possible team setups etc.
+
+        // TODO choice: calculate bailout with panic mode?
+        //      a bailout is usually not as stressed as a true out-of-air? Since the loop
+        //      usually remains somewhat breathable for a short while? Unless it's a dramatic
+        //      flood perhaps?
+        // Bailout reserve: worst-case open-circuit ascent at normal SAC rate.
+        val reserveByGas = mutableMapOf<Gas, Double>()
+        val bailoutScenarios = findWorstCaseAscentCandidates(divePlan, bailout = true).map { maxTtsSegment ->
+            val ascent = divePlan.alternativeAccents[maxTtsSegment.end]
+            ascent?.calculateOpenCircuitGasRequirements(configuration.sacRate, environment)
+                ?: error("DivePlan does not have alternative ascent for T=${maxTtsSegment.end}, this should not happen and is a developer mistake.")
+        }
+
+        // Take the highest gas requirement per cylinder across all scenarios
+        bailoutScenarios.forEach { scenario ->
+            scenario.forEach { (cylinder, requirement) ->
+                reserveByGas.updateOrInsert(cylinder.gas, requirement) { existing, new -> max(existing, new) }
             }
         }
 
-        // Pool total gas requirements by gas mix rather than by individual cylinder identity.
-        //
-        // The decompression planner currently always selects one representative cylinder per gas
-        // mix via List<Cylinder>.findBestDecoGas(). When the user has multiple cylinders with the
-        // same mix (e.g. doubles for back mount diving or sidemount diving), the other cylinder(s)
-        // never appear in any DiveSegment and are therefore invisible to the raw baseLine gas
-        // requirement map.
-        //
-        // By pooling requirements by Gas and then redistributing proportionally to each cylinder's
-        // capacity, we correctly spread the usage across all same-mix cylinders.
-        //
-        // Note: this does not address the scenario where, once a cylinder is empty, a
-        // less-than-ideal gas may still be breathed for the remainder of the dive. Fixing that
-        // requires a significant change in the planner.
-        val baseLineOpenCircuitByGas = mutableMapOf<Gas, Double>()
-        baseLineOpenCircuit.forEach { (cylinder, requirement) ->
-            baseLineOpenCircuitByGas.updateOrInsert(cylinder.gas, requirement, Double::plus)
-        }
-        val emergencyOpenCircuitByGas = mutableMapOf<Gas, Double>()
-        emergencyOpenCircuit.forEach { (cylinder, requirement) ->
-            emergencyOpenCircuitByGas.updateOrInsert(cylinder.gas, requirement, Double::plus)
-        }
-
-        val cylindersByGas = divePlan.cylinders.groupBy { it.gas }
-
-        // Distribute the open circuit requirements proportionally across same-gas cylinders.
-        val openCircuitResult = cylindersByGas
-            .filter { (gas, _) -> gas in baseLineOpenCircuitByGas || gas in emergencyOpenCircuitByGas }
-            .flatMap { (gas, cylinders) ->
-                distributeProportionally(
-                    cylinders = cylinders.map { it.cylinder },
-                    totalNormal = baseLineOpenCircuitByGas[gas] ?: 0.0,
-                    totalEmergency = emergencyOpenCircuitByGas[gas] ?: 0.0,
-                )
-            }
-
-        if (!isCcr) {
-            return openCircuitResult.toImmutableList()
-        }
+        val bailoutResult = distributeByGas(divePlan, emptyMap(), reserveByGas)
 
         val closedCircuitResult = ccrSegments.calculateClosedCircuitGasRequirements(
             cylinders = divePlan.cylinders.map { it.cylinder },
@@ -143,7 +167,37 @@ class GasPlanner {
             environment = environment,
         )
 
-        return closedCircuitResult.merge(openCircuitResult).toImmutableList()
+        return closedCircuitResult.merge(bailoutResult).toImmutableList()
+    }
+
+    /**
+     * Pools gas requirements by mix and distributes them proportionally across same-mix cylinders.
+     *
+     * The decompression planner always selects one representative cylinder per gas mix via
+     * List<Cylinder>.findBestDecoGas(). When the user has multiple cylinders with the same mix
+     * (e.g. doubles or sidemount), the other cylinder(s) never appear in any DiveSegment and are
+     * invisible to the raw requirement maps. Pooling by Gas and then redistributing proportionally
+     * to each cylinder's capacity correctly spreads the usage across all same-mix cylinders.
+     *
+     * Note: this does not address the scenario where, once a cylinder is empty, a less-than-ideal
+     * gas may still be breathed for the remainder of the dive. Fixing that requires a significant
+     * change in the planner, which is now based on 'best-gas' not on 'make it work'.
+     */
+    private fun distributeByGas(
+        divePlan: DivePlan,
+        normalByGas: Map<Gas, Double>,
+        reserveByGas: Map<Gas, Double>,
+    ): List<CylinderGasRequirements> {
+        val cylindersByGas = divePlan.cylinders.groupBy { it.gas }
+        return cylindersByGas
+            .filter { (gas, _) -> gas in normalByGas || gas in reserveByGas }
+            .flatMap { (gas, cylinders) ->
+                distributeProportionally(
+                    cylinders = cylinders.map { it.cylinder },
+                    totalNormal = normalByGas[gas] ?: 0.0,
+                    totalEmergency = reserveByGas[gas] ?: 0.0,
+                )
+            }
     }
 
     /**
@@ -221,6 +275,9 @@ class GasPlanner {
         return merged.values.toList()
     }
 
+    /**
+     * Distributes the given gas usage evenly across the cylinders, assumes cylinder are of the same mix.
+     */
     private fun distributeProportionally(
         cylinders: List<Cylinder>,
         totalNormal: Double,

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasTest.kt
@@ -14,17 +14,17 @@ package org.neotech.app.abysner.domain.core.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
 
 class GasTest {
 
     @Test
     fun oxygenMod_returnsCorrectModForOxygen() {
         assertEquals(
-            5.98,
+            5.983,
             Gas.Oxygen.oxygenMod(1.6, Environment.Default),
             DOUBLE_PRECISION_DELTA
         )
-
     }
 
     @Test
@@ -105,6 +105,45 @@ class GasTest {
             DOUBLE_PRECISION_DELTA
         )
     }
+
+    @Test
+    fun inspiredGas_normalDepthProducesExpectedMix() {
+        val inspired = Gas.Air.inspiredGas(depthInMetersToBar(30.0, Environment.SeaLevelFresh).value, 1.3)
+        assertEquals(0.328, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
+        assertEquals(0.0, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
+    }
+
+    /**
+     * At ambient pressure of about 1.2093 bar (2 meters) the loop would require just under 108%
+     * oxygen fraction to reach the setpoint, which is physically impossible so it clamps to 100%.
+     */
+    @Test
+    fun inspiredGas_shallowDepthClampsToMaximumOxygenFraction() {
+        val inspired = Gas.Air.inspiredGas(depthInMetersToBar(2.0, Environment.SeaLevelFresh).value, 1.3)
+        assertEquals(1.0, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
+        assertEquals(0.0, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
+    }
+
+    /**
+     * When the diluent oxygen partial pressure itself is higher than the set-point at depth, the
+     * loop should clamp to the diluent oxygen partial pressure and thus fraction. This is a
+     * simplification/assumption made by the decompression planner as well see:
+     * [org.neotech.app.abysner.domain.decompression.algorithm.buhlmann.ccrSchreinerInputs]
+     */
+    @Test
+    fun inspiredGas_deepDepthClampsToMinimumDiluentOxygenFraction() {
+        // At very deep depth, setpoint / ambient < diluent O2, should clamp to diluent O2
+        val inspired = Gas.Air.inspiredGas(depthInMetersToBar(200.0, Environment.SeaLevelFresh).value, 0.5)
+        assertEquals(Gas.Air.oxygenFraction, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
+        assertEquals(Gas.Air.heliumFraction, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
+    }
+
+    @Test
+    fun inspiredGas_trimixDiluentScalesHeliumCorrectly() {
+        val inspired = Gas.Trimix2135.inspiredGas(depthInMetersToBar(30.0, Environment.SeaLevelFresh).value, 1.3)
+        assertEquals(0.328, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
+        assertEquals(0.298, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
+    }
 }
 
-private val DOUBLE_PRECISION_DELTA = 1e-2
+private const val DOUBLE_PRECISION_DELTA = 1e-3

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
@@ -53,7 +53,7 @@ class GasPlannerTest {
     )
 
     @Test
-    fun findPotentialWorstCaseTtsPoints_returnsNonDominatedScenariosAtEachDepth() {
+    fun findWorstCaseAscentCandidates_returnsNonDominatedScenariosAtEachDepth() {
 
         val bottomGas = Cylinder.steel12Liter(Gas.Trimix2135)
         val decoGas = Cylinder.aluminium80Cuft(Gas.Nitrox50)
@@ -94,14 +94,14 @@ class GasPlannerTest {
         // to the depth in general (but figuring out this is done in 'calculateGasPlan' in the
         // GasPlanner)
 
-        val ttsWorstCaseScenarios = GasPlanner().findPotentialWorstCaseTtsPoints(divePlan)
+        val ttsWorstCaseScenarios = GasPlanner().findWorstCaseAscentCandidates(divePlan)
         assertEquals(2, ttsWorstCaseScenarios.size)
         assertTrue { ttsWorstCaseScenarios.any { it.end == 11 && it.endDepth == 50.0 && it.ttsAfter == 12 } }
         assertTrue { ttsWorstCaseScenarios.any { it.end == 51 && it.endDepth == 20.0 && it.ttsAfter == 13 } }
     }
 
     @Test
-    fun findPotentialWorstCaseTtsPoints_returnsOnlyDeepestWorstCaseScenario() {
+    fun findWorstCaseAscentCandidates_returnsOnlyDeepestWorstCaseScenario() {
 
         val bottomGas = Cylinder.steel12Liter(Gas.Air)
 
@@ -134,7 +134,7 @@ class GasPlannerTest {
         // at T=30 and D=15.0: TTS=3
         // at T=48 and D=23.0: TTS=12
 
-        val ttsWorstCaseScenarios = GasPlanner().findPotentialWorstCaseTtsPoints(divePlan)
+        val ttsWorstCaseScenarios = GasPlanner().findWorstCaseAscentCandidates(divePlan)
         assertEquals(1, ttsWorstCaseScenarios.size)
         assertTrue { ttsWorstCaseScenarios.any { it.end == 48 && it.endDepth == 23.0 && it.ttsAfter == 12 } }
     }
@@ -298,15 +298,18 @@ class GasPlannerTest {
     }
 
     @Test
-    fun calculateGasPlan_ccrOnlyPlanExcludesBailoutCylinders() {
+    fun calculateGasPlan_ccrPrimaryPlanIncludesBailoutGasInEmergencySlot() {
         val bailoutCylinder = Cylinder.aluminium80Cuft(Gas.Nitrox32)
         val divePlan = ccrDivePlan(extraCylinders = listOf(bailoutCylinder), bailout = false)
         val gasPlan = GasPlanner().calculateGasPlan(divePlan)
 
-        assertEquals(2, gasPlan.size)
+        assertEquals(3, gasPlan.size)
         assertTrue(gasPlan.any { it.cylinder.gas == Gas.Oxygen })
         assertTrue(gasPlan.any { it.cylinder.gas == Gas.Air })
-        assertTrue(gasPlan.none { it.cylinder.gas == Gas.Nitrox32 })
+
+        val bailoutEntry = gasPlan.first { it.cylinder.gas == Gas.Nitrox32 }
+        assertEquals(0.0, bailoutEntry.normalRequirement)
+        assertTrue(bailoutEntry.extraEmergencyRequirement > 0.0)
     }
 
     @Test
@@ -319,7 +322,8 @@ class GasPlannerTest {
         assertNotNull(gasPlan.firstOrNull { it.cylinder.gas == Gas.Air })
 
         val bailoutEntry = gasPlan.first { it.cylinder.gas == Gas.Nitrox32 }
-        assertTrue(bailoutEntry.normalRequirement > 0.0)
+        assertEquals(0.0, bailoutEntry.normalRequirement)
+        assertTrue(bailoutEntry.extraEmergencyRequirement > 0.0)
     }
 
     private fun ccrDivePlan(


### PR DESCRIPTION
The `GasPlanner` is now split into to separate paths for CCR and OC. For CCR, bailout gas requirements are now calculated as the emergency reserve rather than normal usage, regardless of whether the `DivePlan` was produced as a bailout plan.