### PR TITLE
Refactor: Add tolerance utilities, pressure conversions, and rename depth/pressure conversion functions

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanCard.kt
@@ -64,7 +64,7 @@ import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.decompression.model.compactSimilarSegments
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
@@ -456,12 +456,12 @@ private fun RowScope.DecoPlanRow(
         text = gas.toString(),
     )
 
-    val endAmbientPressure = depthInMetersToBar(diveSegment.endDepth, environment).value
+    val endAmbientPressure = metersToAmbientPressure(diveSegment.endDepth, environment).value
 
     val ppO2Text = when (val mode = diveSegment.breathingMode) {
         is BreathingMode.ClosedCircuit -> {
             val endMode = diveSegment.breathingModeAtEnd ?: mode
-            val startAmbientPressure = depthInMetersToBar(diveSegment.startDepth, environment).value
+            val startAmbientPressure = metersToAmbientPressure(diveSegment.startDepth, environment).value
             val ppO2Start = mode.effectivePpO2(startAmbientPressure)
             val ppO2End = endMode.effectivePpO2(endAmbientPressure)
 

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/gasplan/GasPlanCard.kt
@@ -36,7 +36,7 @@ import org.neotech.app.abysner.domain.diveplanning.model.DivePlanSet
 import org.neotech.app.abysner.domain.gasplanning.model.CylinderGasRequirements
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
 import org.neotech.app.abysner.domain.utilities.format
-import org.neotech.app.abysner.domain.utilities.higherThenDelta
+import org.neotech.app.abysner.domain.utilities.greaterThanTolerant
 import org.neotech.app.abysner.presentation.component.AlertSeverity
 import org.neotech.app.abysner.presentation.component.Table
 import org.neotech.app.abysner.presentation.component.TextAlert
@@ -353,8 +353,8 @@ fun GasLimitsTable(
             Text(modifier = Modifier.weight(0.3f), text = "${gasAtDepth.depth.toInt()}m")
 
             val alertSeverityDensity = when {
-                gasAtDepth.density.higherThenDelta(Gas.MAX_GAS_DENSITY, 0.001) -> AlertSeverity.ERROR
-                gasAtDepth.density.higherThenDelta(Gas.MAX_RECOMMENDED_GAS_DENSITY, 0.001) -> AlertSeverity.WARNING
+                gasAtDepth.density.greaterThanTolerant(Gas.MAX_GAS_DENSITY, DISPLAY_TOLERANCE) -> AlertSeverity.ERROR
+                gasAtDepth.density.greaterThanTolerant(Gas.MAX_RECOMMENDED_GAS_DENSITY, DISPLAY_TOLERANCE) -> AlertSeverity.WARNING
                 else -> AlertSeverity.NONE
             }
             TextAlert(
@@ -363,7 +363,7 @@ fun GasLimitsTable(
                 text = DecimalFormat.format(2, gasAtDepth.density),
             )
 
-            val alertSeverityPPO2 = if (gasAtDepth.ppo2.higherThenDelta(Gas.MAX_PPO2, 0.001)) {
+            val alertSeverityPPO2 = if (gasAtDepth.ppo2.greaterThanTolerant(Gas.MAX_PPO2, DISPLAY_TOLERANCE)) {
                 AlertSeverity.ERROR
             } else {
                 AlertSeverity.NONE
@@ -436,4 +436,11 @@ private fun GasPlanCardComponentCcrBailoutPreview() {
         )
     }
 }
+
+/**
+ * Half-unit at 2 decimal places: prevents alerts when the displayed value rounds to exactly the
+ * threshold.
+ */
+private const val DISPLAY_TOLERANCE = 0.005
+
 

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/CcrLoopPropertiesComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/CcrLoopPropertiesComponent.kt
@@ -27,7 +27,7 @@ import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.core.model.Salinity
 import org.neotech.app.abysner.domain.core.physics.ATMOSPHERIC_PRESSURE_AT_SEA_LEVEL
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.utilities.format
 import org.neotech.app.abysner.presentation.component.BigNumberDisplay
 import org.neotech.app.abysner.presentation.component.BigNumberSize
@@ -44,7 +44,7 @@ fun CcrLoopPropertiesComponent(
     diluent: Gas,
     environment: Environment,
 ) {
-    val ambientPressure = depthInMetersToBar(depth.toDouble(), environment).value
+    val ambientPressure = metersToAmbientPressure(depth.toDouble(), environment).value
     val inspiredGas = diluent.inspiredGas(ambientPressure, setpoint)
     val inspiredDensity = inspiredGas.densityAtDepth(depth.toDouble(), environment)
 

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentPickerBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/segments/SegmentPickerBottomSheet.kt
@@ -59,7 +59,7 @@ import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
 import org.neotech.app.abysner.domain.diveplanning.model.bailoutCylinders
 import org.neotech.app.abysner.domain.diveplanning.model.ccrDiluentCylinder
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.core.physics.partialPressure
 import org.neotech.app.abysner.presentation.component.DropDown
 import org.neotech.app.abysner.presentation.component.GasPropertiesComponent
@@ -298,7 +298,7 @@ private fun SegmentPickerBottomSheet(
                 } else if (anyErrorMessage == null) {
                     val diluentGas = cylinders.ccrDiluentCylinder()?.cylinder?.gas
                     if (diluentGas != null) {
-                        val ambientPressure = depthInMetersToBar(depth.toDouble(), environment).value
+                        val ambientPressure = metersToAmbientPressure(depth.toDouble(), environment).value
                         val diluentPpO2 = partialPressure(ambientPressure, diluentGas.oxygenFraction)
                         if (diluentPpO2 > configuration.ccrHighSetpoint) {
                             anyErrorMessage = "Warning: Diluent PPO2 exceeds setpoint at this depth!"

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
@@ -12,8 +12,8 @@
 
 package org.neotech.app.abysner.domain.core.model
 
-import org.neotech.app.abysner.domain.core.physics.barToDepthInMeters
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.ambientPressureToMeters
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
 import kotlin.math.round
 
@@ -37,7 +37,7 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
      * Returns the oxygen MOD in meters.
      */
     fun oxygenMod(ppO2: Double, environment: Environment): Double {
-        return barToDepthInMeters(ppO2 / this.oxygenFraction, environment)
+        return ambientPressureToMeters(ppO2 / this.oxygenFraction, environment)
     }
 
     /**
@@ -57,9 +57,9 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
         // Helium has a narc factor of 0 while N2 and O2 have a narc factor of 1
         val narcIndex = (this.oxygenFraction) + (this.nitrogenFraction)
 
-        val bars = depthInMetersToBar(depth, environment)
+        val bars = metersToAmbientPressure(depth, environment)
         val equivalentBars = bars.value * narcIndex
-        return barToDepthInMeters(equivalentBars, environment)
+        return ambientPressureToMeters(equivalentBars, environment)
     }
 
     val density: Double by lazy {
@@ -70,7 +70,7 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
     }
 
     fun densityAtDepth(depth: Double, environment: Environment): Double {
-        val bar = depthInMetersToBar(depth, environment)
+        val bar = metersToAmbientPressure(depth, environment)
         return density * bar.value
     }
 
@@ -79,7 +79,7 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
      */
     fun densityMod(maxAllowedDensity: Double = MAX_GAS_DENSITY, environment: Environment): Double {
         val bar = maxAllowedDensity / density
-        return barToDepthInMeters(bar, environment)
+        return ambientPressureToMeters(bar, environment)
     }
 
     /**

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/GasSelection.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/GasSelection.kt
@@ -12,7 +12,7 @@
 
 package org.neotech.app.abysner.domain.core.model
 
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import kotlin.math.round
 
 /**
@@ -54,7 +54,7 @@ fun List<Cylinder>.findBestGas(depth: Double, environment: Environment, maxPpO2:
  * picks the highest-O2 option as the least-bad choice. Returns null if the list is empty.
  */
 internal fun List<Cylinder>.findBreathableFallbackGas(depth: Double, environment: Environment, minPPO2: Double = Gas.MIN_PPO2, ): Cylinder? {
-    val pressure = depthInMetersToBar(depth, environment).value
+    val pressure = metersToAmbientPressure(depth, environment).value
     val nonHypoxic = filter { it.gas.oxygenFraction * pressure >= minPPO2 }
     return if (nonHypoxic.isNotEmpty()) {
         nonHypoxic.minByOrNull { it.gas.oxygenFraction }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/physics/Pressure.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/physics/Pressure.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -15,20 +15,25 @@ package org.neotech.app.abysner.domain.core.physics
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.decompression.DecompressionPlanner
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
+import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import kotlin.jvm.JvmInline
 import kotlin.math.exp
 import kotlin.math.ln
 
 /**
- * Represents pressure in metric bars, 1 bar is equal to 100.000 Pascal.
- * The idea of using an inline value class for Pressure is not to use it
- * everywhere, but instead to allow for compile-time checks (without run-time
- * performance hits) when crossing abstraction boundaries, such as crossing
- * between the [DecompressionPlanner] (works with meters currently) and
+ * Represents pressure in metric bars, 1 bar is equal to 100.000 Pascal. The idea of using an inline
+ * value class for Pressure is not to use it everywhere, but instead to allow for compile-time
+ * checks (without run-time performance hits) when crossing abstraction boundaries, such as crossing
+ * between the [DivePlanner] (works in display-units) and [DecompressionPlanner] /
  * [DecompressionModel] (works in pressure).
  */
 @JvmInline
-value class Pressure(val value: Double)
+value class Pressure(val value: Double) {
+    operator fun plus(other: Pressure): Pressure = Pressure(this.value + other.value)
+    operator fun minus(other: Pressure): Pressure = Pressure(this.value - other.value)
+    operator fun times(factor: Double): Pressure = Pressure(this.value * factor)
+    operator fun div(divisor: Double): Pressure = Pressure(this.value / divisor)
+}
 
 /**
  * Calculates the partial pressure of an individual gas component from the total pressure of the gas
@@ -60,38 +65,78 @@ fun Double.asPsiToBar(): Double = this / 14.503774
 
 fun Double.asBarToPsi(): Double = this * 14.503774
 
-
 /**
  * Converts depth in meters given a certain density (salinity) and atmospheric pressure to pressure
  * in bars including atmospheric pressure.
  *
  * @param depth water depth in meters
- * @param environment the density (salinity) of the water and atmospheric pressure.
+ * @param environment the environment to use for salinity and atmospheric pressure.
  * @return pressure at the given depth.
  */
-fun depthInMetersToBar(depth: Double, environment: Environment): Pressure {
+fun metersToAmbientPressure(depth: Double, environment: Environment): Pressure {
     val weightDensity = environment.salinity.density * GRAVITY_ON_EARTH
     return Pressure(pascalToBar(depth * weightDensity) + environment.atmosphericPressure)
 }
+
+/**
+ * Converts depth in meters given a certain salinity (density) to hydrostatic pressure in bars,
+ * which is the pressure excluding atmospheric pressure.
+ *
+ * @param depth water depth in meters.
+ * @param environment the environment to use for salinity.
+ * @return pressure at the given depth excluding atmospheric pressure.
+ */
+fun metersToHydrostaticPressure(depth: Double, environment: Environment): Pressure {
+    val weightDensity = environment.salinity.density * GRAVITY_ON_EARTH
+    return Pressure(pascalToBar(depth * weightDensity))
+}
+
+/**
+ * Converts depth in feet given a certain salinity (density) and atmospheric pressure to ambient
+ * pressure in bars, which includes atmospheric pressure.
+ *
+ * @param depth water depth in feet.
+ * @param environment the environment to use for salinity and atmospheric pressure.
+ * @return ambient pressure at the given depth, this includes atmospheric pressure.
+ */
+fun feetToAmbientPressure(depth: Double, environment: Environment): Pressure =
+    metersToAmbientPressure(depth * METERS_PER_FOOT, environment)
+
+/**
+ * Converts depth in feet given a certain salinity (density) to hydrostatic pressure in bars,
+ * which is the pressure excluding atmospheric pressure.
+ *
+ * @param depth water depth in feet.
+ * @param environment the environment to use for salinity.
+ * @return pressure at the given depth excluding atmospheric pressure.
+ */
+fun feetToHydrostaticPressure(depth: Double, environment: Environment): Pressure =
+    metersToHydrostaticPressure(depth * METERS_PER_FOOT, environment)
 
 /**
  * Converts pressure in bars including atmospheric pressure to depth in meters given a certain
  * density (salinity) and atmospheric pressure.
  *
  * @param pressure pressure including atmospheric pressure.
- * @param environment the density (salinity) of the water and atmospheric pressure.
+ * @param environment the environment to use for salinity and atmospheric pressure.
  * @return depth in meters for the given pressure.
  */
-fun barToDepthInMeters(pressure: Double, environment: Environment): Double {
+fun ambientPressureToMeters(pressure: Double, environment: Environment): Double {
     val waterPressure = pressure - environment.atmosphericPressure
     val weightDensity = environment.salinity.density * GRAVITY_ON_EARTH
     return barToPascal(waterPressure) / weightDensity
 }
 
-@Suppress("NOTHING_TO_INLINE")
-inline fun barToDepthInMeters(pressure: Pressure, environment: Environment): Double {
-    return barToDepthInMeters(pressure.value, environment)
-}
+/**
+ * Converts ambient pressure in bars to water depth in feet given a certain salinity (density) and
+ * atmospheric pressure.
+ *
+ * @param pressure ambient pressure (hydrostatic + atmospheric pressure).
+ * @param environment the environment to use for salinity and atmospheric pressure.
+ * @return depth in feet for the given pressure.
+ */
+fun ambientPressureToFeet(pressure: Double, environment: Environment): Double =
+    ambientPressureToMeters(pressure, environment) / METERS_PER_FOOT
 
 /**
  * Transforms altitude in meters to pressure in bars.
@@ -123,11 +168,16 @@ const val ATMOSPHERIC_PRESSURE_AT_SEA_LEVEL = 1.01325
 
 /**
  *  Constant temperature in degrees Kelvin which is used during pressure to altitude calculations.
- *  This is essentially 15 degrees celsius.
+ *  This is essentially 15 degrees Celsius.
  */
 private const val ATMOSPHERIC_TEMPERATURE = 273.15 + 15.0
 
 /**
- * Gravity on earth in meters per seconds squared (m/s²)
+ * Gravity on earth in meters per second squared (m/s²).
  */
 internal const val GRAVITY_ON_EARTH = 9.80665
+
+/**
+ * Constant for foot to meter conversion, according to international standard.
+ */
+private const val METERS_PER_FOOT = 0.3048

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
@@ -22,8 +22,8 @@ import org.neotech.app.abysner.domain.core.model.SetpointSwitch
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.findBetterGasOrFallback
-import org.neotech.app.abysner.domain.core.physics.barToDepthInMeters
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.ambientPressureToMeters
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.decompression.model.subList
@@ -123,8 +123,8 @@ class DecompressionPlanner(
      */
     private fun applyDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null): BreathingMode {
 
-        val startPressure = depthInMetersToBar(startDepth, environment)
-        val endPressure = depthInMetersToBar(endDepth, environment)
+        val startPressure = metersToAmbientPressure(startDepth, environment)
+        val endPressure = metersToAmbientPressure(endDepth, environment)
 
         // Check if the setpoint switch depth is crossed during this segment
         val switchDepth = setpointSwitch?.depth?.toDouble()
@@ -137,7 +137,7 @@ class DecompressionPlanner(
             // TODO: See [DiveSegment.breathingModeAtEnd]
             val timeFractionBeforeSwitch = abs(setpointSwitch.depth - startDepth) / abs(endDepth - startDepth)
 
-            val pressureSwitch = depthInMetersToBar(setpointSwitch.depth.toDouble(), environment)
+            val pressureSwitch = metersToAmbientPressure(setpointSwitch.depth.toDouble(), environment)
 
             if (timeFractionBeforeSwitch > 0.0) {
                 model.addPressureChange(startPressure, pressureSwitch, gas.gas, timeFractionBeforeSwitch * timeInMinutes, breathingMode.ccrSetpointOrNull)
@@ -153,7 +153,7 @@ class DecompressionPlanner(
             breathingModeAtEnd = null
         }
 
-        val ceiling = barToDepthInMeters(model.getCeiling(), environment)
+        val ceiling = ambientPressureToMeters(model.getCeiling().value, environment)
 
         segments.add(
             DiveSegment(
@@ -545,7 +545,7 @@ class DecompressionPlanner(
         // Ceil to the next whole meter (or foot) so the ceiling is never shallower than what the
         // model reports. Using round() here would allow the diver up to 0.5m shallower than the
         // true ceiling (e.g. a raw ceiling of 3.2m would round to 3m, violating the ceiling).
-        var ceiling = ceil(barToDepthInMeters(model.getCeiling(), environment)).toInt()
+        var ceiling = ceil(ambientPressureToMeters(model.getCeiling().value, environment)).toInt()
         // Snap up to the nearest deco grid point (e.g. 3m or 10ft increments). The ceiling must
         // never be shallower than the model ceiling, so we only move deeper.
         while (ceiling % decoStepSize != 0) {

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
@@ -14,7 +14,7 @@ package org.neotech.app.abysner.domain.decompression.model
 
 import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Cylinder
-import org.neotech.app.abysner.domain.utilities.equalsDelta
+import org.neotech.app.abysner.domain.utilities.equalsTolerant
 import kotlin.math.max
 
 data class DiveSegment(
@@ -160,9 +160,6 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
     compactAscentsAndStops: Boolean = false
 ): MutableList<DiveSegment> {
 
-    // Maximum delta between travel speeds for them to be considered equal.
-    val maxTravelSpeedDelta = 0.0001
-
     var i = 0
     while (i < size - 1) {
         val currentSegment = this[i]
@@ -170,7 +167,7 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
         if (
             currentSegment.type.isFlat &&
             currentSegment.type == nextSegment.type &&
-            currentSegment.endDepth == nextSegment.startDepth &&
+            currentSegment.endDepth.equalsTolerant(nextSegment.startDepth) &&
             currentSegment.cylinder == nextSegment.cylinder &&
             currentSegment.breathingMode == nextSegment.breathingMode
         ) {
@@ -184,8 +181,9 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
             this[i] = combinedSegment
             this.removeAt(i + 1)
         } else if (
-            currentSegment.travelSpeed.equalsDelta(nextSegment.travelSpeed, maxTravelSpeedDelta) &&
-            currentSegment.endDepth == nextSegment.startDepth &&
+            !currentSegment.type.isFlat &&
+            currentSegment.travelSpeed.equalsTolerant(nextSegment.travelSpeed) &&
+            currentSegment.endDepth.equalsTolerant(nextSegment.startDepth) &&
             currentSegment.cylinder == nextSegment.cylinder &&
             (currentSegment.breathingMode == nextSegment.breathingMode ||
                 currentSegment.breathingModeAtEnd == nextSegment.breathingMode)
@@ -204,7 +202,7 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
             compactAscentsAndStops &&
             currentSegment.isGasSwitch &&
             nextSegment.isDecompressionStop &&
-            currentSegment.endDepth == nextSegment.startDepth
+            currentSegment.endDepth.equalsTolerant(nextSegment.startDepth)
         ) {
             // A gas switch followed by a deco stop at the same depth: absorb the stop into the
             // switch so both appear as a single row. The cylinder is kept from the switch segment

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/model/DivePlan.kt
@@ -20,7 +20,7 @@ import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
 import kotlin.math.ceil
 
@@ -69,7 +69,7 @@ data class DivePlan(
         val depth: Double,
         val environment: Environment,
     ) {
-        val ppo2 = gas.oxygenFraction * depthInMetersToBar(depth, environment).value
+        val ppo2 = gas.oxygenFraction * metersToAmbientPressure(depth, environment).value
         val density: Double = gas.densityAtDepth(depth, environment)
     }
 

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
@@ -18,7 +18,7 @@ import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.gasplanning.model.GasPlan
@@ -223,8 +223,8 @@ class GasPlanner {
         // Diluent usage due to loop expansion
         val diluentLitersByCylinder = mutableMapOf<Cylinder, Double>()
         forEach { segment ->
-            val startPressure = depthInMetersToBar(segment.startDepth, environment).value
-            val endPressure = depthInMetersToBar(segment.endDepth, environment).value
+            val startPressure = metersToAmbientPressure(segment.startDepth, environment).value
+            val endPressure = metersToAmbientPressure(segment.endDepth, environment).value
             val pressureIncrease = endPressure - startPressure
             if (pressureIncrease > 0.0) {
                 val expansion = pressureIncrease * ccrLoopVolume
@@ -250,7 +250,7 @@ class GasPlanner {
         val requiredLitersByCylinder = mutableMapOf<Cylinder, Double>()
         forEach { segment ->
             if (segment.breathingMode is BreathingMode.OpenCircuit) {
-                val pressure = depthInMetersToBar(segment.averageDepth, environment)
+                val pressure = metersToAmbientPressure(segment.averageDepth, environment)
                 val sacAtDepth = sac * pressure.value
                 val liters = segment.duration * sacAtDepth
                 requiredLitersByCylinder.updateOrInsert(segment.cylinder, liters, Double::plus)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculator.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculator.kt
@@ -14,7 +14,7 @@ package org.neotech.app.abysner.domain.gasplanning
 
 import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Environment
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.decompression.algorithm.buhlmann.ccrSchreinerInputs
 import kotlin.math.exp
@@ -35,7 +35,7 @@ object OxygenToxicityCalculator {
     fun calculateCns(segments: List<DiveSegment>, environment: Environment): Double {
         var cns = 0.0
         segments.forEach {
-            val averagePressure = depthInMetersToBar((it.startDepth + it.endDepth) / 2.0, environment).value
+            val averagePressure = metersToAmbientPressure((it.startDepth + it.endDepth) / 2.0, environment).value
             val ppO2 = effectivePartialOxygenPressure(it.cylinder.gas.oxygenFraction, averagePressure, it.breathingMode)
             cns += calculateCns(ppO2, it.duration)
         }
@@ -74,8 +74,8 @@ object OxygenToxicityCalculator {
         // CNS this seems to be more important (or even necessary).
         var otu = 0.0
         segments.forEach {
-            val startAmbientPressure = depthInMetersToBar(it.startDepth, environment).value
-            val endAmbientPressure = depthInMetersToBar(it.endDepth, environment).value
+            val startAmbientPressure = metersToAmbientPressure(it.startDepth, environment).value
+            val endAmbientPressure = metersToAmbientPressure(it.endDepth, environment).value
             val ppo2Start = effectivePartialOxygenPressure(it.cylinder.gas.oxygenFraction, startAmbientPressure, it.breathingMode)
             val ppo2End = effectivePartialOxygenPressure(it.cylinder.gas.oxygenFraction, endAmbientPressure, it.breathingMode)
             otu += this.calculateOtu(it.duration, ppo2Start, ppo2End)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/utilities/NumberExtensions.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/utilities/NumberExtensions.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2024 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -13,16 +13,72 @@
 package org.neotech.app.abysner.domain.utilities
 
 import kotlin.math.abs
-import kotlin.math.max
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.round
 
 /**
- * See: https://levelup.gitconnected.com/double-equality-in-kotlin-f99392cba0e4
+ * Returns true if [this] and [other] differ by less than [tolerance]. Use for
+ * comparisons where floating-point arithmetic noise might prevent exact equality.
  */
-fun Double.equalsDelta(other: Double, delta: Double) = abs(this - other) < delta * max(abs(this), abs(other))
+fun Double.equalsTolerant(other: Double, tolerance: Double = FLOATING_POINT_TOLERANCE): Boolean =
+    abs(this - other) < tolerance
 
 /**
- * See: https://levelup.gitconnected.com/double-equality-in-kotlin-f99392cba0e4
+ * Returns true if [this] is strictly greater than [other], accounting for floating-point noise.
+ * Small differences within [tolerance] are treated as equal.
  */
-fun Double.higherThenDelta(other: Double, delta: Double): Boolean {
-    return this > other && !this.equalsDelta(other, delta)
+fun Double.greaterThanTolerant(other: Double, tolerance: Double = FLOATING_POINT_TOLERANCE): Boolean =
+    this > other + tolerance
+
+/**
+ * Returns true if [this] is greater than or equal to [other], accounting for floating-point noise.
+ * Values just barely below [other] due to noise are still considered equal.
+ */
+fun Double.greaterThanOrEqualTolerant(other: Double, tolerance: Double = FLOATING_POINT_TOLERANCE): Boolean =
+    this >= other - tolerance
+
+/**
+ * Returns true if [this] is strictly less than [other], accounting for floating-point noise.
+ * Small differences within [tolerance] are treated as equal.
+ */
+fun Double.lessThanTolerant(other: Double, tolerance: Double = FLOATING_POINT_TOLERANCE): Boolean =
+    this < other - tolerance
+
+/**
+ * Returns true if [this] is less than or equal to [other], accounting for floating-point noise.
+ * Values just barely above [other] due to noise are still considered equal.
+ */
+fun Double.lessThanOrEqualTolerant(other: Double, tolerance: Double = FLOATING_POINT_TOLERANCE): Boolean =
+    this <= other + tolerance
+
+/**
+ * Like [ceil], but subtracts [FLOATING_POINT_TOLERANCE] first so that values just barely above an
+ * integer due to floating-point noise round as expected. For example, `ceilTolerant(9.0000000002)`
+ * returns 9.0, not 10.0.
+ */
+fun ceilTolerant(value: Double): Double = ceil(value - FLOATING_POINT_TOLERANCE)
+
+/**
+ * Like [floor], but adds [FLOATING_POINT_TOLERANCE] first so that values just barely below an
+ * integer due to floating-point noise round as expected. For example, `floorTolerant(2.9999999998)`
+ * returns 3.0, not 2.0.
+ */
+fun floorTolerant(value: Double): Double = floor(value + FLOATING_POINT_TOLERANCE)
+
+/**
+ * Strips floating-point arithmetic noise by rounding to [FLOATING_POINT_TOLERANCE] precision (6
+ * decimal places). For depth in meters this is micrometer precision, for pressure in bar this is
+ * microbar precision, both far beyond what diving calculations need.
+ *
+ * For example: `removeFloatingPointNoise(6.000000000000001)` returns 6.0.
+ */
+fun removeFloatingPointNoise(value: Double): Double {
+    val factor = 1.0 / FLOATING_POINT_TOLERANCE
+    return round(value * factor) / factor
 }
+
+/**
+ * Small absolute tolerance used to absorb floating-point arithmetic noise.
+ */
+private const val FLOATING_POINT_TOLERANCE = 1e-6

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasTest.kt
@@ -14,7 +14,7 @@ package org.neotech.app.abysner.domain.core.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 
 class GasTest {
 
@@ -108,7 +108,7 @@ class GasTest {
 
     @Test
     fun inspiredGas_normalDepthProducesExpectedMix() {
-        val inspired = Gas.Air.inspiredGas(depthInMetersToBar(30.0, Environment.SeaLevelFresh).value, 1.3)
+        val inspired = Gas.Air.inspiredGas(metersToAmbientPressure(30.0, Environment.SeaLevelFresh).value, 1.3)
         assertEquals(0.328, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
         assertEquals(0.0, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
     }
@@ -119,7 +119,7 @@ class GasTest {
      */
     @Test
     fun inspiredGas_shallowDepthClampsToMaximumOxygenFraction() {
-        val inspired = Gas.Air.inspiredGas(depthInMetersToBar(2.0, Environment.SeaLevelFresh).value, 1.3)
+        val inspired = Gas.Air.inspiredGas(metersToAmbientPressure(2.0, Environment.SeaLevelFresh).value, 1.3)
         assertEquals(1.0, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
         assertEquals(0.0, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
     }
@@ -133,14 +133,14 @@ class GasTest {
     @Test
     fun inspiredGas_deepDepthClampsToMinimumDiluentOxygenFraction() {
         // At very deep depth, setpoint / ambient < diluent O2, should clamp to diluent O2
-        val inspired = Gas.Air.inspiredGas(depthInMetersToBar(200.0, Environment.SeaLevelFresh).value, 0.5)
+        val inspired = Gas.Air.inspiredGas(metersToAmbientPressure(200.0, Environment.SeaLevelFresh).value, 0.5)
         assertEquals(Gas.Air.oxygenFraction, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
         assertEquals(Gas.Air.heliumFraction, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
     }
 
     @Test
     fun inspiredGas_trimixDiluentScalesHeliumCorrectly() {
-        val inspired = Gas.Trimix2135.inspiredGas(depthInMetersToBar(30.0, Environment.SeaLevelFresh).value, 1.3)
+        val inspired = Gas.Trimix2135.inspiredGas(metersToAmbientPressure(30.0, Environment.SeaLevelFresh).value, 1.3)
         assertEquals(0.328, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
         assertEquals(0.298, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
     }

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/physics/PressureTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/physics/PressureTest.kt
@@ -13,31 +13,59 @@
 package org.neotech.app.abysner.domain.core.physics
 
 import org.neotech.app.abysner.domain.core.model.Environment
+import org.neotech.app.abysner.domain.core.model.Salinity
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PressureTest {
 
-    @Test
-    fun depthInMetersToBar_convertsCorrectly() {
-        // 10 meters (pure water)
-        assertEquals(1.9939, depthInMetersToBar(10.0, Environment.Default).value, DOUBLE_TOLERANCE)
+    private val environment = Environment(Salinity.WATER_EN13319, ATMOSPHERIC_PRESSURE_AT_SEA_LEVEL)
 
-        // 24 meters (pure water)
-        assertEquals(3.3668, depthInMetersToBar(24.0, Environment.Default).value, DOUBLE_TOLERANCE)
+    @Test
+    fun metersToAmbientPressure_convertsCorrectly() {
+        assertEquals(2.0135283, metersToAmbientPressure(10.0, environment).value, DOUBLE_TOLERANCE)
+        assertEquals(25.0199292, metersToAmbientPressure(240.0, environment).value, DOUBLE_TOLERANCE)
     }
 
     @Test
-    fun altitudeToPressure_convertsCorrectly() {
-        assertEquals(ATMOSPHERIC_PRESSURE_AT_SEA_LEVEL, altitudeToPressure(0.0), 1e-4)
-        assertEquals(0.7099843196815809, altitudeToPressure(3000.0), DOUBLE_TOLERANCE)
+    fun metersToAmbientPressure_zeroDepthReturnsSurfacePressure() {
+        assertEquals(environment.atmosphericPressure, metersToAmbientPressure(0.0, environment).value)
     }
 
     @Test
-    fun pressureToAltitude_convertsCorrectly() {
-        assertEquals(0.0, pressureToAltitude(ATMOSPHERIC_PRESSURE_AT_SEA_LEVEL), DOUBLE_TOLERANCE)
-        assertEquals(3000.0, pressureToAltitude(0.7099843196815809), DOUBLE_TOLERANCE)
+    fun metersToHydrostaticPressure_excludesAtmosphericPressure() {
+        val ambient = metersToAmbientPressure(10.0, environment).value
+        val hydrostatic = metersToHydrostaticPressure(10.0, environment).value
+        assertEquals(ambient - environment.atmosphericPressure, hydrostatic, DOUBLE_TOLERANCE)
+    }
+
+    @Test
+    fun ambientPressureToMeters_surfacePressureReturnsZero() {
+        assertEquals(0.0, ambientPressureToMeters(environment.atmosphericPressure, environment), DOUBLE_TOLERANCE)
+    }
+
+    @Test
+    fun feetToAmbientPressure_convertsCorrectly() {
+        assertEquals(2.0193699253, feetToAmbientPressure(33.0, environment).value, DOUBLE_TOLERANCE)
+        assertEquals(25.0076857936, feetToAmbientPressure(787.0, environment).value, DOUBLE_TOLERANCE)
+    }
+
+    @Test
+    fun feetToAmbientPressure_zeroDepthReturnsSurfacePressure() {
+        assertEquals(environment.atmosphericPressure, feetToAmbientPressure(0.0, environment).value)
+    }
+
+    @Test
+    fun feetToHydrostaticPressure_excludesAtmosphericPressure() {
+        val ambient = feetToAmbientPressure(33.0, environment).value
+        val hydrostatic = feetToHydrostaticPressure(33.0, environment).value
+        assertEquals(ambient - environment.atmosphericPressure, hydrostatic, DOUBLE_TOLERANCE)
+    }
+
+    @Test
+    fun ambientPressureToFeet_surfacePressureReturnsZero() {
+        assertEquals(0.0, ambientPressureToFeet(environment.atmosphericPressure, environment), DOUBLE_TOLERANCE)
     }
 }
 
-private val DOUBLE_TOLERANCE = 1e-4
+private const val DOUBLE_TOLERANCE = 1e-8

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannCcrTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannCcrTest.kt
@@ -14,7 +14,7 @@ package org.neotech.app.abysner.domain.decompression.algorithm.buhlmann
 
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -35,7 +35,7 @@ class BuhlmannCcrTest {
         val ocModel = createModel()
         val ccrModel = createModel()
 
-        val depth = depthInMetersToBar(30.0, environment)
+        val depth = metersToAmbientPressure(30.0, environment)
 
         ocModel.addPressureChange(depth, depth, Gas.Air, timeInMinutes = 30)
         ccrModel.addPressureChange(depth, depth, Gas.Air, timeInMinutes = 30, ccrSetpoint = 1.3)
@@ -56,7 +56,7 @@ class BuhlmannCcrTest {
         val singleCallModel = createModel()
         val multiCallModel = createModel()
 
-        val depth = depthInMetersToBar(30.0, environment)
+        val depth = metersToAmbientPressure(30.0, environment)
         val gas = Gas.Air
         val setpoint = 1.3
 
@@ -95,8 +95,8 @@ class BuhlmannCcrTest {
     fun ccrPressureChange_descentFlatAndAscentDoNotCrash() {
         val model = createModel()
 
-        val surface = depthInMetersToBar(0.0, environment)
-        val bottom = depthInMetersToBar(20.0, environment)
+        val surface = metersToAmbientPressure(0.0, environment)
+        val bottom = metersToAmbientPressure(20.0, environment)
         val gas = Gas.Air
         val setpoint = 1.3
 
@@ -114,8 +114,8 @@ class BuhlmannCcrTest {
     fun referencePlan6_producesExpectedNoDecompressionLimit() {
         // TODO once planner is CCR aware, this plan/test should move to DivePlannerTest
         val model = createModel(gfLow = 0.3, gfHigh = 0.7)
-        val surface = depthInMetersToBar(0.0, environment)
-        val bottom = depthInMetersToBar(30.0, environment)
+        val surface = metersToAmbientPressure(0.0, environment)
+        val bottom = metersToAmbientPressure(30.0, environment)
         val gas = Gas.Air
         val setpoint = 1.3
 
@@ -140,7 +140,7 @@ class BuhlmannCcrTest {
         val ocModel = createModel()
         val ccrModel = createModel()
 
-        val depth = depthInMetersToBar(30.0, environment)
+        val depth = metersToAmbientPressure(30.0, environment)
 
         val ocNdl = ocModel.getNoDecompressionLimit(depth, Gas.Air)
         val ccrNdl = ccrModel.getNoDecompressionLimit(depth, Gas.Air, ccrSetpoint = 1.3)
@@ -157,7 +157,7 @@ class BuhlmannCcrTest {
     @Test
     fun getNoDecompressionLimit_ccrDoesNotAlterTissueState() {
         val model = createModel()
-        val depth = depthInMetersToBar(30.0, environment)
+        val depth = metersToAmbientPressure(30.0, environment)
 
         val ceilingBefore = model.getCeiling()
         model.getNoDecompressionLimit(depth, Gas.Air, ccrSetpoint = 1.3)

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannTest.kt
@@ -2,7 +2,7 @@ package org.neotech.app.abysner.domain.decompression.algorithm.buhlmann
 
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.diveplanning.DivePlannerTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -38,7 +38,7 @@ class BuhlmannTest {
 
         depths.forEachIndexed { index, depth ->
             val ndlTime = model.getNoDecompressionLimit(
-                depthInMetersToBar(depth.toDouble(), environment),
+                metersToAmbientPressure(depth.toDouble(), environment),
                 Gas.Air
             )
             assertEquals(expectedNdlTimes[index], ndlTime)
@@ -60,7 +60,7 @@ class BuhlmannTest {
             gfLow = 0.3,
             gfHigh = 0.7,
         )
-        model.addFlat(depthInMetersToBar(30.0, environment), Gas.Air, 30)
+        model.addFlat(metersToAmbientPressure(30.0, environment), Gas.Air, 30)
 
         val first  = model.getCeiling()
         val second = model.getCeiling()
@@ -79,7 +79,7 @@ class BuhlmannTest {
             gfLow = 0.3,
             gfHigh = 0.7,
         )
-        val depth = depthInMetersToBar(30.0, environment)
+        val depth = metersToAmbientPressure(30.0, environment)
 
         model.addFlat(depth, Gas.Air, 20)
         val snapshot = model.snapshot()
@@ -103,7 +103,7 @@ class BuhlmannTest {
             gfLow = 0.3,
             gfHigh = 0.7,
         )
-        val depth = depthInMetersToBar(21.0, environment)
+        val depth = metersToAmbientPressure(21.0, environment)
         assertFailsWith<IllegalArgumentException>(
             message = "Expected IllegalArgumentException for timeInMinutes=0"
         ) {

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilitiesTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannUtilitiesTest.kt
@@ -13,7 +13,7 @@
 package org.neotech.app.abysner.domain.decompression.algorithm.buhlmann
 
 import org.neotech.app.abysner.domain.core.model.Environment
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.max
@@ -122,7 +122,7 @@ class BuhlmannUtilitiesTest {
         val nitrogenFractionDiluent = 0.20
         val setpoint = 1.0
         val surfacePressure = Environment.SeaLevelFresh.atmosphericPressure
-        val endPressure = depthInMetersToBar(90.0, Environment.SeaLevelFresh).value
+        val endPressure = metersToAmbientPressure(90.0, Environment.SeaLevelFresh).value
         val time = 5.0
         val pressureRate = (endPressure - surfacePressure) / time
         val initialNitrogenPressure = 0.79 * surfacePressure
@@ -174,7 +174,7 @@ class BuhlmannUtilitiesTest {
         val nitrogenFractionDiluent = 0.20
         val setpoint = 1.0
         val surfacePressure = Environment.SeaLevelFresh.atmosphericPressure
-        val endPressure = depthInMetersToBar(90.0, Environment.SeaLevelFresh).value
+        val endPressure = metersToAmbientPressure(90.0, Environment.SeaLevelFresh).value
         val time = 5.0
         val pressureRate = (endPressure - surfacePressure) / time
         val initialNitrogenPressure = 0.79 * surfacePressure

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculatorTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculatorTest.kt
@@ -16,7 +16,7 @@ import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
-import org.neotech.app.abysner.domain.core.physics.depthInMetersToBar
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -35,7 +35,7 @@ class OxygenToxicityCalculatorTest {
         val setpoint = 1.3
         val depth = 30.0
         val duration = 30
-        val ambientPressure = depthInMetersToBar(depth, environment).value
+        val ambientPressure = metersToAmbientPressure(depth, environment).value
 
         val ccrSegments = flatSegment(depth, duration, Gas.Trimix2135, BreathingMode.ccr(setpoint))
 
@@ -90,7 +90,7 @@ class OxygenToxicityCalculatorTest {
         val setpoint = 1.3
         val depth = 30.0
         val duration = 30
-        val ambientPressure = depthInMetersToBar(depth, environment).value
+        val ambientPressure = metersToAmbientPressure(depth, environment).value
 
         val ccrSegments = flatSegment(depth, duration, Gas.Trimix2135, BreathingMode.ccr(setpoint))
 

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/utilities/NumberExtensionsTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/utilities/NumberExtensionsTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.utilities
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NumberExtensionsTest {
+
+    @Test
+    fun equalsTolerant_trueForExactlyEqualValues() {
+        assertTrue(5.0.equalsTolerant(5.0))
+    }
+
+    @Test
+    fun equalsTolerant_trueForDifferenceWithinTolerance() {
+        assertTrue(5.0.equalsTolerant(5.0 + 1e-7))
+    }
+
+    @Test
+    fun equalsTolerant_falseForDifferenceOutsideTolerance() {
+        assertFalse(5.0.equalsTolerant(5.0 + 1e-5))
+    }
+
+    @Test
+    fun greaterThanTolerant_falseWhenWithinTolerance() {
+        assertFalse((5.0 + 1e-7).greaterThanTolerant(5.0))
+    }
+
+    @Test
+    fun greaterThanTolerant_trueWhenOutsideTolerance() {
+        assertTrue((5.0 + 1e-5).greaterThanTolerant(5.0))
+    }
+
+    @Test
+    fun greaterThanOrEqualTolerant_trueWhenWithinTolerance() {
+        assertTrue((5.0 - 1e-7).greaterThanOrEqualTolerant(5.0))
+    }
+
+    @Test
+    fun greaterThanOrEqualTolerant_falseWhenOutsideTolerance() {
+        assertFalse((5.0 - 1e-5).greaterThanOrEqualTolerant(5.0))
+    }
+
+    @Test
+    fun lessThanTolerant_falseWhenWithinTolerance() {
+        assertFalse((5.0 - 1e-7).lessThanTolerant(5.0))
+    }
+
+    @Test
+    fun lessThanTolerant_trueWhenOutsideTolerance() {
+        assertTrue((5.0 - 1e-5).lessThanTolerant(5.0))
+    }
+
+    @Test
+    fun lessThanOrEqualTolerant_trueWhenWithinTolerance() {
+        assertTrue((5.0 + 1e-7).lessThanOrEqualTolerant(5.0))
+    }
+
+    @Test
+    fun lessThanOrEqualTolerant_falseWhenOutsideTolerance() {
+        assertFalse((5.0 + 1e-5).lessThanOrEqualTolerant(5.0))
+    }
+
+    @Test
+    fun ceilTolerant_floorsWhenWithinTolerance() {
+        assertEquals(9.0, ceilTolerant(9.0000000002))
+    }
+
+    @Test
+    fun ceilTolerant_ceilsWhenOutsideTolerance() {
+        assertEquals(10.0, ceilTolerant(9.5))
+    }
+
+    @Test
+    fun ceilTolerant_returnsExactInteger() {
+        assertEquals(9.0, ceilTolerant(9.0))
+    }
+
+    @Test
+    fun floorTolerant_ceilsWhenWithinTolerance() {
+        assertEquals(3.0, floorTolerant(2.9999999998))
+    }
+
+    @Test
+    fun floorTolerant_floorsWhenOutsideTolerance() {
+        assertEquals(2.0, floorTolerant(2.5))
+    }
+
+    @Test
+    fun floorTolerant_returnsExactInteger() {
+        assertEquals(3.0, floorTolerant(3.0))
+    }
+
+    @Test
+    fun removeFloatingPointNoise_removesNoiseWithinTolerance() {
+        assertEquals(6.0, removeFloatingPointNoise(6.000000000000001))
+    }
+
+    @Test
+    fun removeFloatingPointNoise_preservesDecimalsOutsideTolerance() {
+        assertEquals(6.123456, removeFloatingPointNoise(6.123456))
+    }
+}


### PR DESCRIPTION
Added floating-point tolerance comparison functions and noise remove function, and feet-based pressure conversion functions. Renamed `depthInMetersToBar` to `metersToAmbientPressure` and `barToDepthInMeters` to `ambientPressureToMeters`.

Required for: #49 