### PR TITLE
Refactor: Make `GasSelection` API pressure-based

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
@@ -15,6 +15,7 @@ package org.neotech.app.abysner.domain.core.model
 import org.neotech.app.abysner.domain.core.physics.ambientPressureToMeters
 import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.utilities.DecimalFormat
+import kotlin.math.floor
 import kotlin.math.round
 
 data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
@@ -34,32 +35,49 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
     val nitrogenFraction = (1.0 - (oxygenFraction + heliumFraction))
 
     /**
-     * Returns the oxygen MOD in meters.
+     * Returns the oxygen MOD as absolute ambient pressure in bar.
+     */
+    fun oxygenModAmbientPressure(ppO2: Double): Double = ppO2 / oxygenFraction
+
+    /**
+     * Returns the oxygen MOD in depth meters for the given environment.
+     * TODO: this method must be made unit aware when imperial unit support is added.
      */
     fun oxygenMod(ppO2: Double, environment: Environment): Double {
-        return ambientPressureToMeters(ppO2 / this.oxygenFraction, environment)
+        return ambientPressureToMeters(oxygenModAmbientPressure(ppO2), environment)
     }
 
     /**
-     * Returns the oxygen MOD in meters, rounded to the nearest integer.
+     * Returns the oxygen MOD in depth meters, floored to a whole number while taking into account
+     * the [MOD_TOLERANCE], which adds a bit of margin to the allowed ambient pressure for this gas
+     * before making the conversion. This allows values like 20.92 meters to become 21 meters,
+     * instead of being floored to 20 meters. Which is often closer to what divers expect, as they
+     * often work with rules of thumb.
+     *
+     * This approach is very similar to simply rounding the true MOD in meters to the nearest
+     * integer. However since it operates on the raw ambient pressure this will keep working for
+     * imperial units as well, however it is probably less important for imperial units since the
+     * feet granularity is finer than meters.
+     *
+     * [findBestGas][org.neotech.app.abysner.domain.core.model.findBestGas] and this method both
+     * use the same tolerances, so switch depths are consistent with the MODs shown to the user
+     * (except those clamp to a 3 meter or 10 feet step size).
+     *
+     * TODO: this method must be made unit aware when imperial unit support is added.
      */
-    fun oxygenModRounded(ppO2: Double, environment: Environment): Int {
-        return round(oxygenMod(ppO2, environment)).toInt()
+    fun oxygenModRounded(ppO2: Double, environment: Environment, modTolerance: Double = MOD_TOLERANCE): Int {
+        return floor(ambientPressureToMeters(oxygenModAmbientPressure(ppO2) + modTolerance, environment)).toInt()
     }
 
     /**
-     * Calculates END (Equivalent Narcotic Depth). Only Oxygen and Nitrogen are considered in this
-     * calculation.
+     * Calculates END (Equivalent Narcotic Depth) as absolute ambient pressure in bar. Only oxygen
+     * and nitrogen are considered narcotic.
      *
      * https://en.wikipedia.org/wiki/Equivalent_narcotic_depth
      */
-    fun endInMeters(depth: Double, environment: Environment): Double {
-        // Helium has a narc factor of 0 while N2 and O2 have a narc factor of 1
-        val narcIndex = (this.oxygenFraction) + (this.nitrogenFraction)
-
-        val bars = metersToAmbientPressure(depth, environment)
-        val equivalentBars = bars.value * narcIndex
-        return ambientPressureToMeters(equivalentBars, environment)
+    fun endAmbientPressure(ambientPressure: Double): Double {
+        val narcIndex = oxygenFraction + nitrogenFraction
+        return ambientPressure * narcIndex
     }
 
     val density: Double by lazy {
@@ -69,21 +87,35 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
         oxygenDensity + heliumDensity + nitrogenDensity
     }
 
+    fun densityAtAmbientPressure(ambientPressure: Double): Double = density * ambientPressure
+
     fun densityAtDepth(depth: Double, environment: Environment): Double {
-        val bar = metersToAmbientPressure(depth, environment)
-        return density * bar.value
+        return densityAtAmbientPressure(metersToAmbientPressure(depth, environment).value)
     }
 
     /**
-     * Returns the gas density MOD in meters.
+     * Returns the gas density MOD as absolute ambient pressure in bar.
+     */
+    fun densityModAmbientPressure(maxAllowedDensity: Double = MAX_GAS_DENSITY): Double =
+        maxAllowedDensity / density
+
+    /**
+     * Returns the gas density MOD in depth meters.
+     *
+     * TODO: this method must be made unit aware when imperial unit support is added.
      */
     fun densityMod(maxAllowedDensity: Double = MAX_GAS_DENSITY, environment: Environment): Double {
-        val bar = maxAllowedDensity / density
-        return ambientPressureToMeters(bar, environment)
+        return ambientPressureToMeters(densityModAmbientPressure(maxAllowedDensity), environment)
     }
 
     /**
-     * Returns the gas density MOD in meters, rounded to the nearest integer.
+     * Returns the gas density MOD in depth meters, rounded to the nearest integer.
+     *
+     * TODO: this method must be made unit aware when imperial unit support is added. Note that
+     *       rounding here is fine in both metric and imperial units, since there are not really
+     *       rules of thumb for density MODs like there are for oxygen MODs. So a tolerance on
+     *       pressure would not be required here. In metric we round a bit more compared to
+     *       imperial, but that is fine.
      */
     fun densityModRounded(maxAllowedDensity: Double = MAX_GAS_DENSITY, environment: Environment): Int {
         return round(densityMod(maxAllowedDensity, environment)).toInt()
@@ -142,6 +174,17 @@ data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
         const val MAX_GAS_DENSITY = 6.2
         const val MAX_PPO2 = 1.6
         const val MIN_PPO2 = 0.16
+
+        /**
+         * Pressure tolerance in bar for MOD comparisons. Divers traditionally used rule of thumb
+         * methods for MOD calculations and some mixes are generally accepted to be usable at
+         * certain depths. For example 100% oxygen is commonly accepted to be usable till 6m/20ft,
+         * even though the true MOD is around 5.8 meters. This tolerance allows the app to meet
+         * diver expectations and match traditional rules of thumb. The 0.05 bar tolerance
+         * corresponds to roughly half a meter. This tolerance matters mostly for metric divers,
+         * since imperial units (feet) the granularity is finer to begin with.
+         */
+        const val MOD_TOLERANCE = 0.05
 
         val Air = Gas(oxygenFraction = 0.21, heliumFraction = 0.0)
         val Nitrox28 = Gas(oxygenFraction = 0.28, heliumFraction = 0.0)

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/GasSelection.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/GasSelection.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2026 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -12,31 +12,35 @@
 
 package org.neotech.app.abysner.domain.core.model
 
-import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
-import kotlin.math.round
-
 /**
- * Returns the best gas in the list for the current depth. Filters on oxygen MOD (by [maxPpO2]),
- * then prefers gases that satisfy [maxEND]. If multiple gases satisfy END, then the highest oxygen
- * fraction is chosen, otherwise the highest helium fraction. If nothing satisfies the END
- * constraint, the END constraint is dropped and the highest oxygen fraction gas within MOD is
- * returned (helium as tiebreaker). Returns null if no gas satisfies the oxygen MOD at all.
+ * Returns the best gas in the list for the given ambient pressure. Filters on oxygen MOD (by
+ * [maxPpO2]), then prefers gases that satisfy the END constraint
+ * ([maxEquivalentNarcoticAmbientPressure]). If multiple gases satisfy END, the highest oxygen
+ * fraction within MOD is chosen (helium as tiebreaker). If nothing satisfies the END constraint,
+ * the END constraint is dropped and the highest oxygen fraction gas within MOD is returned (helium
+ * as tiebreaker). Returns null if no gas satisfies the oxygen MOD at all.
  *
  * Density is intentionally not included as a constraint here: higher-O2 deco gases are denser, so
  * including density would bias the selection away from exactly the gases chosen for their
  * off-gassing properties. Density warnings are shown to the user separately.
+ *
+ * @param modTolerance small pressure allowance (bar) added to the oxygen MOD limit. Divers expect
+ * some common gasses to be usable certain depths for example oxygen at 6 meters with ppO2 1.6,
+ * even when the true MOD is shallower. Defaults to [Gas.MOD_TOLERANCE].
  */
-fun List<Cylinder>.findBestGas(depth: Double, environment: Environment, maxPpO2: Double, maxEND: Double): Cylinder? {
+fun List<Cylinder>.findBestGas(
+    ambientPressure: Double,
+    maxPpO2: Double,
+    maxEquivalentNarcoticAmbientPressure: Double,
+    modTolerance: Double = Gas.MOD_TOLERANCE,
+): Cylinder? {
     // Step 1: Filter: Don't even consider gas that is beyond the MOD
     return filter {
-        // Note: we use round here, since that better matches some divers expectations of certain
-        // gases being usable at certain depths. Even if the ppO2 would be ever so slightly above
-        // the max. The safer option would be floor, but that is not matching expectations.
-        depth <= round(it.gas.oxygenMod(maxPpO2, environment))
+        ambientPressure <= it.gas.oxygenModAmbientPressure(maxPpO2) + modTolerance
     }.maxWithOrNull(
         compareBy(
             // Step 2: Prefer gas that is within END
-            { round(it.gas.endInMeters(depth, environment)) <= maxEND },
+            { it.gas.endAmbientPressure(ambientPressure) <= maxEquivalentNarcoticAmbientPressure },
             // Step 3: Tie? Prefer the higher oxygen fraction (will be valid within MOD)
             { it.gas.oxygenFraction },
             // Step 4: Still a tie? Prefer the higher helium fraction (lower density)
@@ -49,13 +53,13 @@ fun List<Cylinder>.findBestGas(depth: Double, environment: Environment, maxPpO2:
 }
 
 /**
- * Last-resort fallback when [findBestGas] returns null (no gas satisfies the O2 MOD at this depth).
- * Prefers the lowest-O2 non-hypoxic candidate to minimize toxicity risk. If everything is hypoxic,
- * picks the highest-O2 option as the least-bad choice. Returns null if the list is empty.
+ * Last-resort fallback when [findBestGas] returns null (no gas satisfies the O2 MOD at this
+ * ambient pressure). Prefers the lowest-O2 non-hypoxic candidate to minimize toxicity risk. If
+ * everything is hypoxic, picks the highest-O2 option as the least-bad choice. Returns null if the
+ * list is empty.
  */
-internal fun List<Cylinder>.findBreathableFallbackGas(depth: Double, environment: Environment, minPPO2: Double = Gas.MIN_PPO2, ): Cylinder? {
-    val pressure = metersToAmbientPressure(depth, environment).value
-    val nonHypoxic = filter { it.gas.oxygenFraction * pressure >= minPPO2 }
+internal fun List<Cylinder>.findBreathableFallbackGas(ambientPressure: Double, minPPO2: Double = Gas.MIN_PPO2): Cylinder? {
+    val nonHypoxic = filter { it.gas.oxygenFraction * ambientPressure >= minPPO2 }
     return if (nonHypoxic.isNotEmpty()) {
         nonHypoxic.minByOrNull { it.gas.oxygenFraction }
     } else {
@@ -69,17 +73,17 @@ internal fun List<Cylinder>.findBreathableFallbackGas(depth: Double, environment
  */
 fun List<Cylinder>.findBetterGasOrFallback(
     currentCylinder: Cylinder?,
-    depth: Double,
-    environment: Environment,
+    ambientPressure: Double,
     maxPPO2: Double,
-    maxEND: Double,
+    maxEquivalentNarcoticAmbientPressure: Double,
+    modTolerance: Double = Gas.MOD_TOLERANCE,
     minPPO2: Double = Gas.MIN_PPO2
 ): Cylinder? {
-    val best = findBestGas(depth, environment, maxPPO2, maxEND)
+    val best = findBestGas(ambientPressure, maxPPO2, maxEquivalentNarcoticAmbientPressure, modTolerance)
     if (best != null) {
         return best
     } else {
-        val fallback = findBreathableFallbackGas(depth, environment, minPPO2) ?: return currentCylinder
+        val fallback = findBreathableFallbackGas(ambientPressure, minPPO2) ?: return currentCylinder
         // Only switch to the fallback if it is better than the current gas (see findBreathableFallbackGas).
         return if (currentCylinder == null || fallback.gas.oxygenFraction < currentCylinder.gas.oxygenFraction) {
             fallback

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
@@ -212,7 +212,7 @@ class DecompressionPlanner(
         while (currentDepth > toDepth) {
             if (!isCcr) {
                 // Check if there is a better gas to breath at the current depth
-                val betterDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, depth = currentDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
+                val betterDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, ambientPressure = metersToAmbientPressure(currentDepth, environment).value, maxPPO2 = maxppO2, maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEND, environment).value)
                 // Only start using the better gas when we reach a deco increment point
 
                 if (betterDecoGas != null && betterDecoGas.gas != gas.gas && currentDepth.toInt() % decoStepSize == 0) {
@@ -235,7 +235,7 @@ class DecompressionPlanner(
                 var nextDepth = currentDepth - 1
                 var nextDecoGas: Cylinder?
                 while(nextDepth >= targetDepth) {
-                    nextDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, depth = nextDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
+                    nextDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, ambientPressure = metersToAmbientPressure(nextDepth, environment).value, maxPPO2 = maxppO2, maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEND, environment).value)
                     if (nextDecoGas != null && nextDecoGas.gas != gas.gas && nextDepth.toInt() % decoStepSize == 0) {
                         targetDepth = nextDepth
                         break
@@ -266,7 +266,7 @@ class DecompressionPlanner(
         }
 
         if (!isCcr) {
-            val betterDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, depth = currentDepth, environment = environment, maxPPO2 = maxppO2, maxEND = maxEND)
+            val betterDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, ambientPressure = metersToAmbientPressure(currentDepth, environment).value, maxPPO2 = maxppO2, maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEND, environment).value)
             if (betterDecoGas != null && betterDecoGas.gas != gas.gas && currentDepth.toInt() % decoStepSize == 0) {
                 // Gas switch time on the old gas before switching
                 addGasSwitch(currentDepth, gas, gasSwitchTime, effectiveBreathingMode)
@@ -312,10 +312,9 @@ class DecompressionPlanner(
         if (isBailout) {
             val bestBailoutGas = decoGases.findBetterGasOrFallback(
                 currentCylinder = null,
-                depth = fromDepth,
-                environment = environment,
+                ambientPressure = metersToAmbientPressure(fromDepth, environment).value,
                 maxPPO2 = maxPpO2,
-                maxEND = maxEquivalentNarcoticDepth
+                maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEquivalentNarcoticDepth, environment).value
             )
             if (bestBailoutGas != null) {
                 addGasSwitch(fromDepth, gas, 1, breathingMode)
@@ -333,7 +332,7 @@ class DecompressionPlanner(
         // Check if there is a better gas to switch to at the current depth before
         // ascending. Gas switching is skipped in CCR mode (diver stays on the loop).
         if (!isCcr) {
-            val betterGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, depth = fromDepth, environment = environment, maxPPO2 = maxPpO2, maxEND = maxEquivalentNarcoticDepth)
+            val betterGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, ambientPressure = metersToAmbientPressure(fromDepth, environment).value, maxPPO2 = maxPpO2, maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEquivalentNarcoticDepth, environment).value)
             if (betterGas != null && betterGas.gas != gas.gas) {
                 // Gas switch time on the old gas before switching
                 addGasSwitch(fromDepth, gas, gasSwitchTime, breathingMode)

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasSelectionTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasSelectionTest.kt
@@ -1,6 +1,6 @@
 /*
  * Abysner - Dive planner
- * Copyright (C) 2026 Neotech
+ * Copyright (C) 2024-2026 Neotech
  *
  * Abysner is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License version 3,
@@ -12,6 +12,7 @@
 
 package org.neotech.app.abysner.domain.core.model
 
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -22,78 +23,121 @@ class GasSelectionTest {
 
     private fun cylinders(vararg gas: Gas) = gas.map { Cylinder.steel12Liter(it) }
 
+    private fun ambient(meters: Double): Double = metersToAmbientPressure(meters, environment).value
+
     @Test
     fun findBestGas_returnsNullWhenAllGasesExceedMaxPPO2() {
         val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50, Gas.Oxygen)
-        assertNull(cylinders.findBestGas(depth = 70.0, environment = environment, maxPpO2 = 1.6, maxEND = END_UNSPECIFIED))
+        val bestGas = cylinders.findBestGas(
+            ambientPressure = ambient(meters = 70.0),
+            maxPpO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = END_UNSPECIFIED
+        )
+        assertNull(bestGas)
     }
 
     @Test
     fun findBestGas_returnsHighestOxygenGasWithinModWhenAllSatisfyEnd() {
         val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50)
-        assertEquals(Gas.Nitrox50, cylinders.findBestGas(depth = 20.0, environment = environment, maxPpO2 = 1.6, maxEND = 40.0)?.gas)
+        val bestGas = cylinders.findBestGas(
+            ambientPressure = ambient(meters = 20.0),
+            maxPpO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = ambient(meters = 40.0)
+        )
+        assertEquals(Gas.Nitrox50, bestGas?.gas)
     }
 
     @Test
     fun findBestGas_excludesGasThatExceedsItsMod() {
         val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50)
-        assertEquals(Gas.Nitrox32, cylinders.findBestGas(depth = 25.0, environment = environment, maxPpO2 = 1.6, maxEND = 40.0)?.gas)
+        val bestGas = cylinders.findBestGas(
+            ambientPressure = ambient(meters = 25.0),
+            maxPpO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = ambient(meters = 40.0)
+        )
+        assertEquals(Gas.Nitrox32, bestGas?.gas)
     }
 
     @Test
     fun findBestGas_prefersIdealCandidateOverFallback() {
-        // Air END is 40 meter and exceeds the maxEND, however Trimix2135 is belo the maxEND (about 22 meters)
+        // Air END is 40 meter and exceeds the maxEND, however Trimix2135 is below the maxEND (about 22 meters)
         val cylinders = cylinders(Gas.Air, Gas.Trimix2135)
-        assertEquals(Gas.Trimix2135, cylinders.findBestGas(depth = 40.0, environment = environment, maxPpO2 = 1.6, maxEND = 30.0)?.gas)
+        val bestGas = cylinders.findBestGas(
+            ambientPressure = ambient(meters = 40.0),
+            maxPpO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = ambient(meters = 30.0)
+        )
+        assertEquals(Gas.Trimix2135, bestGas?.gas)
     }
 
     @Test
     fun findBestGas_returnsHighestOxygenWithinModWhenNoGasSatisfiesEnd() {
         val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50)
-        assertEquals(Gas.Nitrox32, cylinders.findBestGas(depth = 40.0, environment = environment, maxPpO2 = 1.6, maxEND = 20.0)?.gas)
+        val bestGas = cylinders.findBestGas(
+            ambientPressure = ambient(meters = 40.0),
+            maxPpO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = ambient(meters = 20.0)
+        )
+        assertEquals(Gas.Nitrox32, bestGas?.gas)
     }
 
     @Test
     fun findBestGas_prefersHigherHeliumWhenOxygenFractionsAreEqualAndEndIsUnspecified() {
         val cylinders = cylinders(Gas.Air, Gas.Trimix2135)
-        assertEquals(Gas.Trimix2135, cylinders.findBestGas(depth = 50.0, environment = environment, maxPpO2 = 1.6, maxEND = END_UNSPECIFIED)?.gas)
+        val bestGas = cylinders.findBestGas(
+            ambientPressure = ambient(meters = 50.0),
+            maxPpO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = END_UNSPECIFIED
+        )
+        assertEquals(Gas.Trimix2135, bestGas?.gas)
     }
 
     @Test
     fun findBestGas_prefersHigherHeliumWhenOxygenFractionsAreEqualAndNoGasSatisfiesEnd() {
         val cylinders = cylinders(Gas.Air, Gas.Trimix2135)
-        assertEquals(Gas.Trimix2135, cylinders.findBestGas(depth = 50.0, environment = environment, maxPpO2 = 1.6, maxEND = 20.0)?.gas)
+        val bestGas = cylinders.findBestGas(
+            ambientPressure = ambient(meters = 50.0),
+            maxPpO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = ambient(meters = 20.0)
+        )
+        assertEquals(Gas.Trimix2135, bestGas?.gas)
     }
 
     @Test
     fun findBreathableFallbackGas_returnsLowestOxygenAmongHyperoxicGases() {
         val cylinders = cylinders(Gas.Nitrox50, Gas.Nitrox32)
-        assertEquals(Gas.Nitrox32, cylinders.findBreathableFallbackGas(depth = 10.0, environment = environment)?.gas)
+        assertEquals(Gas.Nitrox32, cylinders.findBreathableFallbackGas(ambientPressure = ambient(meters = 10.0))?.gas)
     }
 
     @Test
     fun findBreathableFallbackGas_returnsHighestOxygenWhenAllGasesAreHypoxic() {
         val cylinders = cylinders(Gas.Trimix1070, Gas.Trimix1555)
-        assertEquals(Gas.Trimix1555, cylinders.findBreathableFallbackGas(depth = 0.0, environment = environment)?.gas)
+        assertEquals(Gas.Trimix1555, cylinders.findBreathableFallbackGas(ambientPressure = ambient(meters = 0.0))?.gas)
     }
 
     @Test
     fun findBreathableFallbackGas_ignoresHypoxicGasesWhenNonHypoxicAvailable() {
         val cylinders = cylinders(Gas.Trimix1070, Gas.Trimix1555, Gas.Trimix1845, Gas.Trimix2135)
-        assertEquals(Gas.Trimix1845, cylinders.findBreathableFallbackGas(depth = 0.0, environment = environment)?.gas)
+        assertEquals(Gas.Trimix1845, cylinders.findBreathableFallbackGas(ambientPressure = ambient(meters = 0.0))?.gas)
     }
 
     @Test
     fun findBreathableFallbackGas_respectsCustomMinPPO2() {
         val cylinders = cylinders(Gas.Air, Gas.Nitrox50)
-        assertEquals(Gas.Nitrox50, cylinders.findBreathableFallbackGas(depth = 10.0, environment = environment, minPPO2 = 0.50)?.gas)
+        assertEquals(Gas.Nitrox50, cylinders.findBreathableFallbackGas(ambientPressure = ambient(meters = 10.0), minPPO2 = 0.50)?.gas)
     }
 
     @Test
     fun findBetterGasOrFallback_returnsBestGasWhenAvailable() {
         val currentCylinder = Cylinder.steel12Liter(Gas.Air)
         val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50)
-        assertEquals(Gas.Nitrox50, cylinders.findBetterGasOrFallback(currentCylinder = currentCylinder, depth = 20.0, environment = environment, maxPPO2 = 1.6, maxEND = 40.0)?.gas)
+        val result = cylinders.findBetterGasOrFallback(
+            currentCylinder = currentCylinder,
+            ambientPressure = ambient(meters = 20.0),
+            maxPPO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = ambient(meters = 40.0)
+        )
+        assertEquals(Gas.Nitrox50, result?.gas)
     }
 
     @Test
@@ -102,7 +146,13 @@ class GasSelectionTest {
         // Current gas is Nitrox32 (higher O2 than Air), so Air is genuinely a better (less toxic) option.
         val currentCylinder = Cylinder.steel12Liter(Gas.Nitrox32)
         val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50, Gas.Oxygen)
-        assertEquals(Gas.Air, cylinders.findBetterGasOrFallback(currentCylinder = currentCylinder, depth = 70.0, environment = environment, maxPPO2 = 1.6, maxEND = END_UNSPECIFIED)?.gas)
+        val result = cylinders.findBetterGasOrFallback(
+            currentCylinder = currentCylinder,
+            ambientPressure = ambient(meters = 70.0),
+            maxPPO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = END_UNSPECIFIED
+        )
+        assertEquals(Gas.Air, result?.gas)
     }
 
     @Test
@@ -111,7 +161,13 @@ class GasSelectionTest {
         // return Nitrox50, but Air already has lower O2, so the current gas (Air) is returned.
         val currentCylinder = Cylinder.steel12Liter(Gas.Air)
         val cylinders = cylinders(Gas.Nitrox50)
-        assertEquals(Gas.Air, cylinders.findBetterGasOrFallback(currentCylinder = currentCylinder, depth = 30.0, environment = environment, maxPPO2 = 1.6, maxEND = END_UNSPECIFIED)?.gas)
+        val result = cylinders.findBetterGasOrFallback(
+            currentCylinder = currentCylinder,
+            ambientPressure = ambient(meters = 30.0),
+            maxPPO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = END_UNSPECIFIED
+        )
+        assertEquals(Gas.Air, result?.gas)
     }
 }
 

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasTest.kt
@@ -19,12 +19,54 @@ import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 class GasTest {
 
     @Test
-    fun oxygenMod_returnsCorrectModForOxygen() {
-        assertEquals(
-            5.983,
-            Gas.Oxygen.oxygenMod(1.6, Environment.Default),
-            DOUBLE_PRECISION_DELTA
-        )
+    fun oxygenMod_returnsCorrectModForCommonGases() {
+        assertEquals(40.653, Gas.Nitrox28.oxygenMod(1.4, Environment.SeaLevelFresh), DOUBLE_TOLERANCE)
+        assertEquals(39.469, Gas.Nitrox28.oxygenMod(1.4, Environment.SeaLevelSalt), DOUBLE_TOLERANCE)
+
+        assertEquals(34.280, Gas.Nitrox32.oxygenMod(1.4, Environment.SeaLevelFresh), DOUBLE_TOLERANCE)
+        assertEquals(33.281, Gas.Nitrox32.oxygenMod(1.4, Environment.SeaLevelSalt), DOUBLE_TOLERANCE)
+
+        assertEquals(22.299, Gas.Nitrox50.oxygenMod(1.6, Environment.SeaLevelFresh), DOUBLE_TOLERANCE)
+        assertEquals(21.649, Gas.Nitrox50.oxygenMod(1.6, Environment.SeaLevelSalt), DOUBLE_TOLERANCE)
+
+        assertEquals(10.062, Gas.Nitrox80.oxygenMod(1.6, Environment.SeaLevelFresh), DOUBLE_TOLERANCE)
+        assertEquals(9.769, Gas.Nitrox80.oxygenMod(1.6, Environment.SeaLevelSalt), DOUBLE_TOLERANCE)
+
+        assertEquals(5.983, Gas.Oxygen.oxygenMod(1.6, Environment.SeaLevelFresh), DOUBLE_TOLERANCE)
+        assertEquals(5.809, Gas.Oxygen.oxygenMod(1.6, Environment.SeaLevelSalt), DOUBLE_TOLERANCE)
+    }
+
+    @Test
+    fun oxygenModRounded_matchesCommonlyAcceptedDepths() {
+        // EAN28 is commonly accepted at 40 meter at 1.4 ppO2. However, even with a tolerance of
+        // about half a meter it does not qualify for 40 meter dives in salt water at 1013 millibar
+        // atmospheric pressure. I guess divers just have to accept that, the current tolerance is
+        // big enough to allow for rounding in meters that makes sense, but the idea is not to
+        // always match rules of thumb.
+        //
+        // 1.4 / 0,28 = 5     bar ambient
+        // 5 - 1,013  = 3,987 bar hydrostatic
+        //
+        // Pressure per meter in salt water: 1030 kg/m3 * 9.81 m/s2 / 100000 Pa/bar = 0.101043 bar/m
+        //
+        // Max depth 28% = 3.987 / 0.101043 = 39.45 meter
+        //
+        // If we would use Environment.SeaLevelSaltEn13319 instead of Environment.SeaLevelSalt
+        // it would just about qualify for 40 meter dives.
+        assertEquals(41, Gas.Nitrox28.oxygenModRounded(1.4, Environment.SeaLevelFresh))
+        assertEquals(39, Gas.Nitrox28.oxygenModRounded(1.4, Environment.SeaLevelSalt))
+
+        assertEquals(34, Gas.Nitrox32.oxygenModRounded(1.4, Environment.SeaLevelFresh))
+        assertEquals(33, Gas.Nitrox32.oxygenModRounded(1.4, Environment.SeaLevelSalt))
+
+        assertEquals(22, Gas.Nitrox50.oxygenModRounded(1.6, Environment.SeaLevelFresh))
+        assertEquals(22, Gas.Nitrox50.oxygenModRounded(1.6, Environment.SeaLevelSalt))
+
+        assertEquals(10, Gas.Nitrox80.oxygenModRounded(1.6, Environment.SeaLevelFresh))
+        assertEquals(10, Gas.Nitrox80.oxygenModRounded(1.6, Environment.SeaLevelSalt))
+
+        assertEquals(6, Gas.Oxygen.oxygenModRounded(1.6, Environment.SeaLevelFresh))
+        assertEquals(6, Gas.Oxygen.oxygenModRounded(1.6, Environment.SeaLevelSalt))
     }
 
     @Test
@@ -39,23 +81,23 @@ class GasTest {
         assertEquals(
             2.568,
             Gas.Air.densityAtDepth(10.0, Environment.SeaLevelFresh),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
         assertEquals(
             2.606,
             Gas.Air.densityAtDepth(10.0, Environment.SeaLevelSalt),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
 
         assertEquals(
             1.819,
             Gas.Trimix2135.densityAtDepth(10.0, Environment.SeaLevelFresh),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
         assertEquals(
             1.846,
             Gas.Trimix2135.densityAtDepth(10.0, Environment.SeaLevelSalt),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
     }
 
@@ -64,53 +106,53 @@ class GasTest {
         assertEquals(
             38.746,
             Gas.Air.densityMod(Gas.MAX_GAS_DENSITY, Environment.SeaLevelFresh),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
         assertEquals(
             37.618,
             Gas.Air.densityMod(Gas.MAX_GAS_DENSITY, Environment.SeaLevelSalt),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
 
         assertEquals(
             58.943,
             Gas.Trimix2135.densityMod(Gas.MAX_GAS_DENSITY, Environment.SeaLevelFresh),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
         assertEquals(
             57.226,
             Gas.Trimix2135.densityMod(Gas.MAX_GAS_DENSITY, Environment.SeaLevelSalt),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
 
         assertEquals(
             30.830,
             Gas.Air.densityMod(Gas.MAX_RECOMMENDED_GAS_DENSITY, Environment.SeaLevelFresh),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
         assertEquals(
             29.932,
             Gas.Air.densityMod(Gas.MAX_RECOMMENDED_GAS_DENSITY, Environment.SeaLevelSalt),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
 
         assertEquals(
             47.769,
             Gas.Trimix2135.densityMod(Gas.MAX_RECOMMENDED_GAS_DENSITY, Environment.SeaLevelFresh),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
         assertEquals(
             46.378,
             Gas.Trimix2135.densityMod(Gas.MAX_RECOMMENDED_GAS_DENSITY, Environment.SeaLevelSalt),
-            DOUBLE_PRECISION_DELTA
+            DOUBLE_TOLERANCE
         )
     }
 
     @Test
     fun inspiredGas_normalDepthProducesExpectedMix() {
         val inspired = Gas.Air.inspiredGas(metersToAmbientPressure(30.0, Environment.SeaLevelFresh).value, 1.3)
-        assertEquals(0.328, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
-        assertEquals(0.0, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
+        assertEquals(0.328, inspired.oxygenFraction, DOUBLE_TOLERANCE)
+        assertEquals(0.0, inspired.heliumFraction, DOUBLE_TOLERANCE)
     }
 
     /**
@@ -120,8 +162,8 @@ class GasTest {
     @Test
     fun inspiredGas_shallowDepthClampsToMaximumOxygenFraction() {
         val inspired = Gas.Air.inspiredGas(metersToAmbientPressure(2.0, Environment.SeaLevelFresh).value, 1.3)
-        assertEquals(1.0, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
-        assertEquals(0.0, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
+        assertEquals(1.0, inspired.oxygenFraction, DOUBLE_TOLERANCE)
+        assertEquals(0.0, inspired.heliumFraction, DOUBLE_TOLERANCE)
     }
 
     /**
@@ -134,16 +176,16 @@ class GasTest {
     fun inspiredGas_deepDepthClampsToMinimumDiluentOxygenFraction() {
         // At very deep depth, setpoint / ambient < diluent O2, should clamp to diluent O2
         val inspired = Gas.Air.inspiredGas(metersToAmbientPressure(200.0, Environment.SeaLevelFresh).value, 0.5)
-        assertEquals(Gas.Air.oxygenFraction, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
-        assertEquals(Gas.Air.heliumFraction, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
+        assertEquals(Gas.Air.oxygenFraction, inspired.oxygenFraction, DOUBLE_TOLERANCE)
+        assertEquals(Gas.Air.heliumFraction, inspired.heliumFraction, DOUBLE_TOLERANCE)
     }
 
     @Test
     fun inspiredGas_trimixDiluentScalesHeliumCorrectly() {
         val inspired = Gas.Trimix2135.inspiredGas(metersToAmbientPressure(30.0, Environment.SeaLevelFresh).value, 1.3)
-        assertEquals(0.328, inspired.oxygenFraction, DOUBLE_PRECISION_DELTA)
-        assertEquals(0.298, inspired.heliumFraction, DOUBLE_PRECISION_DELTA)
+        assertEquals(0.328, inspired.oxygenFraction, DOUBLE_TOLERANCE)
+        assertEquals(0.298, inspired.heliumFraction, DOUBLE_TOLERANCE)
     }
 }
 
-private const val DOUBLE_PRECISION_DELTA = 1e-3
+private const val DOUBLE_TOLERANCE = 1e-3

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/physics/PolynomialRealGasModelTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/physics/PolynomialRealGasModelTest.kt
@@ -35,4 +35,4 @@ class PolynomialRealGasModelTest {
     }
 }
 
-private val DOUBLE_TOLERANCE = 1e-6
+private const val DOUBLE_TOLERANCE = 1e-6


### PR DESCRIPTION
This changes the `GasSelection` functions to accept ambient pressure instead of depth in meters (and an environment), this allows for depth-unit agnostic gas selection.

Required for: #49