### PR TITLE
Refactor: Replace wrapper classes with top-level @Inject composable functions

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/MainNavController.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/MainNavController.kt
@@ -42,40 +42,17 @@ enum class Destinations(override val destinationName: String) : DestinationDefin
     TERMS_AND_CONDITIONS_INITIAL("terms-and-conditions-initial")
 }
 
-// Metro supports @Inject on top-level functions, but the generated types are not resolved by the
-// IDE, causing "Unresolved reference" errors. This wrapper class avoids those IDE errors.
-// See: https://zacsweers.github.io/metro/latest/installation/#ide-support
 @Inject
-class MainNavController(
-    private val viewModelCreator: () -> MainNavControllerViewModel,
-    private val plannerScreen: PlannerScreen,
-    private val diveConfigurationScreen: DiveConfigurationScreen,
-    private val settingsScreen: SettingsScreen,
-    private val termsAndConditionsScreen: TermsAndConditionsScreen,
-    private val aboutScreen: AboutScreen,
-) {
-    @Composable
-    operator fun invoke() {
-        MainNavController(
-            viewModel = viewModel { viewModelCreator() },
-            plannerScreen = plannerScreen,
-            diveConfigurationScreen = diveConfigurationScreen,
-            settingsScreen = settingsScreen,
-            termsAndConditionsScreen = termsAndConditionsScreen,
-            aboutScreen = aboutScreen,
-        )
-    }
-}
-
 @Composable
 fun MainNavController(
-    viewModel: MainNavControllerViewModel,
+    viewModelCreator: () -> MainNavControllerViewModel,
     plannerScreen: PlannerScreen,
     diveConfigurationScreen: DiveConfigurationScreen,
     settingsScreen: SettingsScreen,
     termsAndConditionsScreen: TermsAndConditionsScreen,
     aboutScreen: AboutScreen,
 ) {
+    val viewModel = viewModel { viewModelCreator() }
 
     val startDestination = when (viewModel.settings.value.termsAndConditionsAccepted) {
         false -> Destinations.TERMS_AND_CONDITIONS_INITIAL

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/DiveConfigurationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/DiveConfigurationScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -70,29 +71,12 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 
 
-// Metro supports @Inject on top-level functions, but the generated types are not resolved by the
-// IDE, causing "Unresolved reference" errors. This wrapper class avoids those IDE errors.
-// See: https://zacsweers.github.io/metro/latest/installation/#ide-support
 @Inject
-class DiveConfigurationScreen(
-    private val planningRepository: PlanningRepository,
-    private val settingsRepository: SettingsRepository,
-) {
-    @Composable
-    operator fun invoke(navController: NavHostController) {
-        DiveConfigurationScreen(
-            navController = navController,
-            planningRepository = planningRepository,
-            settingsRepository = settingsRepository,
-        )
-    }
-}
-
 @Composable
 fun DiveConfigurationScreen(
-    navController: NavHostController,
     planningRepository: PlanningRepository,
     settingsRepository: SettingsRepository,
+    @Assisted navController: NavHostController,
 ) {
     // TODO should be adding a ViewModel to this screen
     val configuration by planningRepository.configuration.collectAsState()

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/SettingsScreen.kt
@@ -39,6 +39,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import kotlinx.collections.immutable.toImmutableList
 import org.neotech.app.abysner.domain.core.model.UnitSystem
+import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.Inject
 import org.neotech.app.abysner.domain.settings.SettingsRepository
 import org.neotech.app.abysner.domain.settings.model.SettingsModel
@@ -48,26 +49,11 @@ import org.neotech.app.abysner.presentation.component.preferences.SingleChoicePr
 import org.neotech.app.abysner.presentation.component.preferences.SwitchPreference
 import org.neotech.app.abysner.presentation.theme.AbysnerTheme
 
-// Metro supports @Inject on top-level functions, but the generated types are not resolved by the
-// IDE, causing "Unresolved reference" errors. This wrapper class avoids those IDE errors.
-// See: https://zacsweers.github.io/metro/latest/installation/#ide-support
 @Inject
-class SettingsScreen(
-    private val settingsRepository: SettingsRepository,
-) {
-    @Composable
-    operator fun invoke(navController: NavHostController) {
-        SettingsScreen(
-            navController = navController,
-            settingsRepository = settingsRepository
-        )
-    }
-}
-
 @Composable
-private fun SettingsScreen(
-    navController: NavHostController,
+fun SettingsScreen(
     settingsRepository: SettingsRepository,
+    @Assisted navController: NavHostController,
 ) {
     // TODO should be adding a ViewModel to this screen
     val settings by settingsRepository.settings.collectAsState()

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/about/AboutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/about/AboutScreen.kt
@@ -60,27 +60,17 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.Inject
 import org.jetbrains.compose.resources.painterResource
 import org.neotech.app.abysner.presentation.Destinations
 import org.neotech.app.abysner.presentation.theme.AbysnerTheme
 import org.neotech.app.abysner.version.VersionInfo
 
-// Metro supports @Inject on top-level functions, but the generated types are not resolved by the
-// IDE, causing "Unresolved reference" errors. This wrapper class avoids those IDE errors.
-// See: https://zacsweers.github.io/metro/latest/installation/#ide-support
 @Inject
-class AboutScreen {
-
-    @Composable
-    operator fun invoke(navController: NavHostController) {
-        AboutScreen(navController = navController)
-    }
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AboutScreen(navController: NavHostController = rememberNavController()) {
+fun AboutScreen(@Assisted navController: NavHostController = rememberNavController()) {
     val uriHandler = LocalUriHandler.current
 
     AbysnerTheme {

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
@@ -51,6 +51,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import kotlinx.collections.immutable.toImmutableList
+import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.Inject
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.DiveMode
@@ -76,27 +77,14 @@ import org.neotech.app.abysner.presentation.preview.DEVICE_PHONE_MAX_HEIGHT
 import org.neotech.app.abysner.presentation.preview.PreviewData
 import kotlin.time.Duration
 
-// Metro supports @Inject on top-level functions, but the generated types are not resolved by the
-// IDE, causing "Unresolved reference" errors. This wrapper class avoids those IDE errors.
-// See: https://zacsweers.github.io/metro/latest/installation/#ide-support
-@Inject
-class PlannerScreen(
-    private val viewModelCreator: () -> PlanScreenViewModel,
-) {
-    @Composable
-    operator fun invoke(navController: NavHostController) {
-        PlannerScreen(
-            viewModel = viewModel { viewModelCreator() },
-            navController = navController,
-        )
-    }
-}
 
+@Inject
 @Composable
-private fun PlannerScreen(
-    viewModel: PlanScreenViewModel,
-    navController: NavHostController
+fun PlannerScreen(
+    viewModelCreator: () -> PlanScreenViewModel,
+    @Assisted navController: NavHostController,
 ) {
+    val viewModel = viewModel { viewModelCreator() }
     val uiState: PlanScreenViewModel.UiState by viewModel.uiState.collectAsState()
 
     PlannerScreen(

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/terms_and_conditions/TermsAndConditionsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/terms_and_conditions/TermsAndConditionsScreen.kt
@@ -49,6 +49,7 @@ import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import com.mikepenz.markdown.model.markdownPadding
+import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.Inject
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.neotech.app.abysner.presentation.Destinations
@@ -64,27 +65,13 @@ import org.neotech.app.abysner.presentation.utilities.closeApp
 import org.neotech.app.abysner.presentation.utilities.consumed
 import org.neotech.app.abysner.presentation.utilities.runBlockingInPreview
 
-// Metro supports @Inject on top-level functions, but the generated types are not resolved by the
-// IDE, causing "Unresolved reference" errors. This wrapper class avoids those IDE errors.
-// See: https://zacsweers.github.io/metro/latest/installation/#ide-support
 @Inject
-class TermsAndConditionsScreen(
-    private val viewModelCreator: () -> TermsAndConditionsViewModel,
-) {
-    @Composable
-    operator fun invoke(navController: NavHostController = rememberNavController()) {
-        TermsAndConditionsScreen(
-            navController = navController,
-            viewModel = viewModel { viewModelCreator() }
-        )
-    }
-}
-
 @Composable
-private fun TermsAndConditionsScreen(
-    navController: NavHostController,
-    viewModel: TermsAndConditionsViewModel
+fun TermsAndConditionsScreen(
+    viewModelCreator: () -> TermsAndConditionsViewModel,
+    @Assisted navController: NavHostController = rememberNavController(),
 ) {
+    val viewModel = viewModel { viewModelCreator() }
     val uiState: UiState = viewModel.uiState.collectAsState().value
     TermsAndConditionsScreen(
         navController = navController,


### PR DESCRIPTION
The downside of this is that the IDE (Android Studio Quail 1 | 2026.1.1 Canary 1) does not yet resolve the generated class types, and will show "Unresolved reference" on parameters like `PlannerScreen` in `MainNavController`.

A fix can be applied on the IDE (Android Studio) by opening the registry (Ctrl/Cmd+Shift+A, type 'Registry') and disabling the flag `kotlin.k2.only.bundled.compiler.plugins.enabled`. However symbol navigation ('Go to Definition') and similar actions don't seem to work.