### PR TITLE
Fix: `travelTime` rounding down allowed slightly exceeding max ascent/descent rate

### DIFF
--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/ShareImageScreenshotTestKt/ShareImageScreenshotTest_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/ShareImageScreenshotTestKt/ShareImageScreenshotTest_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ca9684a3fa5c302d41faa83eaffd48ebab5a6b2fe426cbcc46a74a1bd2e9f00
-size 228475
+oid sha256:832d22c07a87f4f079c39039f391adbf00ae1d1edcdab2af519302610ee73c32
+size 228020

--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenScreenshotTest_d12982c9_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenScreenshotTest_d12982c9_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62e8fb7fa9d974e8909a6380918ec60d567b9059a666f365114ef692faa55774
-size 189359
+oid sha256:6db42c40d2156d0e62e080c33585c455a91cb6ac7e3eb2cc2c150b17f41b591f
+size 190067

--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenWithWarningsScreenshotTest_d12982c9_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenWithWarningsScreenshotTest_d12982c9_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e5d44a94deeb5e38ac3fcbe714a44759de9edbe98ad012253f0a6903a5e3a14
-size 219443
+oid sha256:5c484c59735891141b21e9285f7e32981856043861bdc7e8dbf15fda239a38bd
+size 219011

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
@@ -14,7 +14,7 @@ package org.neotech.app.abysner.domain.core.model
 
 import org.neotech.app.abysner.domain.core.physics.altitudeToPressure
 import org.neotech.app.abysner.domain.persistence.EnumPreference
-import kotlin.math.floor
+import kotlin.math.ceil
 import kotlin.math.max
 
 /**
@@ -127,7 +127,7 @@ data class Configuration(
         return if(distance == 0.0) {
             0
         } else {
-            max(floor(distance / rate).toInt(), 1)
+            max(ceil(distance / rate).toInt(), 1)
         }
     }
 }

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/ConfigurationTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/ConfigurationTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.core.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConfigurationTest {
+
+    private val configuration = Configuration(
+        maxAscentRate = 5.0,
+        maxDescentRate = 20.0,
+    )
+
+    @Test
+    fun travelTime_returnsWholeMinutesForEvenDivision() {
+        assertEquals(2, configuration.travelTime(-40.0))
+        assertEquals(3, configuration.travelTime(15.0))
+    }
+
+    @Test
+    fun travelTime_roundsUpToNotExceedConfiguredRate() {
+        assertEquals(3, configuration.travelTime(-50.0))
+        assertEquals(2, configuration.travelTime(8.0))
+    }
+
+    @Test
+    fun travelTime_returnsZeroForZeroDistance() {
+        assertEquals(0, configuration.travelTime(0.0))
+    }
+}


### PR DESCRIPTION
`floor` produced travel times shorter than possible at the configured max rate. Changed to `ceil` so limits are never exceeded. Reference plans are unaffected because their depths divide evenly by the configured rates.