### PR TITLE
Add: Support for depth-based CCR setpoint switching in `DivePlanner`

### DIFF
--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/Mappers.kt
@@ -53,6 +53,8 @@ fun Configuration.toResource() = ConfigurationResourceV1(
     ccrHighSetpoint = ccrHighSetpoint,
     ccrLoopVolumeLiters = ccrLoopVolumeLiters,
     ccrMetabolicO2LitersPerMinute = ccrMetabolicO2LitersPerMinute,
+    ccrToHighSetpointSwitchDepth = ccrToHighSetpointSwitchDepth,
+    ccrToLowSetpointSwitchDepth = ccrToLowSetpointSwitchDepth,
 )
 
 fun ConfigurationResourceV1.toModel() = Configuration(
@@ -79,6 +81,8 @@ fun ConfigurationResourceV1.toModel() = Configuration(
     ccrHighSetpoint = ccrHighSetpoint,
     ccrLoopVolumeLiters = ccrLoopVolumeLiters,
     ccrMetabolicO2LitersPerMinute = ccrMetabolicO2LitersPerMinute,
+    ccrToHighSetpointSwitchDepth = ccrToHighSetpointSwitchDepth,
+    ccrToLowSetpointSwitchDepth = ccrToLowSetpointSwitchDepth,
 )
 
 

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/resources/ConfigurationResourceV1.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/resources/ConfigurationResourceV1.kt
@@ -30,4 +30,6 @@ data class ConfigurationResourceV1(
     val ccrHighSetpoint: Double = 1.2,
     val ccrLoopVolumeLiters: Double = 7.0,
     val ccrMetabolicO2LitersPerMinute: Double = 0.8,
+    val ccrToHighSetpointSwitchDepth: Int? = null,
+    val ccrToLowSetpointSwitchDepth: Int? = null,
 ): SerializableResource

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
@@ -63,11 +63,45 @@ data class Configuration(
      * usage for CCR dives.
      */
     val ccrMetabolicO2LitersPerMinute: Double = 0.8,
+    /**
+     * Depth (meters) at which the planner switches from the low setpoint to the high setpoint
+     * during descent. Null disables the auto-switch and causes the switch to occur when a bottom
+     * section is reached.
+     */
+    val ccrToHighSetpointSwitchDepth: Int? = null,
+    /**
+     * Depth (meters) at which the planner switches from the high setpoint to the low setpoint
+     * during ascent. Null disables the auto-switch, meaning the high setpoint remains active until
+     * the surface is reached or a new descent starts.
+     */
+    val ccrToLowSetpointSwitchDepth: Int? = null,
 ) {
 
     val environment = Environment(salinity, altitudeToPressure(altitude))
 
     val gf = "${(gfLow * 100).toInt()}/${(gfHigh * 100).toInt()}"
+
+    /**
+     * Returns a [SetpointSwitch] for the descent phase (low to high setpoint), or null if
+     * the switch is disabled or the dive is not CCR.
+     */
+    fun descentSetpointSwitch(breathingMode: BreathingMode): SetpointSwitch? =
+        ccrToHighSetpointSwitchDepth?.let { depth ->
+            (breathingMode as? BreathingMode.ClosedCircuit)?.let {
+                SetpointSwitch(depth = depth, toBreathingMode = BreathingMode.ClosedCircuit(ccrHighSetpoint))
+            }
+        }
+
+    /**
+     * Returns a [SetpointSwitch] for the ascent phase (high to low setpoint), or null if
+     * the switch is disabled or the dive is not CCR.
+     */
+    fun ascentSetpointSwitch(breathingMode: BreathingMode): SetpointSwitch? =
+        ccrToLowSetpointSwitchDepth?.let { depth ->
+            (breathingMode as? BreathingMode.ClosedCircuit)?.let {
+                SetpointSwitch(depth = depth, toBreathingMode = BreathingMode.ClosedCircuit(ccrLowSetpoint))
+            }
+        }
 
     enum class Algorithm(val shortName: String): EnumPreference {
         BUHLMANN_ZH16C("ZHL-16C-GF") {

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/SetpointSwitch.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/SetpointSwitch.kt
@@ -1,0 +1,24 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.core.model
+
+/**
+ * Describes a CCR setpoint switch that should occur when the diver crosses a specific depth. This
+ * can be fed into the [org.neotech.app.abysner.domain.decompression.DecompressionPlanner] to have
+ * it automatically switch when certain depths are crossed during the dive.
+ */
+data class SetpointSwitch(
+    val depth: Int,
+    val toBreathingMode: BreathingMode.ClosedCircuit,
+)
+

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
@@ -18,6 +18,7 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.SetpointSwitch
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.findBetterGasOrFallback
@@ -26,7 +27,6 @@ import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.decompression.model.subList
-import org.neotech.app.abysner.domain.diveplanning.DivePlanner.PlanningException
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.max
@@ -90,38 +90,73 @@ class DecompressionPlanner(
         return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.GAS_SWITCH, breathingMode)
     }
 
-    fun addDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
+    fun addDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null) {
         require(startDepth != endDepth) { "Use addFlat() for flat segments, startDepth and endDepth must differ." }
+        // Setpoint switches only apply to CCR, ignore for OC to prevent accidental breathing mode switches.
+        val effectiveSetpointSwitch = if (breathingMode is BreathingMode.ClosedCircuit) {
+            setpointSwitch
+        } else {
+            null
+        }
         val type = if (startDepth < endDepth) DiveSegment.Type.DECENT else DiveSegment.Type.ASCENT
-        return addDepthChangeInternal(startDepth, endDepth, gas, timeInMinutes, type, breathingMode)
+        return addDepthChangeInternal(startDepth, endDepth, gas, timeInMinutes, type, breathingMode, effectiveSetpointSwitch)
     }
 
-    private fun addDepthChangeInternal(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode) {
+    private fun addDepthChangeInternal(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null) {
         if(timeInMinutes > 0 && calculateTissueChangesPerMinute && !isCalculatingTts) {
             val diff = startDepth - endDepth
-            repeat(timeInMinutes) {
-                val statDepthForThisMinute = startDepth - (diff * ((it) / timeInMinutes.toDouble()))
-                val endDepthForThisMinute = startDepth - (diff * ((it + 1) / timeInMinutes.toDouble()))
-                addDepthChange(statDepthForThisMinute, endDepthForThisMinute, gas, 1, type, breathingMode)
+            var currentBreathingMode = breathingMode
+            repeat(timeInMinutes) { minute ->
+                val startDepthForThisMinute = startDepth - (diff * ((minute) / timeInMinutes.toDouble()))
+                val endDepthForThisMinute = startDepth - (diff * ((minute + 1) / timeInMinutes.toDouble()))
+                currentBreathingMode = applyDepthChange(startDepthForThisMinute, endDepthForThisMinute, gas, 1, type, currentBreathingMode, setpointSwitch)
             }
         } else {
-            addDepthChange(startDepth, endDepth, gas, timeInMinutes, type, breathingMode)
+            applyDepthChange(startDepth, endDepth, gas, timeInMinutes, type, breathingMode, setpointSwitch)
         }
     }
 
-    private fun addDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode) {
+    /**
+     * Finalizes a pressure change, applies the tissue loading, decompression ceiling changes and
+     * other effects of a pressure change to the model, then adds a segment to the list of segments.
+     * This also takes care of sub-minute precision setpoint switches, and returns the effective
+     * breathing mode at the end of this pressure change.
+     */
+    private fun applyDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null): BreathingMode {
 
         val startPressure = depthInMetersToBar(startDepth, environment)
         val endPressure = depthInMetersToBar(endDepth, environment)
 
-        if (timeInMinutes > 0) {
-            model.addPressureChange(startPressure, endPressure, gas.gas, timeInMinutes, breathingMode.ccrSetpointOrNull)
+        // Check if the setpoint switch depth is crossed during this segment
+        val switchDepth = setpointSwitch?.depth?.toDouble()
+        val crossesSwitchDepth = switchDepth != null &&
+            (startDepth < switchDepth) != (endDepth < switchDepth)
+
+        val breathingModeAtEnd: BreathingMode.ClosedCircuit?
+        if (timeInMinutes > 0 && crossesSwitchDepth) {
+            // Sub-minute precision: split the model call at the exact switch depth
+            // TODO: See [DiveSegment.breathingModeAtEnd]
+            val timeFractionBeforeSwitch = abs(setpointSwitch.depth - startDepth) / abs(endDepth - startDepth)
+
+            val pressureSwitch = depthInMetersToBar(setpointSwitch.depth.toDouble(), environment)
+
+            if (timeFractionBeforeSwitch > 0.0) {
+                model.addPressureChange(startPressure, pressureSwitch, gas.gas, timeFractionBeforeSwitch * timeInMinutes, breathingMode.ccrSetpointOrNull)
+            }
+            if (timeFractionBeforeSwitch < 1.0) {
+                model.addPressureChange(pressureSwitch, endPressure, gas.gas, (1.0 - timeFractionBeforeSwitch) * timeInMinutes, setpointSwitch.toBreathingMode.ccrSetpointOrNull)
+            }
+            breathingModeAtEnd = setpointSwitch.toBreathingMode
+        } else {
+            if (timeInMinutes > 0) {
+                model.addPressureChange(startPressure, endPressure, gas.gas, timeInMinutes, breathingMode.ccrSetpointOrNull)
+            }
+            breathingModeAtEnd = null
         }
 
         val ceiling = barToDepthInMeters(model.getCeiling(), environment)
 
-        //store this as a stage
-        this.segments.add(
+        segments.add(
             DiveSegment(
                 start = runtime,
                 duration = timeInMinutes,
@@ -131,12 +166,14 @@ class DecompressionPlanner(
                 type = type,
                 gfCeilingAtEnd = ceiling,
                 breathingMode = breathingMode,
+                breathingModeAtEnd = breathingModeAtEnd,
             )
         )
         this.runtime += timeInMinutes
+        return breathingModeAtEnd ?: breathingMode
     }
 
-    fun calculateTimeToSurface(breathingMode: BreathingMode): Int {
+    fun calculateTimeToSurface(breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null): Int {
         // TODO this is not an ideal method to acquire this information, as we generate a lot
         //      of info we don't need.
 
@@ -151,7 +188,7 @@ class DecompressionPlanner(
         var alternativeAscentSegments: List<DiveSegment> = emptyList()
         val start = runtime
         val result = resetAfter {
-            calculateDecompression(toDepth = 0, breathingMode = breathingMode).sumOf { it.duration }.also {
+            calculateDecompression(toDepth = 0, breathingMode = breathingMode, setpointSwitch = setpointSwitch).sumOf { it.duration }.also {
                 alternativeAscentSegments = segments.subList(start).toList()
             }
         }
@@ -166,10 +203,12 @@ class DecompressionPlanner(
      * Gas switching is skipped when [breathingMode] is [BreathingMode.ClosedCircuit], since the
      * diver stays on the loop.
      */
-    private fun addDecoDepthChange(fromDepth: Double, toDepth: Double, maxppO2: Double, maxEND: Double, fromGas: Cylinder, ascentRateInMetersPerMinute: Double, breathingMode: BreathingMode): Cylinder {
+    private fun addDecoDepthChange(fromDepth: Double, toDepth: Double, maxppO2: Double, maxEND: Double, fromGas: Cylinder, ascentRateInMetersPerMinute: Double, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null): Cylinder {
         val isCcr = breathingMode is BreathingMode.ClosedCircuit
         var gas = fromGas
         var currentDepth = fromDepth
+        // After crossing the switch depth, use the switched-to breathing mode for all subsequent segments.
+        var effectiveBreathingMode = breathingMode
 
         while (currentDepth > toDepth) {
             if (!isCcr) {
@@ -181,7 +220,7 @@ class DecompressionPlanner(
                     // Gas switch time is spent on the old gas: the diver is still breathing the
                     // previous gas while preparing to switch (grabbing regulator, purging, etc.).
                     // The actual switch to the new gas happens after the gas switch time.
-                    addGasSwitch(currentDepth, gas, gasSwitchTime, breathingMode)
+                    addGasSwitch(currentDepth, gas, gasSwitchTime, effectiveBreathingMode)
                     gas = betterDecoGas
                 }
             }
@@ -199,7 +238,7 @@ class DecompressionPlanner(
                 while(nextDepth >= targetDepth) {
                     nextDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, depth = nextDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
                     if (nextDecoGas != null && nextDecoGas.gas != gas.gas && nextDepth.toInt() % decoStepSize == 0) {
-                        targetDepth = nextDepth //Only carry us up to the point where we can use this better gas.
+                        targetDepth = nextDepth
                         break
                     }
                     nextDepth--
@@ -217,8 +256,12 @@ class DecompressionPlanner(
             val depthChange = abs(currentDepth - targetDepth)
             val duration = max(1, ceil(depthChange / ascentRateInMetersPerMinute).toInt())
 
-            // println("Moving diver from $fromDepth to $targetDepth on gas $gas over $duration minutes.")
-            addDepthChange(currentDepth, targetDepth, gas, duration, breathingMode)
+            addDepthChange(currentDepth, targetDepth, gas, duration, effectiveBreathingMode, setpointSwitch)
+
+            // If the switch depth was crossed during this segment, update the effective mode
+            if (setpointSwitch != null && currentDepth > setpointSwitch.depth && targetDepth <= setpointSwitch.depth) {
+                effectiveBreathingMode = setpointSwitch.toBreathingMode
+            }
 
             currentDepth = targetDepth
         }
@@ -227,7 +270,7 @@ class DecompressionPlanner(
             val betterDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, depth = currentDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
             if (betterDecoGas != null && betterDecoGas.gas != gas.gas && currentDepth.toInt() % decoStepSize == 0) {
                 // Gas switch time on the old gas before switching
-                addGasSwitch(currentDepth, gas, gasSwitchTime, breathingMode)
+                addGasSwitch(currentDepth, gas, gasSwitchTime, effectiveBreathingMode)
                 gas = betterDecoGas
             }
         }
@@ -238,7 +281,15 @@ class DecompressionPlanner(
     fun calculateDecompression(
         toDepth: Int,
         breathingMode: BreathingMode,
+        setpointSwitch: SetpointSwitch? = null,
     ): List<DiveSegment> {
+        // Setpoint switches only apply to CCR, ignore for OC to prevent accidental breathing mode switches
+        val effectiveSetpointSwitch = if (breathingMode is BreathingMode.ClosedCircuit) {
+            setpointSwitch
+        } else {
+            null
+        }
+
         val isCcr = breathingMode is BreathingMode.ClosedCircuit
         var gas: Cylinder
         val fromDepth: Double
@@ -306,15 +357,30 @@ class DecompressionPlanner(
                 maxEquivalentNarcoticDepth,
                 gas,
                 ascentRate,
-                breathingMode
+                breathingMode,
+                effectiveSetpointSwitch
             )
         }
+
+        // After the initial ascent, determine if the switch depth was already crossed.
+        var effectiveBreathingMode = if (effectiveSetpointSwitch != null && fromDepth > effectiveSetpointSwitch.depth &&
+            max(ceiling.toDouble(), toDepth.toDouble()) <= effectiveSetpointSwitch.depth) {
+            effectiveSetpointSwitch.toBreathingMode
+        } else {
+            breathingMode
+        }
+
         // Keep making deco stops until the deco ceiling is above the surface
         while (ceiling > 0) {
 
             val currentDepth = ceiling.toDouble()
             if(currentDepth <= toDepth) {
                 break
+            }
+
+            // Update effective breathing mode if we're now above the switch depth
+            if (effectiveSetpointSwitch != null && currentDepth <= effectiveSetpointSwitch.depth) {
+                effectiveBreathingMode = effectiveSetpointSwitch.toBreathingMode
             }
 
             // Check the new ceiling
@@ -349,7 +415,7 @@ class DecompressionPlanner(
                 var stopTime = 0
                 while (ceiling > nextDecoDepth && ceiling > toDepth || (forceMinimalDecoStopTime && stopTime < 1)) {
                     // Add 1 minute of decompression and test the ceiling again, until the ceiling is higher.
-                    this.addDecoStop(currentDepth, gas, 1, breathingMode)
+                    this.addDecoStop(currentDepth, gas, 1, effectiveBreathingMode)
                     stopTime++
 
                     // TODO: Should we calculate the gf based on the current stop depth, or the next stop depth we want to reach?
@@ -373,7 +439,7 @@ class DecompressionPlanner(
                     }
                 }
             }
-            gas = this.addDecoDepthChange(currentDepth, ceiling.toDouble(), maxPpO2, maxEquivalentNarcoticDepth, gas, ascentRate, breathingMode)
+            gas = this.addDecoDepthChange(currentDepth, ceiling.toDouble(), maxPpO2, maxEquivalentNarcoticDepth, gas, ascentRate, effectiveBreathingMode, effectiveSetpointSwitch)
         }
 
         return if(segments.size == segmentSizeStart) {

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/DecompressionModel.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/DecompressionModel.kt
@@ -17,8 +17,8 @@ import org.neotech.app.abysner.domain.core.physics.Pressure
 import kotlin.reflect.KClass
 
 /**
- * A decompression model is allows adding dive sections to load tissues, and a method that returns
- * the current ceiling.
+ * A decompression model tracks tissue loading across dive sections and provides the current
+ * decompression ceiling.
  */
 interface DecompressionModel {
 
@@ -51,6 +51,11 @@ interface DecompressionModel {
      * null open-circuit behavior is assumed)
      */
     fun addPressureChange(startPressure: Pressure, endPressure: Pressure, gas: Gas, timeInMinutes: Int, ccrSetpoint: Double? = null)
+
+    /**
+     * Same as [addPressureChange] but accepts fractional minutes for sub-minute precision.
+     */
+    fun addPressureChange(startPressure: Pressure, endPressure: Pressure, gas: Gas, timeInMinutes: Double, ccrSetpoint: Double? = null)
 
     /**
      * Calculates and returns the current tissue ceiling in bars (including atmospheric pressure)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
@@ -69,6 +69,10 @@ class Buhlmann(
      * null open-circuit behavior is assumed)
      */
     override fun addPressureChange(startPressure: Pressure, endPressure: Pressure, gas: Gas, timeInMinutes: Int, ccrSetpoint: Double?) {
+        addPressureChange(startPressure, endPressure, gas, timeInMinutes.toDouble(), ccrSetpoint)
+    }
+
+    override fun addPressureChange(startPressure: Pressure, endPressure: Pressure, gas: Gas, timeInMinutes: Double, ccrSetpoint: Double?) {
         val fO2 = gas.oxygenFraction
         val fHe = gas.heliumFraction
         tissues.forEach {
@@ -213,9 +217,13 @@ data class TissueCompartment(
     val partialNitrogenPressure: Double get() = pNitrogen
 
     fun addPressureChange(startPressure: Double, endPressure: Double, fO2: Double, fHe: Double, timeInMinutes: Int, ccrSetpoint: Double? = null): Double {
+        return addPressureChange(startPressure, endPressure, fO2, fHe, timeInMinutes.toDouble(), ccrSetpoint)
+    }
+
+    fun addPressureChange(startPressure: Double, endPressure: Double, fO2: Double, fHe: Double, timeInMinutes: Double, ccrSetpoint: Double? = null): Double {
         // A zero or negative duration makes no physical sense (no exposure has occurred), and
         // would also cause a division by zero in pressureChangeInBarsPerMinute.
-        require(timeInMinutes > 0) {
+        require(timeInMinutes > 0.0) {
             "Invalid duration `$timeInMinutes` for on/off-gassing tissues. The minimum duration must be higher than 0."
         }
 
@@ -246,7 +254,7 @@ data class TissueCompartment(
         startPressure: Double,
         fN2: Double,
         fHe: Double,
-        timeInMinutes: Int,
+        timeInMinutes: Double,
         depthChangeInBarsPerMinute: Double
     ) {
         // Inspired gas pressure: subtract alveolar water vapor pressure from ambient before
@@ -257,14 +265,14 @@ data class TissueCompartment(
         this.pNitrogen = schreinerEquation(
             initialTissuePressure = pNitrogen,
             inspiredGasPressure = partialPressure(inspiredPressure, fN2),
-            time = timeInMinutes.toDouble(),
+            time = timeInMinutes,
             halfTime = parameters.n2HalfTime,
             inspiredGasRate = partialPressure(depthChangeInBarsPerMinute, fN2),
         )
         this.pHelium = schreinerEquation(
             initialTissuePressure = pHelium,
             inspiredGasPressure = partialPressure(inspiredPressure, fHe),
-            time = timeInMinutes.toDouble(),
+            time = timeInMinutes,
             halfTime = parameters.heHalfTime,
             inspiredGasRate = partialPressure(depthChangeInBarsPerMinute, fHe),
         )
@@ -290,7 +298,7 @@ data class TissueCompartment(
         fO2: Double,
         fN2: Double,
         fHe: Double,
-        timeInMinutes: Int,
+        timeInMinutes: Double,
         depthChangeInBarsPerMinute: Double,
         ccrSetpoint: Double,
     ) {
@@ -411,7 +419,7 @@ data class TissueCompartment(
             this.pNitrogen = schreinerEquation(
                 initialTissuePressure = pNitrogen,
                 inspiredGasPressure = inspiredNitrogenPressure,
-                time = timeInMinutes.toDouble(),
+                time = timeInMinutes,
                 halfTime = parameters.n2HalfTime,
                 inspiredGasRate = inspiredNitrogenRate,
             )
@@ -425,7 +433,7 @@ data class TissueCompartment(
             this.pHelium = schreinerEquation(
                 initialTissuePressure = pHelium,
                 inspiredGasPressure = inspiredHeliumPressure,
-                time = timeInMinutes.toDouble(),
+                time = timeInMinutes,
                 halfTime = parameters.heHalfTime,
                 inspiredGasRate = inspiredHeliumRate,
             )

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilities.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilities.kt
@@ -69,10 +69,10 @@ internal fun waterVapourPressureInBars(degreesCelsius: Double): Double {
 /**
  * Calculates the change in pressure in bars per minute.
  *
- * @return the pressure changes in bars per minute, positive if descending, negative if ascending.
+ * @return pressure change per minute, positive if descending, negative if ascending.
  */
-internal fun pressureChangeInBarsPerMinute(beginPressure: Double, endPressure: Double, timeInMinutes: Int): Double {
-    require(timeInMinutes > 0) { "timeInMinutes must be a positive integer, instead got: $timeInMinutes." }
+internal fun pressureChangeInBarsPerMinute(beginPressure: Double, endPressure: Double, timeInMinutes: Double): Double {
+    require(timeInMinutes > 0.0) { "timeInMinutes must be positive, instead got: $timeInMinutes." }
     return (endPressure - beginPressure) / timeInMinutes
 }
 

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
@@ -55,6 +55,19 @@ data class DiveSegment(
      */
     val breathingMode: BreathingMode = BreathingMode.OpenCircuit,
 
+    /**
+     * Non-null when a CCR setpoint switch occurred mid-segment. In that case [breathingMode] is
+     * the mode at the start of the segment and this field is the mode at the end.
+     *
+     * TODO
+     *   This is a bit hacky from an architecture point of view, this can happen because we
+     *   currently adhere to exact depths for these switches, which can cause them to occur
+     *   mid-minute which is currently our smallest (and purposefully chosen) time-unit. If we need
+     *   more detailed segments, should we add second precision to the segments that require second
+     *   precision, instead of custom fields to jump the gap?
+     */
+    val breathingModeAtEnd: BreathingMode.ClosedCircuit? = null,
+
     val travelSpeed: Double = (startDepth - endDepth) / duration.toDouble(),
 
     /**
@@ -161,9 +174,12 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
             currentSegment.cylinder == nextSegment.cylinder &&
             currentSegment.breathingMode == nextSegment.breathingMode
         ) {
+            val mergedModeAtEnd = (nextSegment.breathingModeAtEnd ?: currentSegment.breathingModeAtEnd)
+                ?.takeIf { it != currentSegment.breathingMode }
             val combinedSegment = currentSegment.copy(
                 duration = currentSegment.duration + nextSegment.duration,
                 gfCeilingAtEnd = nextSegment.gfCeilingAtEnd,
+                breathingModeAtEnd = mergedModeAtEnd,
             )
             this[i] = combinedSegment
             this.removeAt(i + 1)
@@ -171,12 +187,16 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
             currentSegment.travelSpeed.equalsDelta(nextSegment.travelSpeed, maxTravelSpeedDelta) &&
             currentSegment.endDepth == nextSegment.startDepth &&
             currentSegment.cylinder == nextSegment.cylinder &&
-            currentSegment.breathingMode == nextSegment.breathingMode
+            (currentSegment.breathingMode == nextSegment.breathingMode ||
+                currentSegment.breathingModeAtEnd == nextSegment.breathingMode)
         ) {
+            val mergedModeAtEnd = (nextSegment.breathingModeAtEnd ?: currentSegment.breathingModeAtEnd)
+                ?.takeIf { it != currentSegment.breathingMode }
             val combinedSegment = currentSegment.copy(
                 endDepth = nextSegment.endDepth,
                 duration = currentSegment.duration + nextSegment.duration,
                 gfCeilingAtEnd = nextSegment.gfCeilingAtEnd,
+                breathingModeAtEnd = mergedModeAtEnd,
             )
             this[i] = combinedSegment
             this.removeAt(i + 1)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
@@ -18,6 +18,7 @@ import kotlinx.collections.immutable.toPersistentList
 import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.DiveMode
+import org.neotech.app.abysner.domain.core.model.SetpointSwitch
 import org.neotech.app.abysner.domain.decompression.DecompressionPlanner
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
 import org.neotech.app.abysner.domain.decompression.algorithm.buhlmann.Buhlmann
@@ -127,6 +128,8 @@ class DivePlanner(
 
                     val runtime = decompressionPlanner.runtime
 
+                    val ascentSwitch = configuration.ascentSetpointSwitch(breathingMode)
+
                     // Ascending (calculate decompression)
                     if(!configuration.useDecoGasBetweenSections) {
                         // Store current deco gases
@@ -135,10 +138,10 @@ class DivePlanner(
                         // Only allow the listed bottom gas to get to this segment
                         // This is similar to what MultiDeco does
                         decompressionPlanner.setDecoGases(listOf(it.cylinder))
-                        decompressionPlanner.calculateDecompression(toDepth = it.depth, breathingMode = breathingMode)
+                        decompressionPlanner.calculateDecompression(toDepth = it.depth, breathingMode = breathingMode, setpointSwitch = ascentSwitch)
                         decompressionPlanner.setDecoGases(gases)
                     } else {
-                        decompressionPlanner.calculateDecompression(toDepth = it.depth, breathingMode = breathingMode)
+                        decompressionPlanner.calculateDecompression(toDepth = it.depth, breathingMode = breathingMode, setpointSwitch = ascentSwitch)
                     }
 
                     val timeSpend = decompressionPlanner.runtime - runtime
@@ -155,7 +158,7 @@ class DivePlanner(
                             breathingMode,
                         )
                     }
-                    decompressionPlanner.collectTts(breathingMode, isCcr, ttsBySegmentIndex)
+                    decompressionPlanner.collectTts(breathingMode, isCcr, ttsBySegmentIndex, ascentSwitch)
 
                 } else {
                     // Descending
@@ -163,12 +166,17 @@ class DivePlanner(
 
                     val timeLeftAtPlannedDepth = it.duration - timeToChange
 
+                    val descentSwitch = configuration.descentSetpointSwitch(breathingMode)
+
+                    val ascentSwitchForTts = configuration.ascentSetpointSwitch(breathingMode)
+
                     decompressionPlanner.addDepthChange(
                         currentDepth,
                         it.depth.toDouble(),
                         it.cylinder,
                         timeToChange,
                         descentBreathingMode,
+                        setpointSwitch = descentSwitch,
                     )
 
                     // TODO allow 0? And just not add the flat?
@@ -182,7 +190,7 @@ class DivePlanner(
                             breathingMode,
                         )
                     }
-                    decompressionPlanner.collectTts(breathingMode, isCcr, ttsBySegmentIndex)
+                    decompressionPlanner.collectTts(breathingMode, isCcr, ttsBySegmentIndex, ascentSwitchForTts)
                 }
                 currentDepth = it.depth.toDouble()
             } else {
@@ -192,7 +200,8 @@ class DivePlanner(
                     it.duration,
                     breathingMode,
                 )
-                decompressionPlanner.collectTts(breathingMode, isCcr, ttsBySegmentIndex)
+                val ascentSwitchForTts = configuration.ascentSetpointSwitch(breathingMode)
+                decompressionPlanner.collectTts(breathingMode, isCcr, ttsBySegmentIndex, ascentSwitchForTts)
                 currentDepth = it.depth.toDouble()
             }
         }
@@ -204,7 +213,12 @@ class DivePlanner(
         } else {
             breathingMode
         }
-        decompressionPlanner.calculateDecompression(toDepth = 0, breathingMode = ascentBreathingMode)
+        val finalAscentSwitch = if (!bailout) {
+            configuration.ascentSetpointSwitch(breathingMode)
+        } else {
+            null
+        }
+        decompressionPlanner.calculateDecompression(toDepth = 0, breathingMode = ascentBreathingMode, setpointSwitch = finalAscentSwitch)
 
         val segments = decompressionPlanner.getSegments().mapIndexed { index, segment ->
             ttsBySegmentIndex[index]?.let {
@@ -250,9 +264,10 @@ class DivePlanner(
         breathingMode: BreathingMode,
         isCcr: Boolean,
         destination: MutableMap<Int, TtsValues>,
+        ascentSwitch: SetpointSwitch? = null,
     ) {
         val segmentIndex = getSegments().lastIndex
-        val tts = calculateTimeToSurface(breathingMode)
+        val tts = calculateTimeToSurface(breathingMode, ascentSwitch)
         // OC bailout TTS: time to surface if the diver comes off the loop now. This second call
         // overwrites the alternative ascent stored for this timestamp, which is intentional:
         // the OC bailout ascent is the one that matters for emergency gas planning.

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/SetpointSwitchTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/SetpointSwitchTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.diveplanning
+
+import org.neotech.app.abysner.domain.core.model.BreathingMode
+import org.neotech.app.abysner.domain.core.model.Configuration
+import org.neotech.app.abysner.domain.core.model.Configuration.Algorithm
+import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
+import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.core.model.Salinity
+import org.neotech.app.abysner.domain.decompression.model.DiveSegment
+import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
+import org.neotech.app.abysner.domain.diveplanning.model.assign
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class CcrSetpointSwitchTest {
+
+    private val lowSetpoint = 0.7
+    private val highSetpoint = 1.2
+    private val lowMode = BreathingMode.ClosedCircuit(lowSetpoint)
+    private val highMode = BreathingMode.ClosedCircuit(highSetpoint)
+
+    private fun createPlanner(
+        switchDepthDescend: Int? = 6,
+        switchDepthAscend: Int? = 6,
+    ): DivePlanner = DivePlanner(
+        Configuration(
+            maxAscentRate = 9.0,
+            maxDescentRate = 18.0,
+            gfLow = 0.3,
+            gfHigh = 0.7,
+            salinity = Salinity.WATER_SALT,
+            algorithm = Algorithm.BUHLMANN_ZH16C,
+            decoStepSize = 3,
+            lastDecoStopDepth = 3,
+            ccrLowSetpoint = lowSetpoint,
+            ccrHighSetpoint = highSetpoint,
+            ccrToHighSetpointSwitchDepth = switchDepthDescend,
+            ccrToLowSetpointSwitchDepth = switchDepthAscend,
+        )
+    )
+
+    @Test
+    fun ccrDive_descentSwitchDepthSetsBreathingModeAtEnd() {
+        val diluent = Cylinder.aluminium80Cuft(Gas.Air)
+        val planner = createPlanner(switchDepthDescend = 6, switchDepthAscend = null)
+
+        val plan = planner.addDive(
+            listOf(DiveProfileSection(duration = 20, depth = 36, cylinder = diluent)),
+            listOf(diluent).assign(),
+            diveMode = DiveMode.CLOSED_CIRCUIT
+        )
+
+        // The descent from 0 to 18 meters crosses the 6 meters switch point. At 18 meters per
+        // minute the switch will be in the first segment/minute.
+        val segments = plan.segments
+        val firstSegment = segments.first()
+
+        assertEquals(DiveSegment.Type.DECENT, firstSegment.type)
+        assertEquals(lowMode, firstSegment.breathingMode)
+        assertEquals(highMode, firstSegment.breathingModeAtEnd)
+    }
+
+    @Test
+    fun ccrDive_ascentSwitchDepthSetsBreathingModeAtEnd() {
+        val diluent = Cylinder.aluminium80Cuft(Gas.Air)
+        val planner = createPlanner(switchDepthDescend = null, switchDepthAscend = 6)
+
+        val plan = planner.addDive(
+            listOf(DiveProfileSection(duration = 10, depth = 18, cylinder = diluent)),
+            listOf(diluent).assign(),
+            diveMode = DiveMode.CLOSED_CIRCUIT
+        )
+
+        val segments = plan.segments
+
+        // The ascent from 18 to 0 meters crosses the 6 meters switch point. At 9 meters per
+        // minute the switch will be in the second (and last) segment/minute.
+        val switchSegment = segments.last { it.type == DiveSegment.Type.ASCENT }
+
+        assertEquals(highMode, switchSegment.breathingMode)
+        assertEquals(lowMode, switchSegment.breathingModeAtEnd)
+    }
+
+    @Test
+    fun ccrDive_ascentSwitchDepthWithDecoStopSwitchesAtStopDepth() {
+        val diluent = Cylinder.aluminium80Cuft(Gas.Air)
+        val planner = createPlanner(switchDepthDescend = null, switchDepthAscend = 6)
+
+        val plan = planner.addDive(
+            listOf(DiveProfileSection(duration = 30, depth = 30, cylinder = diluent)),
+            listOf(diluent).assign(),
+            diveMode = DiveMode.CLOSED_CIRCUIT
+        )
+
+        val segments = plan.segments
+
+        // With deco stops the switch depth aligns with a deco stop at 6 meters. The planner
+        // transitions to the low setpoint at the deco stop level exactly (no sub-minute switch).
+
+        // All segments at or above 6 meter should use the low setpoint.
+        val segmentsAtOrAboveSwitchDepth = segments.filter {
+            it.startDepth <= 6.0 && it.type != DiveSegment.Type.DECENT
+        }
+        segmentsAtOrAboveSwitchDepth.forEach {
+            assertEquals(lowMode, it.breathingMode)
+        }
+
+        // All segments below 6 meter should use the high setpoint.
+        val deepAscentSegments = segments.filter {
+            it.type == DiveSegment.Type.ASCENT && it.startDepth > 6.0
+        }
+        deepAscentSegments.forEach {
+            assertEquals(highMode, it.breathingMode)
+        }
+    }
+
+    @Test
+    fun ccrDive_switchDepthDisabledUsesDefaultBehavior() {
+        val diluent = Cylinder.aluminium80Cuft(Gas.Air)
+        val planner = createPlanner(switchDepthDescend = null, switchDepthAscend = null)
+
+        val plan = planner.addDive(
+            listOf(DiveProfileSection(duration = 30, depth = 30, cylinder = diluent)),
+            listOf(diluent).assign(),
+            diveMode = DiveMode.CLOSED_CIRCUIT
+        )
+
+        val segments = plan.segments
+
+        // No segment should have breathingModeAtEnd set, since the switches happen between
+        // sections with default behavior.
+        val switchSegments = segments.filter { it.breathingModeAtEnd != null }
+        assertEquals(0, switchSegments.size)
+
+        // All descents should use low setpoint
+        segments.filter { it.type == DiveSegment.Type.DECENT }.forEach {
+            assertEquals(lowMode, it.breathingMode)
+        }
+        // All ascents and flat segments should use high setpoint
+        segments.filter { it.type != DiveSegment.Type.DECENT }.forEach {
+            assertEquals(highMode, it.breathingMode)
+        }
+    }
+}


### PR DESCRIPTION
Adds configurable switch depths for transitioning between the low and high CCR setpoints during descent and ascent. The `DecompressionPlanner` handles the switch at sub-minute precision by splitting the tissue loading calculation at the exact switch depth. This is different from the rest of the planner which avoids sub-minute precision, for example: `DivePlanner` doesn't honor exact ascent/descent speeds either, as it rounds to whole minutes to avoid rounding on the UI/table level. Unlike ascents and descents, setpoint switches do not impact the decompression table: the exact crossing time will not be exposed to the UI and doesn't need to be.