### PR TITLE
Refactor: Make `DecompressionPlanner` work with pressure instead of depth

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPropertiesComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/GasPropertiesComponent.kt
@@ -90,7 +90,7 @@ fun GasPropertiesComponent(
             horizontalArrangement = Arrangement.spacedBy(12.dp)) {
 
             val mod = gas?.let {
-                "${round(it.oxygenMod(maxPPO2, environment)).toInt()}m"
+                "${it.oxygenModRounded(maxPPO2, environment)}m"
             } ?: EMPTY_PLACEHOLDER
 
             FlipCardComponent(
@@ -118,7 +118,7 @@ fun GasPropertiesComponent(
             if(showSecondaryPPO2) {
 
                 val modSecondary = gas?.let {
-                    "${round(it.oxygenMod(maxPPO2Secondary!!, environment)).toInt()}m"
+                    "${it.oxygenModRounded(maxPPO2Secondary!!, environment)}m"
                 } ?: EMPTY_PLACEHOLDER
 
                 FlipCardComponent(

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraph.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/decoplan/DecoPlanGraph.kt
@@ -55,6 +55,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
@@ -113,7 +114,7 @@ fun DecoPlanGraph(
         majorTickSize = 0.dp,
         lineWidth = 1.dp,
     )
-    
+
     Column {
 
         FlowLegend2(
@@ -246,55 +247,61 @@ fun DecoPlanGraph(
 private fun DecoPlanGraphPreview() {
 
     val cylinder = Cylinder.steel12Liter(Gas.Air)
+    val environment = Environment.Default
 
     Surface {
         DecoPlanGraph(
             modifier = Modifier.height(164.dp), divePlan = DivePlan(
                 segments = persistentListOf(
-                    DiveSegment(
-                        0,
-                        3,
-                        0.0,
-                        25.0,
-                        cylinder,
+                    DiveSegment.fromMeters(
+                        start = 0,
+                        duration = 3,
+                        startDepth = 0.0,
+                        endDepth = 25.0,
+                        cylinder = cylinder,
                         type = DiveSegment.Type.DECENT,
-                        gfCeilingAtEnd = 0.0
+                        gfCeilingAtEnd = 0.0,
+                        environment = environment,
                     ),
-                    DiveSegment(
-                        3,
-                        20,
-                        25.0,
-                        25.0,
-                        cylinder,
+                    DiveSegment.fromMeters(
+                        start = 3,
+                        duration = 20,
+                        startDepth = 25.0,
+                        endDepth = 25.0,
+                        cylinder = cylinder,
                         type = DiveSegment.Type.FLAT,
-                        gfCeilingAtEnd = 3.0
+                        gfCeilingAtEnd = 3.0,
+                        environment = environment,
                     ),
-                    DiveSegment(
-                        23,
-                        3,
-                        25.0,
-                        5.0,
-                        cylinder,
+                    DiveSegment.fromMeters(
+                        start = 23,
+                        duration = 3,
+                        startDepth = 25.0,
+                        endDepth = 5.0,
+                        cylinder = cylinder,
                         type = DiveSegment.Type.ASCENT,
-                        gfCeilingAtEnd = 2.0
+                        gfCeilingAtEnd = 2.0,
+                        environment = environment,
                     ),
-                    DiveSegment(
-                        26,
-                        3,
-                        5.0,
-                        5.0,
-                        cylinder,
+                    DiveSegment.fromMeters(
+                        start = 26,
+                        duration = 3,
+                        startDepth = 5.0,
+                        endDepth = 5.0,
+                        cylinder = cylinder,
                         type = DiveSegment.Type.DECO_STOP,
-                        gfCeilingAtEnd = 1.0
+                        gfCeilingAtEnd = 1.0,
+                        environment = environment,
                     ),
-                    DiveSegment(
-                        29,
-                        1,
-                        5.0,
-                        0.0,
-                        cylinder,
+                    DiveSegment.fromMeters(
+                        start = 29,
+                        duration = 1,
+                        startDepth = 5.0,
+                        endDepth = 0.0,
+                        cylinder = cylinder,
                         type = DiveSegment.Type.ASCENT,
-                        gfCeilingAtEnd = 0.0
+                        gfCeilingAtEnd = 0.0,
+                        environment = environment,
                     ),
                 ),
                 alternativeAccents = persistentMapOf(),

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
@@ -13,7 +13,9 @@
 package org.neotech.app.abysner.domain.core.model
 
 import org.neotech.app.abysner.domain.core.physics.altitudeToPressure
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.persistence.EnumPreference
+import org.neotech.app.abysner.domain.utilities.ceilTolerant
 import kotlin.math.ceil
 import kotlin.math.max
 
@@ -88,7 +90,7 @@ data class Configuration(
     fun descentSetpointSwitch(breathingMode: BreathingMode): SetpointSwitch? =
         ccrToHighSetpointSwitchDepth?.let { depth ->
             (breathingMode as? BreathingMode.ClosedCircuit)?.let {
-                SetpointSwitch(depth = depth, toBreathingMode = BreathingMode.ClosedCircuit(ccrHighSetpoint))
+                SetpointSwitch(ambientPressure = metersToAmbientPressure(depth.toDouble(), environment).value, toBreathingMode = BreathingMode.ClosedCircuit(ccrHighSetpoint))
             }
         }
 
@@ -99,7 +101,7 @@ data class Configuration(
     fun ascentSetpointSwitch(breathingMode: BreathingMode): SetpointSwitch? =
         ccrToLowSetpointSwitchDepth?.let { depth ->
             (breathingMode as? BreathingMode.ClosedCircuit)?.let {
-                SetpointSwitch(depth = depth, toBreathingMode = BreathingMode.ClosedCircuit(ccrLowSetpoint))
+                SetpointSwitch(ambientPressure = metersToAmbientPressure(depth.toDouble(), environment).value, toBreathingMode = BreathingMode.ClosedCircuit(ccrLowSetpoint))
             }
         }
 
@@ -116,7 +118,8 @@ data class Configuration(
     }
 
     /**
-     * Calculate travel time, negative distance is descending, positive is ascending.
+     * Calculate travel time from a depth distance in meters. Negative distance is descending,
+     * positive is ascending.
      */
     fun travelTime(distance: Double): Int {
         val rate = if(distance > 0) {
@@ -128,6 +131,25 @@ data class Configuration(
             0
         } else {
             max(ceil(distance / rate).toInt(), 1)
+        }
+    }
+
+    /**
+     * Calculate travel time from a pressure difference. Positive means ascending (pressure
+     * decreasing), negative means descending (pressure increasing).
+     */
+    fun travelTime(pressureDifference: Double, environment: Environment): Int {
+        val ascentRatePressure = metersToAmbientPressure(maxAscentRate, environment).value - environment.atmosphericPressure
+        val descentRatePressure = metersToAmbientPressure(maxDescentRate, environment).value - environment.atmosphericPressure
+        val rate = if (pressureDifference > 0) {
+            ascentRatePressure
+        } else {
+            -descentRatePressure
+        }
+        return if (pressureDifference == 0.0) {
+            0
+        } else {
+            max(ceilTolerant(pressureDifference / rate).toInt(), 1)
         }
     }
 }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/GasSelection.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/GasSelection.kt
@@ -36,6 +36,9 @@ fun List<Cylinder>.findBestGas(
 ): Cylinder? {
     // Step 1: Filter: Don't even consider gas that is beyond the MOD
     return filter {
+        // Perhaps the use of a tolerance is only required for metric? Since in metric we want oxygen
+        // to be usable at 6 meters? But in imperial this might not be as important? Or perhaps this
+        // should even be an advanced level setting?
         ambientPressure <= it.gas.oxygenModAmbientPressure(maxPpO2) + modTolerance
     }.maxWithOrNull(
         compareBy(

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/SetpointSwitch.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/SetpointSwitch.kt
@@ -13,12 +13,12 @@
 package org.neotech.app.abysner.domain.core.model
 
 /**
- * Describes a CCR setpoint switch that should occur when the diver crosses a specific depth. This
- * can be fed into the [org.neotech.app.abysner.domain.decompression.DecompressionPlanner] to have
- * it automatically switch when certain depths are crossed during the dive.
+ * Describes a CCR setpoint switch that should occur when the diver crosses a specific ambient
+ * pressure. This can be fed into the
+ * [org.neotech.app.abysner.domain.decompression.DecompressionPlanner] to have it automatically
+ * switch when certain pressures are crossed during the dive.
  */
 data class SetpointSwitch(
-    val depth: Int,
+    val ambientPressure: Double,
     val toBreathingMode: BreathingMode.ClosedCircuit,
 )
-

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
@@ -20,39 +20,88 @@ import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.SetpointSwitch
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
-import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.findBetterGasOrFallback
+import org.neotech.app.abysner.domain.core.physics.Pressure
 import org.neotech.app.abysner.domain.core.physics.ambientPressureToMeters
 import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.decompression.model.subList
+import org.neotech.app.abysner.domain.utilities.ceilTolerant
+import org.neotech.app.abysner.domain.utilities.equalsTolerant
+import kotlin.math.floor
+import org.neotech.app.abysner.domain.utilities.greaterThanOrEqualTolerant
+import org.neotech.app.abysner.domain.utilities.greaterThanTolerant
+import org.neotech.app.abysner.domain.utilities.lessThanOrEqualTolerant
+import org.neotech.app.abysner.domain.utilities.lessThanTolerant
 import kotlin.math.abs
-import kotlin.math.ceil
 import kotlin.math.max
+import kotlin.math.round
 
 /**
  * The decompression planner makes use of a decompression model and adds algorithms to figure out
- * the exact stop depths, stop times, gas switch depths and more. This class essentially implements
+ * the exact stop depths, stop times, gas switches and more. This class essentially implements
  * diving standards for decompression based on the ceilings returned by the given decompression
  * model.
+ *
+ * All internal calculations work in absolute ambient pressure (bar). The [pressureToDepth]
+ * callback converts pressure to display-units (meters or feet) for output.
  */
 class DecompressionPlanner(
     val model: DecompressionModel,
-    val environment: Environment,
+    val surfacePressure: Double,
     val maxPpO2: Double,
-    val maxEquivalentNarcoticDepth: Double,
-    val ascentRate: Double,
-    val decoStepSize: Int,
-    val lastDecoStopDepth: Int,
+    val maxEquivalentNarcoticAmbientPressure: Double,
+    val ascentRatePressureDelta: Double,
+    /**
+     * The deco step size in pressure (for example about 0.3 bar for 3m steps) used to determine at
+     * which pressures deco stops are required. Must be an exact multiple of
+     * [displayUnitPressureDelta].
+     */
+    val decoStepSizePressureDelta: Double,
+    /**
+     * The ambient pressure of the last allowed deco stop, must be aligned to the deco step size.
+     */
+    val lastDecoStopAmbientPressure: Double,
+    /**
+     * The pressure delta that corresponds to the smallest display unit step (for example about
+     * 0.1 bar for steps of 1 meter).
+     */
+    val displayUnitPressureDelta: Double,
     val forceMinimalDecoStopTime: Boolean,
     val gasSwitchTime: Int,
+    val pressureToDepth: (Double) -> Double,
 ) {
+
+    init {
+        // Both decoStepSizePressureDelta and lastDecoStopAmbientPressure must align to
+        // displayUnitPressureDelta so that deco stops always land on whole display units (e.g.
+        // 3, 6 or 9 meter instead of 2.9, 5.8 or 8.7 meter).
+        val decoStepInDisplayUnits = decoStepSizePressureDelta / displayUnitPressureDelta
+        require(decoStepInDisplayUnits.equalsTolerant(round(decoStepInDisplayUnits))) {
+            "decoStepSizePressureDelta ($decoStepSizePressureDelta) must be an exact multiple of displayUnitPressureDelta ($displayUnitPressureDelta)."
+        }
+        val lastDecoStopDepthPressure = lastDecoStopAmbientPressure - surfacePressure
+        val lastDecoStopInDisplayUnits = lastDecoStopDepthPressure / displayUnitPressureDelta
+        require(lastDecoStopInDisplayUnits.equalsTolerant(round(lastDecoStopInDisplayUnits))) {
+            "lastDecoStopAmbientPressure ($lastDecoStopAmbientPressure) must fall on a display unit grid point relative to surfacePressure ($surfacePressure)."
+        }
+    }
 
     private var isCalculatingTts = false
 
+    /**
+     * Current dive runtime in minutes.
+     */
     var runtime = 0
         private set
+
+    /**
+     * Current dive depth in ambient pressure (bar).
+     */
+    var ambientPressure: Double = surfacePressure
+        private set
+
     private val decoGases = mutableListOf<Cylinder>()
     private val segments = mutableListOf<DiveSegment>()
     private val alternativeAccents: MutableMap<Int, List<DiveSegment>> = mutableMapOf()
@@ -65,7 +114,8 @@ class DecompressionPlanner(
      * Note: These alternative accents are not calculated minute, but as an optimization
      * calculated per section.
      */
-    fun getAlternativeAccents(): ImmutableMap<Int, ImmutableList<DiveSegment>> = alternativeAccents.mapValues { it.value.toPersistentList() }.toPersistentMap()
+    fun getAlternativeAccents(): ImmutableMap<Int, ImmutableList<DiveSegment>> =
+        alternativeAccents.mapValues { it.value.toPersistentList() }.toPersistentMap()
 
     fun getDecoGases(): List<Cylinder> = decoGases.toList()
 
@@ -74,44 +124,50 @@ class DecompressionPlanner(
         this.decoGases.addAll(gases)
     }
 
-
-    fun addFlat(depth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
-        return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.FLAT, breathingMode)
+    fun addFlat(ambientPressure: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
+        return addDepthChangeInternal(ambientPressure, ambientPressure, gas, timeInMinutes, DiveSegment.Type.FLAT, breathingMode)
     }
 
-    private fun addDecoStop(depth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
-        return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.DECO_STOP, breathingMode)
+    private fun addDecoStop(ambientPressure: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
+        return addDepthChangeInternal(ambientPressure, ambientPressure, gas, timeInMinutes, DiveSegment.Type.DECO_STOP, breathingMode)
     }
 
-    private fun addGasSwitch(depth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
+    private fun addGasSwitch(ambientPressure: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode) {
         // A 0-duration segment is still emitted when gasSwitchTime = 0 so the instruction table
         // can consistently show a gas switch row regardless of the configured switch time.
-        return addDepthChangeInternal(depth, depth, gas, timeInMinutes, DiveSegment.Type.GAS_SWITCH, breathingMode)
+        return addDepthChangeInternal(ambientPressure, ambientPressure, gas, timeInMinutes, DiveSegment.Type.GAS_SWITCH, breathingMode)
     }
 
-    fun addDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null) {
-        require(startDepth != endDepth) { "Use addFlat() for flat segments, startDepth and endDepth must differ." }
+    fun addDepthChange(startAmbientPressure: Double, endAmbientPressure: Double, gas: Cylinder, timeInMinutes: Int, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null) {
+        require(startAmbientPressure != endAmbientPressure) {
+            "startAmbientPressure ($startAmbientPressure) is not different from endAmbientPressure ($endAmbientPressure). Use addFlat() for flat segments."
+        }
         // Setpoint switches only apply to CCR, ignore for OC to prevent accidental breathing mode switches.
         val effectiveSetpointSwitch = if (breathingMode is BreathingMode.ClosedCircuit) {
             setpointSwitch
         } else {
             null
         }
-        val type = if (startDepth < endDepth) DiveSegment.Type.DECENT else DiveSegment.Type.ASCENT
-        return addDepthChangeInternal(startDepth, endDepth, gas, timeInMinutes, type, breathingMode, effectiveSetpointSwitch)
+        val type = if (startAmbientPressure < endAmbientPressure) {
+            DiveSegment.Type.DECENT
+        } else {
+            DiveSegment.Type.ASCENT
+        }
+        return addDepthChangeInternal(startAmbientPressure, endAmbientPressure, gas, timeInMinutes, type, breathingMode, effectiveSetpointSwitch)
     }
 
-    private fun addDepthChangeInternal(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null) {
+    private fun addDepthChangeInternal(startAmbientPressure: Double, endAmbientPressure: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null) {
         if(timeInMinutes > 0 && calculateTissueChangesPerMinute && !isCalculatingTts) {
-            val diff = startDepth - endDepth
+            val diff = startAmbientPressure - endAmbientPressure
             var currentBreathingMode = breathingMode
             repeat(timeInMinutes) { minute ->
-                val startDepthForThisMinute = startDepth - (diff * ((minute) / timeInMinutes.toDouble()))
-                val endDepthForThisMinute = startDepth - (diff * ((minute + 1) / timeInMinutes.toDouble()))
-                currentBreathingMode = applyDepthChange(startDepthForThisMinute, endDepthForThisMinute, gas, 1, type, currentBreathingMode, setpointSwitch)
+                // At callers start and end boundaries use exact pressures to avoid floating point noise.
+                val startPressure = if (minute == 0) { startAmbientPressure } else { startAmbientPressure - (diff * (minute / timeInMinutes.toDouble())) }
+                val endPressure = if (minute == timeInMinutes - 1) { endAmbientPressure } else { startAmbientPressure - (diff * ((minute + 1) / timeInMinutes.toDouble())) }
+                currentBreathingMode = applyPressureChange(startPressure, endPressure, gas, 1, type, currentBreathingMode, setpointSwitch)
             }
         } else {
-            applyDepthChange(startDepth, endDepth, gas, timeInMinutes, type, breathingMode, setpointSwitch)
+            applyPressureChange(startAmbientPressure, endAmbientPressure, gas, timeInMinutes, type, breathingMode, setpointSwitch)
         }
     }
 
@@ -121,54 +177,50 @@ class DecompressionPlanner(
      * This also takes care of sub-minute precision setpoint switches, and returns the effective
      * breathing mode at the end of this pressure change.
      */
-    private fun applyDepthChange(startDepth: Double, endDepth: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null): BreathingMode {
+    private fun applyPressureChange(startAmbientPressure: Double, endAmbientPressure: Double, gas: Cylinder, timeInMinutes: Int, type: DiveSegment.Type, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null): BreathingMode {
 
-        val startPressure = metersToAmbientPressure(startDepth, environment)
-        val endPressure = metersToAmbientPressure(endDepth, environment)
-
-        // Check if the setpoint switch depth is crossed during this segment
-        val switchDepth = setpointSwitch?.depth?.toDouble()
-        val crossesSwitchDepth = switchDepth != null &&
-            (startDepth < switchDepth) != (endDepth < switchDepth)
+        // Check if the setpoint switch pressure is crossed during this segment
+        val switchPressure = setpointSwitch?.ambientPressure
+        val crossesSwitchPressure = switchPressure != null &&
+            (startAmbientPressure < switchPressure) != (endAmbientPressure < switchPressure)
 
         val breathingModeAtEnd: BreathingMode.ClosedCircuit?
-        if (timeInMinutes > 0 && crossesSwitchDepth) {
-            // Sub-minute precision: split the model call at the exact switch depth
+        if (timeInMinutes > 0 && crossesSwitchPressure) {
+            // Sub-minute precision: split the model call at the exact switch pressure
             // TODO: See [DiveSegment.breathingModeAtEnd]
-            val timeFractionBeforeSwitch = abs(setpointSwitch.depth - startDepth) / abs(endDepth - startDepth)
-
-            val pressureSwitch = metersToAmbientPressure(setpointSwitch.depth.toDouble(), environment)
+            val timeFractionBeforeSwitch = abs(switchPressure - startAmbientPressure) / abs(endAmbientPressure - startAmbientPressure)
 
             if (timeFractionBeforeSwitch > 0.0) {
-                model.addPressureChange(startPressure, pressureSwitch, gas.gas, timeFractionBeforeSwitch * timeInMinutes, breathingMode.ccrSetpointOrNull)
+                model.addPressureChange(Pressure(startAmbientPressure), Pressure(switchPressure), gas.gas, timeFractionBeforeSwitch * timeInMinutes, breathingMode.ccrSetpointOrNull)
             }
             if (timeFractionBeforeSwitch < 1.0) {
-                model.addPressureChange(pressureSwitch, endPressure, gas.gas, (1.0 - timeFractionBeforeSwitch) * timeInMinutes, setpointSwitch.toBreathingMode.ccrSetpointOrNull)
+                model.addPressureChange(Pressure(switchPressure), Pressure(endAmbientPressure), gas.gas, (1.0 - timeFractionBeforeSwitch) * timeInMinutes, setpointSwitch.toBreathingMode.ccrSetpointOrNull)
             }
             breathingModeAtEnd = setpointSwitch.toBreathingMode
         } else {
             if (timeInMinutes > 0) {
-                model.addPressureChange(startPressure, endPressure, gas.gas, timeInMinutes, breathingMode.ccrSetpointOrNull)
+                model.addPressureChange(Pressure(startAmbientPressure), Pressure(endAmbientPressure), gas.gas, timeInMinutes, breathingMode.ccrSetpointOrNull)
             }
             breathingModeAtEnd = null
         }
-
-        val ceiling = ambientPressureToMeters(model.getCeiling().value, environment)
 
         segments.add(
             DiveSegment(
                 start = runtime,
                 duration = timeInMinutes,
-                startDepth = startDepth,
-                endDepth = endDepth,
+                startPressure = startAmbientPressure,
+                endPressure = endAmbientPressure,
+                startDepth = pressureToDepth(startAmbientPressure),
+                endDepth = pressureToDepth(endAmbientPressure),
                 cylinder = gas,
                 type = type,
-                gfCeilingAtEnd = ceiling,
+                gfCeilingAtEnd = pressureToDepth(model.getCeiling().value),
                 breathingMode = breathingMode,
                 breathingModeAtEnd = breathingModeAtEnd,
             )
         )
         this.runtime += timeInMinutes
+        this.ambientPressure = endAmbientPressure
         return breathingModeAtEnd ?: breathingMode
     }
 
@@ -187,7 +239,7 @@ class DecompressionPlanner(
         var alternativeAscentSegments: List<DiveSegment> = emptyList()
         val start = runtime
         val result = resetAfter {
-            calculateDecompression(toDepth = 0, breathingMode = breathingMode, setpointSwitch = setpointSwitch).sumOf { it.duration }.also {
+            calculateDecompression(toAmbientPressure = surfacePressure, breathingMode = breathingMode, setpointSwitch = setpointSwitch).sumOf { it.duration }.also {
                 alternativeAscentSegments = segments.subList(start).toList()
             }
         }
@@ -197,79 +249,85 @@ class DecompressionPlanner(
     }
 
     /**
-     * Move diver from [fromDepth] to the next ceiling depth [toDepth]. During which a gas change
-     * may occur as the diver reaches depths at which a different gas may be better to breath.
-     * Gas switching is skipped when [breathingMode] is [BreathingMode.ClosedCircuit], since the
-     * diver stays on the loop.
+     * Move diver from [fromAmbientPressure] to the next ceiling pressure [toAmbientPressure].
+     * During which a gas change may occur as the diver reaches pressures at which a different gas
+     * may be better to breathe. Gas switching is skipped when [breathingMode] is
+     * [BreathingMode.ClosedCircuit], since the diver stays on the loop.
      */
-    private fun addDecoDepthChange(fromDepth: Double, toDepth: Double, maxppO2: Double, maxEND: Double, fromGas: Cylinder, ascentRateInMetersPerMinute: Double, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null): Cylinder {
+    private fun addDecoDepthChange(fromAmbientPressure: Double, toAmbientPressure: Double, maxPpO2: Double, maxEquivalentNarcoticAmbientPressure: Double, fromGas: Cylinder, ascentRatePressureDelta: Double, breathingMode: BreathingMode, setpointSwitch: SetpointSwitch? = null): Cylinder {
         val isCcr = breathingMode is BreathingMode.ClosedCircuit
         var gas = fromGas
-        var currentDepth = fromDepth
-        // After crossing the switch depth, use the switched-to breathing mode for all subsequent segments.
+
+        // TODO: We could potentially use this.ambientPressure, but this requires some careful
+        //       refactoring, and might not be worth it?
+        var currentPressure = fromAmbientPressure
+        // After crossing the switch pressure, use the switched-to breathing mode for all subsequent segments.
         var effectiveBreathingMode = breathingMode
 
-        while (currentDepth > toDepth) {
-            if (!isCcr) {
-                // Check if there is a better gas to breath at the current depth
-                val betterDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, ambientPressure = metersToAmbientPressure(currentDepth, environment).value, maxPPO2 = maxppO2, maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEND, environment).value)
-                // Only start using the better gas when we reach a deco increment point
+        fun findBetterGas(currentCylinder: Cylinder?, pressure: Double): Cylinder? =
+            decoGases.findBetterGasOrFallback(currentCylinder, pressure, maxPpO2, maxEquivalentNarcoticAmbientPressure)
 
-                if (betterDecoGas != null && betterDecoGas.gas != gas.gas && currentDepth.toInt() % decoStepSize == 0) {
+        while (currentPressure.greaterThanTolerant(toAmbientPressure)) {
+            if (!isCcr) {
+                // Check if there is a better gas to breathe at the current pressure
+                val betterDecoGas = findBetterGas(currentCylinder = gas, pressure = currentPressure)
+                // Only start using the better gas when we reach a deco increment point
+                if (betterDecoGas != null && betterDecoGas.gas != gas.gas && isAtDecoIncrement(currentPressure)) {
                     // Gas switch time is spent on the old gas: the diver is still breathing the
                     // previous gas while preparing to switch (grabbing regulator, purging, etc.).
                     // The actual switch to the new gas happens after the gas switch time.
-                    addGasSwitch(currentDepth, gas, gasSwitchTime, effectiveBreathingMode)
+                    addGasSwitch(currentPressure, gas, gasSwitchTime, effectiveBreathingMode)
                     gas = betterDecoGas
                 }
             }
 
-            // targetDepth is to toDepth, unless there's a better gas to switch to on the way up,
-            // then the target depth may be something between currentDepth and toDepth.
-            var targetDepth = toDepth
+            // targetPressure is toAmbientPressure, unless there's a better gas to switch to on the way up,
+            // then the target pressure may be something between currentPressure and toAmbientPressure.
+            var targetPressure = toAmbientPressure
 
             if (!isCcr) {
-                // Figure out if before we reach the targetDepth anything needs to happen (gas switch)
-                // We do this by descending with increments of 1 meter and checking if there is a better
-                // gas available at each depth.
-                var nextDepth = currentDepth - 1
+                // Figure out if before we reach the targetPressure gas switches are required at any
+                // of the deco increments between currentPressure and targetPressure (gas switches
+                // are aligned to the decompression stops).
+                var nextPressure = findNextDecoStopPressure(currentPressure)
                 var nextDecoGas: Cylinder?
-                while(nextDepth >= targetDepth) {
-                    nextDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, ambientPressure = metersToAmbientPressure(nextDepth, environment).value, maxPPO2 = maxppO2, maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEND, environment).value)
-                    if (nextDecoGas != null && nextDecoGas.gas != gas.gas && nextDepth.toInt() % decoStepSize == 0) {
-                        targetDepth = nextDepth
+                while(nextPressure.greaterThanOrEqualTolerant(targetPressure)) {
+                    nextDecoGas = findBetterGas(currentCylinder = gas, pressure = nextPressure)
+                    if (nextDecoGas != null && nextDecoGas.gas != gas.gas) {
+                        targetPressure = nextPressure
                         break
                     }
-                    nextDepth--
+                    nextPressure -= decoStepSizePressureDelta
                 }
             }
 
-            // At this point we are either at the target depth, or our target depth has changed due to a gas switch that needs to happen.
+            // At this point we are either at the target pressure, or our target pressure has
+            // changed due to a gas switch that needs to happen.
 
-            // Take the diver to this new target depth, by calculating how much time it will take to
-            // get there and then recalculate the current tissue loading.
+            // Take the diver to this new target pressure, by calculating how much time it will take
+            // to get there and then recalculate the current tissue loading.
 
             // TODO some planners seem to round down (MultiDeco) instead of the more logical ceil
             //      (Subsurface) here? Why is that?
             // Calculate how much time it will take in minutes, rounding up
-            val depthChange = abs(currentDepth - targetDepth)
-            val duration = max(1, ceil(depthChange / ascentRateInMetersPerMinute).toInt())
+            val pressureDelta = abs(currentPressure - targetPressure)
+            val duration = max(1, ceilTolerant(pressureDelta / ascentRatePressureDelta).toInt())
 
-            addDepthChange(currentDepth, targetDepth, gas, duration, effectiveBreathingMode, setpointSwitch)
+            addDepthChange(currentPressure, targetPressure, gas, duration, effectiveBreathingMode, setpointSwitch)
 
-            // If the switch depth was crossed during this segment, update the effective mode
-            if (setpointSwitch != null && currentDepth > setpointSwitch.depth && targetDepth <= setpointSwitch.depth) {
+            // If the switch pressure was crossed during this segment, update the effective mode
+            if (setpointSwitch != null && currentPressure > setpointSwitch.ambientPressure && targetPressure.lessThanOrEqualTolerant(setpointSwitch.ambientPressure)) {
                 effectiveBreathingMode = setpointSwitch.toBreathingMode
             }
 
-            currentDepth = targetDepth
+            currentPressure = targetPressure
         }
 
         if (!isCcr) {
-            val betterDecoGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, ambientPressure = metersToAmbientPressure(currentDepth, environment).value, maxPPO2 = maxppO2, maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEND, environment).value)
-            if (betterDecoGas != null && betterDecoGas.gas != gas.gas && currentDepth.toInt() % decoStepSize == 0) {
+            val betterDecoGas = findBetterGas(currentCylinder = gas, pressure = currentPressure)
+            if (betterDecoGas != null && betterDecoGas.gas != gas.gas && isAtDecoIncrement(currentPressure)) {
                 // Gas switch time on the old gas before switching
-                addGasSwitch(currentDepth, gas, gasSwitchTime, effectiveBreathingMode)
+                addGasSwitch(currentPressure, gas, gasSwitchTime, effectiveBreathingMode)
                 gas = betterDecoGas
             }
         }
@@ -278,7 +336,7 @@ class DecompressionPlanner(
     }
 
     fun calculateDecompression(
-        toDepth: Int,
+        toAmbientPressure: Double,
         breathingMode: BreathingMode,
         setpointSwitch: SetpointSwitch? = null,
     ): List<DiveSegment> {
@@ -291,15 +349,15 @@ class DecompressionPlanner(
 
         val isCcr = breathingMode is BreathingMode.ClosedCircuit
         var gas: Cylinder
-        val fromDepth: Double
+        // TODO do we need a local fromPressure variable, or can we just use this.ambientPressure?
+        val fromPressure: Double
         if (this.segments.isEmpty()) {
-            // TODO
-            //   Instead of throwing an exception (if there are no segments) the current depth could
-            //   be considered 0 meters, hence a simple return would be fine, as no decompression is
-            //   required anyways when going from 0 meters to 0 meters?
+            // TODO Instead of throwing an exception (if there are no segments) the current pressure
+            //      could be considered surface pressure, hence a simple return would be fine, as no
+            //      decompression is required anyways when going from the surface to the surface?
             throw IllegalStateException("Unable to decompress, current depth is 0, have any dive stages been registered?")
         } else {
-            fromDepth = this.segments[this.segments.size-1].endDepth
+            fromPressure = ambientPressure
             gas = this.segments[this.segments.size-1].cylinder
         }
         val segmentSizeStart = this.segments.size
@@ -310,142 +368,131 @@ class DecompressionPlanner(
         // TODO: Should this be configurable, or even tied to the existing Configuration.gasSwitchTime?
         val isBailout = !isCcr && segments.last().breathingMode is BreathingMode.ClosedCircuit
         if (isBailout) {
-            val bestBailoutGas = decoGases.findBetterGasOrFallback(
+            val bestBailoutGas = findBetterGasAtPressure(
                 currentCylinder = null,
-                ambientPressure = metersToAmbientPressure(fromDepth, environment).value,
-                maxPPO2 = maxPpO2,
-                maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEquivalentNarcoticDepth, environment).value
+                ambientPressure = fromPressure,
             )
             if (bestBailoutGas != null) {
-                addGasSwitch(fromDepth, gas, 1, breathingMode)
+                addGasSwitch(fromPressure, gas, 1, breathingMode)
                 gas = bestBailoutGas
             }
         }
 
-        if(toDepth > fromDepth) {
-            throw IllegalArgumentException("Cannot calculate decompression as the target depth ($toDepth meter) is deeper then the current depth ($fromDepth meter). Add an descending depth change first!")
+        if(toAmbientPressure.greaterThanTolerant(fromPressure)) {
+            // TODO Should we not even require fromPressure in the public API? Instead we could use this.ambientPressure?
+            val fromDepth = pressureToDepth(fromPressure)
+            val toDepth = pressureToDepth(toAmbientPressure)
+            throw IllegalArgumentException("Cannot calculate decompression as the target depth (${toDepth.toInt()}) is deeper than the current depth (${fromDepth.toInt()}). Add a descending depth change first!")
         }
 
         // Get the current ceiling:
-        var ceiling = findFirstDecoCeiling(fromDepth, decoStepSize, lastDecoStopDepth, maxPpO2, maxEquivalentNarcoticDepth, gas, ascentRate, breathingMode)
+        var ceiling = findFirstDecoCeiling(fromPressure, maxPpO2, maxEquivalentNarcoticAmbientPressure, gas, ascentRatePressureDelta, breathingMode)
 
-        // Check if there is a better gas to switch to at the current depth before
+        // Check if there is a better gas to switch to at the current pressure before
         // ascending. Gas switching is skipped in CCR mode (diver stays on the loop).
         if (!isCcr) {
-            val betterGas = decoGases.findBetterGasOrFallback(currentCylinder = gas, ambientPressure = metersToAmbientPressure(fromDepth, environment).value, maxPPO2 = maxPpO2, maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(maxEquivalentNarcoticDepth, environment).value)
+            val betterGas = findBetterGasAtPressure(currentCylinder = gas, ambientPressure = fromPressure)
             if (betterGas != null && betterGas.gas != gas.gas) {
                 // Gas switch time on the old gas before switching
-                addGasSwitch(fromDepth, gas, gasSwitchTime, breathingMode)
+                addGasSwitch(fromPressure, gas, gasSwitchTime, breathingMode)
                 gas = betterGas
             }
         }
 
         // Don't allow ceiling below start depth
-        // TODO get this depth from the previous section endDepth?
-        if(ceiling > fromDepth) {
-            // We have to stay at this depth first, do not change depths.
-            ceiling = fromDepth.toInt()
+        // TODO this check feels a bit weird, shouldn't we just throw if this happens?
+        if(ceiling.greaterThanTolerant(fromPressure)) {
+            // We have to stay at this pressure first, do not change pressures.
+            ceiling = fromPressure
         } else {
             // Move the diver to the first ceiling (this may already be the surface)
-
             gas = addDecoDepthChange(
-                fromDepth,
-                max(ceiling.toDouble(), toDepth.toDouble()),
+                fromPressure,
+                max(ceiling, toAmbientPressure),
                 maxPpO2,
-                maxEquivalentNarcoticDepth,
+                maxEquivalentNarcoticAmbientPressure,
                 gas,
-                ascentRate,
+                ascentRatePressureDelta,
                 breathingMode,
                 effectiveSetpointSwitch
             )
         }
 
-        // After the initial ascent, determine if the switch depth was already crossed.
-        var effectiveBreathingMode = if (effectiveSetpointSwitch != null && fromDepth > effectiveSetpointSwitch.depth &&
-            max(ceiling.toDouble(), toDepth.toDouble()) <= effectiveSetpointSwitch.depth) {
+        // After the initial ascent, determine if the switch pressure was already crossed.
+        var effectiveBreathingMode = if (effectiveSetpointSwitch != null && fromPressure > effectiveSetpointSwitch.ambientPressure &&
+            max(ceiling, toAmbientPressure).lessThanOrEqualTolerant(effectiveSetpointSwitch.ambientPressure)) {
             effectiveSetpointSwitch.toBreathingMode
         } else {
             breathingMode
         }
 
-        // Keep making deco stops until the deco ceiling is above the surface
-        while (ceiling > 0) {
+        // Keep making deco stops until the deco ceiling is at or above the surface
+        while (ceiling.greaterThanTolerant(surfacePressure)) {
 
-            val currentDepth = ceiling.toDouble()
-            if(currentDepth <= toDepth) {
+            val currentPressure = ceiling
+            if(currentPressure.lessThanOrEqualTolerant(toAmbientPressure)) {
                 break
             }
 
-            // Update effective breathing mode if we're now above the switch depth
-            if (effectiveSetpointSwitch != null && currentDepth <= effectiveSetpointSwitch.depth) {
+            // Update effective breathing mode if we're now above the switch pressure
+            if (effectiveSetpointSwitch != null && currentPressure.lessThanOrEqualTolerant(effectiveSetpointSwitch.ambientPressure)) {
                 effectiveBreathingMode = effectiveSetpointSwitch.toBreathingMode
             }
 
             // Check the new ceiling
-            ceiling = max(
-                this.getDecoCeiling(decoStepSize, lastDecoStopDepth),
-                toDepth
-            )
+            ceiling = max(this.getDecoCeiling(), toAmbientPressure)
 
             // Don't allow ceiling below start depth
-            // TODO get this depth from the previous section endDepth?
-            if(ceiling > fromDepth) {
-                ceiling = fromDepth.toInt()
+            // TODO this check feels a bit weird, shouldn't we just throw if this happens?
+            if(ceiling.greaterThanTolerant(fromPressure)) {
+                ceiling = fromPressure
             }
 
             // If while moving the diver up to the previous deco ceiling the ceiling itself moved
             // far enough to reach the next deco ceiling, a stop at the previous ceiling would be
             // pointless. Because apparently while traveling the diver has off-gassed enough to no
             // longer need the stop. So instead directly move further up to this next deco ceiling.
-            if(ceiling >= currentDepth || forceMinimalDecoStopTime) {
+            // TODO forceMinimalDecoStopTime should be removed from the code base, it no longer
+            //      makes sense to have this as an option, never did?
+            if(ceiling.greaterThanOrEqualTolerant(currentPressure) || forceMinimalDecoStopTime) {
 
                 // If minimal deco step times are required, force stops to also be symmetric!
-                val nextDecoDepth = if(forceMinimalDecoStopTime) {
-                    max(
-                        findNextDecoDepth(currentDepth.toInt(), decoStepSize, lastDecoStopDepth),
-                        toDepth
-                    )
+                val nextDecoPressure = if(forceMinimalDecoStopTime) {
+                    max(findNextDecoStopPressure(currentPressure), toAmbientPressure)
                 } else {
-                    max(findNextDecoDepth(ceiling, decoStepSize, lastDecoStopDepth), toDepth)
+                    max(findNextDecoStopPressure(ceiling), toAmbientPressure)
                 }
 
-                // Stop at the current deco depth until we can safely ascent to the next deco depth.
+                // Stop at the current deco stop until we can safely ascend to the next deco stop.
                 var stopTime = 0
-                while (ceiling > nextDecoDepth && ceiling > toDepth || (forceMinimalDecoStopTime && stopTime < 1)) {
+                while (ceiling.greaterThanTolerant(nextDecoPressure) && ceiling.greaterThanTolerant(toAmbientPressure) || (forceMinimalDecoStopTime && stopTime < 1)) {
                     // Add 1 minute of decompression and test the ceiling again, until the ceiling is higher.
-                    this.addDecoStop(currentDepth, gas, 1, effectiveBreathingMode)
+                    this.addDecoStop(currentPressure, gas, 1, effectiveBreathingMode)
                     stopTime++
 
-                    // TODO: Should we calculate the gf based on the current stop depth, or the next stop depth we want to reach?
-                    // Because getDecoCeiling may return a deeper ceiling to honor the [decoStepSize]
-                    // the diver could potentially already move up to [toDepth], however to allow
-                    // for some additional conservatism, we only move the diver to toDepth if the nearest
-                    // shallower deco ceiling is cleared as well.
-                    ceiling = max(
-                        this.getDecoCeiling(decoStepSize, lastDecoStopDepth),
-                        toDepth
-                    )
-                    if(ceiling < nextDecoDepth && forceMinimalDecoStopTime) {
-                        // ceiling is skipping a deco step, force the ceiling to be deeper to avoid skipping
-                        ceiling = nextDecoDepth
+                    ceiling = max(this.getDecoCeiling(), toAmbientPressure)
+                    if(ceiling.lessThanTolerant(nextDecoPressure) && forceMinimalDecoStopTime) {
+                        // Ceiling is skipping a deco step, force the ceiling to be deeper to avoid skipping
+                        ceiling = nextDecoPressure
                     }
 
-                    if (ceiling > nextDecoDepth && ceiling > toDepth) {
-                        if (isCeilingClearedDuringAscent(currentDepth, nextDecoDepth, gas, effectiveBreathingMode, effectiveSetpointSwitch)) {
-                            ceiling = nextDecoDepth
+                    if (ceiling.greaterThanTolerant(nextDecoPressure) && ceiling.greaterThanTolerant(toAmbientPressure)) {
+                        if (isCeilingClearedDuringAscent(currentPressure, nextDecoPressure, gas, effectiveBreathingMode, effectiveSetpointSwitch)) {
+                            ceiling = nextDecoPressure
                             break
                         }
                     }
 
                     if(stopTime > 1000) {
-                        // We are probably in a loop where we cannot off-gas enough within the set gradient factors
-                        // to reach the next deco stop. Likely the last deco stop is too shallow, the deco step size is too
-                        // big or the gradient factors are extremely conservative.
+                        // We are probably in a loop where we cannot off-gas enough within the set
+                        // gradient factors to reach the next deco stop. Likely the last deco stop
+                        // is too shallow, the deco step size is too big or the gradient factors are
+                        // extremely conservative.
                         throw DivePlanner.PlanningException("Unable to reach next deco stop within the set gradient factors. Likely the last deco stop is too shallow, the deco step size is too big or the gradient factors are extremely conservative.")
                     }
                 }
             }
-            gas = this.addDecoDepthChange(currentDepth, ceiling.toDouble(), maxPpO2, maxEquivalentNarcoticDepth, gas, ascentRate, effectiveBreathingMode, effectiveSetpointSwitch)
+            gas = this.addDecoDepthChange(currentPressure, ceiling, maxPpO2, maxEquivalentNarcoticAmbientPressure, gas, ascentRatePressureDelta, effectiveBreathingMode, effectiveSetpointSwitch)
         }
 
         return if(segments.size == segmentSizeStart) {
@@ -457,17 +504,15 @@ class DecompressionPlanner(
 
 
     private fun findFirstDecoCeiling(
-        fromDepth: Double,
-        decoStepSize: Int,
-        lastDecoStopDepth: Int,
+        fromPressure: Double,
         maxPpO2: Double,
-        maxEquivalentNarcoticDepth: Double,
+        maxEquivalentNarcoticAmbientPressure: Double,
         gas: Cylinder,
-        ascentRate: Double,
+        ascentRatePressureDelta: Double,
         breathingMode: BreathingMode,
-    ): Int {
+    ): Double {
 
-        var ceiling: Int = getDecoCeiling(decoStepSize, lastDecoStopDepth)
+        var ceiling: Double = getDecoCeiling()
         var nextCeiling = ceiling
         do {
 
@@ -475,33 +520,32 @@ class DecompressionPlanner(
 
             nextCeiling = resetAfter {
 
-                if (ceiling == 0) {
-                    return@resetAfter 0
+                if (ceiling.lessThanOrEqualTolerant(surfacePressure)) {
+                    return@resetAfter surfacePressure
                 }
 
                 // Move diver up
                 addDecoDepthChange(
-                    fromDepth,
-                    ceiling.toDouble(),
+                    fromPressure,
+                    ceiling,
                     maxPpO2,
-                    maxEquivalentNarcoticDepth,
+                    maxEquivalentNarcoticAmbientPressure,
                     gas,
-                    ascentRate,
+                    ascentRatePressureDelta,
                     breathingMode
                 )
 
                 // Check new ceiling (could already be higher)
-                getDecoCeiling(
-                    decoStepSize,
-                    lastDecoStopDepth
-                )
+                getDecoCeiling()
             }
-        } while(ceiling > nextCeiling)
+        } while(ceiling.greaterThanTolerant(nextCeiling))
 
-        val nextDecoDepth = findNextDecoDepth(nextCeiling, decoStepSize, lastDecoStopDepth)
-        if (nextCeiling > 0 && nextDecoDepth >= 0) {
-            if (isCeilingClearedDuringAscent(fromDepth, nextDecoDepth, gas, breathingMode)) {
-                return nextDecoDepth
+        // Check if off-gassing during the ascent to the next shallower deco stop clears the
+        // ceiling, allowing the current stop to be skipped entirely.
+        val nextDecoPressure = findNextDecoStopPressure(nextCeiling)
+        if (nextCeiling.greaterThanTolerant(surfacePressure) && nextDecoPressure.greaterThanOrEqualTolerant(surfacePressure)) {
+            if (isCeilingClearedDuringAscent(fromPressure, nextDecoPressure, gas, breathingMode)) {
+                return nextDecoPressure
             }
         }
 
@@ -509,83 +553,133 @@ class DecompressionPlanner(
     }
 
     /**
-     * Abysner works in whole minutes (as divers plan in minutes), which means a true ceiling of
-     * 3.1 meter would keep the diver at 6 meter for a full extra minute, even though only a few
-     * seconds of off-gassing might be needed to clear that ceiling (to 3 meters). This method
-     * avoids that minute penalty by simulating the ascent from [fromDepth] to [targetDecoDepth], if
-     * the ceiling clears during travel, the stop can be skipped. The model state is rolled back
-     * after the simulation.
+     * Abysner works in whole minutes (as divers plan in minutes), which means a true ceiling just
+     * barely deeper then a deco stop level would keep the diver at the deeper stop level for a full
+     * extra minute, even though only a few seconds of off-gassing might be needed to clear that
+     * ceiling. This method avoids that minute penalty by simulating the ascent from
+     * [fromAmbientPressure] to [targetDecoAmbientPressure]: if the ceiling clears during travel,
+     * the stop can be skipped. The model state is rolled back after the simulation.
      */
     private fun isCeilingClearedDuringAscent(
-        fromDepth: Double,
-        targetDecoDepth: Int,
+        fromAmbientPressure: Double,
+        targetDecoAmbientPressure: Double,
         gas: Cylinder,
         breathingMode: BreathingMode,
         setpointSwitch: SetpointSwitch? = null,
     ): Boolean {
-        if (targetDecoDepth < 0) return false
+        if (targetDecoAmbientPressure.lessThanTolerant(surfacePressure)) {
+            return false
+        }
         val ceilingAfterAscent = resetAfter {
             addDecoDepthChange(
-                fromDepth,
-                targetDecoDepth.toDouble().coerceAtLeast(0.0),
+                fromAmbientPressure,
+                targetDecoAmbientPressure.coerceAtLeast(surfacePressure),
                 maxPpO2,
-                maxEquivalentNarcoticDepth,
+                maxEquivalentNarcoticAmbientPressure,
                 gas,
-                ascentRate,
+                ascentRatePressureDelta,
                 breathingMode,
                 setpointSwitch
             )
-            getDecoCeiling(decoStepSize, lastDecoStopDepth)
+            getDecoCeiling()
         }
-        return ceilingAfterAscent <= targetDecoDepth
+        return ceilingAfterAscent.lessThanOrEqualTolerant(targetDecoAmbientPressure)
     }
 
-    private fun getDecoCeiling(decoStepSize: Int, lastDecoStopDepth: Int): Int {
-        // Ceil to the next whole meter (or foot) so the ceiling is never shallower than what the
-        // model reports. Using round() here would allow the diver up to 0.5m shallower than the
-        // true ceiling (e.g. a raw ceiling of 3.2m would round to 3m, violating the ceiling).
-        var ceiling = ceil(ambientPressureToMeters(model.getCeiling().value, environment)).toInt()
-        // Snap up to the nearest deco grid point (e.g. 3m or 10ft increments). The ceiling must
-        // never be shallower than the model ceiling, so we only move deeper.
-        while (ceiling % decoStepSize != 0) {
-            ceiling += 1
+    private fun getDecoCeiling(): Double {
+        val rawCeiling = model.getCeiling().value
+        if (rawCeiling.lessThanOrEqualTolerant(surfacePressure)) {
+            return surfacePressure
         }
-        if(ceiling > 0 && ceiling in 1..lastDecoStopDepth) {
-            ceiling = lastDecoStopDepth
+
+        val depthPressure = rawCeiling - surfacePressure
+
+        // Snap (ceil) to the deco grid (e.g. 3 meter or 10 feet increments). Because
+        // decoStepSizePressureDelta is guaranteed to be an exact multiple of
+        // displayUnitPressureDelta, this always lands on a display-unit boundary too.
+        val decoGridSteps = ceilTolerant(depthPressure / decoStepSizePressureDelta).toInt()
+        if (decoGridSteps <= 0) {
+            return surfacePressure
         }
-        return ceiling
+        val snappedPressure = surfacePressure + decoGridSteps * decoStepSizePressureDelta
+
+        // If the deco stop falls between surface and the last allowed deco stop depth, clamp to
+        // the last allowed deco stop.
+        return if (snappedPressure.lessThanTolerant(lastDecoStopAmbientPressure) && snappedPressure.greaterThanTolerant(surfacePressure)) {
+            lastDecoStopAmbientPressure
+        } else {
+            snappedPressure
+        }
     }
 
-    private fun findNextDecoDepth(currentDepth: Int, decoStepSize: Int, lastDecoStopDepth: Int): Int {
-        val modulo = currentDepth % decoStepSize
-        val decoStop = if(modulo != 0) {
-            // Current depth not valid deco stop
-            currentDepth - (currentDepth % decoStepSize)
-        } else {
-            // Current depth valid deco stop
-            currentDepth - decoStepSize
+    private fun findNextDecoStopPressure(fromAmbientPressure: Double): Double {
+        val depthPressure = fromAmbientPressure - surfacePressure
+        if (depthPressure.lessThanOrEqualTolerant(0.0)) {
+            return surfacePressure
         }
-        return if(decoStop in 1 ..< lastDecoStopDepth) {
-            0
+
+        val steps = depthPressure / decoStepSizePressureDelta
+        val nearestWholeStep = round(steps)
+        val isOnGrid = steps.equalsTolerant(nearestWholeStep)
+
+        // If exactly on a deco-grid point, go one step shallower, so we select the next stop. If
+        // not, we are in between deco-grid points. In that case the next stop is the nearest
+        // shallower one, so use floor to find it.
+        val nextStep = if (isOnGrid) {
+            nearestWholeStep.toInt() - 1
         } else {
-            decoStop
+            // No need for tolerance, if there was any floating-point noise the isOnGrid check would have caught it
+            floor(steps).toInt()
         }
+        if (nextStep <= 0) {
+            // No more deco stops, next step on the grid is surface, return early and exactly
+            return surfacePressure
+        }
+
+        val nextPressure = surfacePressure + nextStep * decoStepSizePressureDelta
+
+        // If the next stop falls between surface and the configured last deco stop depth, skip to
+        // surface (the dive was configured to not stop in between the surface and
+        // lastDecoStopAmbientPressure).
+        return if (nextPressure.lessThanTolerant(lastDecoStopAmbientPressure)) {
+            surfacePressure
+        } else {
+            nextPressure
+        }
+    }
+
+    private fun isAtDecoIncrement(pressure: Double): Boolean {
+        val steps = (pressure - surfacePressure) / decoStepSizePressureDelta
+        val nearestWholeStep = round(steps)
+        // If nearest whole step is within tolerance to the actual step we are at, the diver is on a
+        // deco grid point.
+        return steps.equalsTolerant(nearestWholeStep)
     }
 
     private fun <T> resetAfter(block: () -> T): T {
         val savedRuntime = runtime
+        val savedAmbientPressure = ambientPressure
         val savedSegments = segments.toList()
         val savedAlternativeAscents = alternativeAccents.toMap()
         val result = model.resetAfter {
             block()
         }
         runtime = savedRuntime
+        ambientPressure = savedAmbientPressure
         segments.clear()
         segments.addAll(savedSegments)
         alternativeAccents.clear()
         alternativeAccents.putAll(savedAlternativeAscents)
         return result
     }
+
+    private fun findBetterGasAtPressure(currentCylinder: Cylinder?, ambientPressure: Double): Cylinder? =
+        decoGases.findBetterGasOrFallback(
+            currentCylinder = currentCylinder,
+            ambientPressure = ambientPressure,
+            maxPPO2 = maxPpO2,
+            maxEquivalentNarcoticAmbientPressure = maxEquivalentNarcoticAmbientPressure,
+        )
 
     fun getSegments(): ImmutableList<DiveSegment> {
         return segments.toPersistentList()

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/model/DiveSegment.kt
@@ -14,6 +14,8 @@ package org.neotech.app.abysner.domain.decompression.model
 
 import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.Environment
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.utilities.equalsTolerant
 import kotlin.math.max
 
@@ -27,13 +29,24 @@ data class DiveSegment(
      * Duration is minutes.
      */
     val duration: Int,
+
     /**
-     * Start depth of this segment (in meters)
+     * Absolute ambient pressure at the start of this segment (bar).
+     */
+    val startPressure: Double,
+
+    /**
+     * Absolute ambient pressure at the end of this segment (bar).
+     */
+    val endPressure: Double,
+
+    /**
+     * Start depth in display units (meters or feet, depending on configuration).
      */
     val startDepth: Double,
 
     /**
-     * End depth of this segment (in meters)
+     * End depth in display units (meters or feet, depending on configuration).
      */
     val endDepth: Double,
     /**
@@ -41,6 +54,11 @@ data class DiveSegment(
      */
     val cylinder: Cylinder,
 
+    /**
+     * Gradient-factor ceiling depth at the end of this segment, in display units (meters or feet).
+     * Zero means no decompression obligation. This is a display value only, not used in
+     * pressure-based calculations.
+     */
     val gfCeilingAtEnd: Double,
 
     /**
@@ -68,7 +86,15 @@ data class DiveSegment(
      */
     val breathingModeAtEnd: BreathingMode.ClosedCircuit? = null,
 
+    /**
+     * Travel speed in display units (meters or feet) per minute for this segment, derived from the depth values.
+     */
     val travelSpeed: Double = (startDepth - endDepth) / duration.toDouble(),
+
+    /**
+     * Pressure change in bar per minute for this segment, derived from the pressure values.
+     */
+    val pressureRate: Double = (startPressure - endPressure) / duration.toDouble(),
 
     /**
      * Time to surface (in minutes) at the end of this segment, using the dive's own breathing
@@ -84,6 +110,40 @@ data class DiveSegment(
      */
     val ttsBailoutAfter: Int? = null,
 ) {
+
+    companion object {
+
+        /**
+         * Creates a [DiveSegment] from depths in meters, computing the ambient pressure values
+         * from the given [environment]. Intended for tests and Compose previews. Core decompression
+         * code should use the primary constructor with raw pressure values and convert those to
+         * display-unit depths.
+         */
+        fun fromMeters(
+            start: Int,
+            duration: Int,
+            startDepth: Double,
+            endDepth: Double,
+            cylinder: Cylinder,
+            type: Type,
+            environment: Environment,
+            gfCeilingAtEnd: Double,
+            breathingMode: BreathingMode = BreathingMode.OpenCircuit,
+            breathingModeAtEnd: BreathingMode.ClosedCircuit? = null,
+        ) = DiveSegment(
+            start = start,
+            duration = duration,
+            startPressure = metersToAmbientPressure(startDepth, environment).value,
+            endPressure = metersToAmbientPressure(endDepth, environment).value,
+            startDepth = startDepth,
+            endDepth = endDepth,
+            cylinder = cylinder,
+            type = type,
+            gfCeilingAtEnd = gfCeilingAtEnd,
+            breathingMode = breathingMode,
+            breathingModeAtEnd = breathingModeAtEnd,
+        )
+    }
 
     val end = start + duration
 
@@ -167,7 +227,7 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
         if (
             currentSegment.type.isFlat &&
             currentSegment.type == nextSegment.type &&
-            currentSegment.endDepth.equalsTolerant(nextSegment.startDepth) &&
+            currentSegment.endPressure.equalsTolerant(nextSegment.startPressure) &&
             currentSegment.cylinder == nextSegment.cylinder &&
             currentSegment.breathingMode == nextSegment.breathingMode
         ) {
@@ -182,8 +242,8 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
             this.removeAt(i + 1)
         } else if (
             !currentSegment.type.isFlat &&
-            currentSegment.travelSpeed.equalsTolerant(nextSegment.travelSpeed) &&
-            currentSegment.endDepth.equalsTolerant(nextSegment.startDepth) &&
+            currentSegment.pressureRate.equalsTolerant(nextSegment.pressureRate) &&
+            currentSegment.endPressure.equalsTolerant(nextSegment.startPressure) &&
             currentSegment.cylinder == nextSegment.cylinder &&
             (currentSegment.breathingMode == nextSegment.breathingMode ||
                 currentSegment.breathingModeAtEnd == nextSegment.breathingMode)
@@ -191,6 +251,7 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
             val mergedModeAtEnd = (nextSegment.breathingModeAtEnd ?: currentSegment.breathingModeAtEnd)
                 ?.takeIf { it != currentSegment.breathingMode }
             val combinedSegment = currentSegment.copy(
+                endPressure = nextSegment.endPressure,
                 endDepth = nextSegment.endDepth,
                 duration = currentSegment.duration + nextSegment.duration,
                 gfCeilingAtEnd = nextSegment.gfCeilingAtEnd,
@@ -202,7 +263,7 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
             compactAscentsAndStops &&
             currentSegment.isGasSwitch &&
             nextSegment.isDecompressionStop &&
-            currentSegment.endDepth.equalsTolerant(nextSegment.startDepth)
+            currentSegment.endPressure.equalsTolerant(nextSegment.startPressure)
         ) {
             // A gas switch followed by a deco stop at the same depth: absorb the stop into the
             // switch so both appear as a single row. The cylinder is kept from the switch segment
@@ -224,6 +285,8 @@ fun MutableList<DiveSegment>.compactSimilarSegments(
             // Previous and next segments are both stops, make this segment the next stop instead.
             val combinedSegment = DiveSegment(
                 start = currentSegment.start,
+                startPressure = nextSegment.startPressure,
+                endPressure = nextSegment.endPressure,
                 endDepth = nextSegment.endDepth,
                 startDepth = nextSegment.startDepth,
                 duration = currentSegment.duration + nextSegment.duration,

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
@@ -19,6 +19,9 @@ import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.SetpointSwitch
+import org.neotech.app.abysner.domain.core.physics.ambientPressureToMeters
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
+import org.neotech.app.abysner.domain.core.physics.metersToHydrostaticPressure
 import org.neotech.app.abysner.domain.decompression.DecompressionPlanner
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
 import org.neotech.app.abysner.domain.decompression.algorithm.buhlmann.Buhlmann
@@ -26,6 +29,7 @@ import org.neotech.app.abysner.domain.diveplanning.model.AssignedCylinder
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.gasplanning.OxygenToxicityCalculator
+import org.neotech.app.abysner.domain.utilities.removeFloatingPointNoise
 import kotlin.time.Duration
 
 /**
@@ -94,17 +98,7 @@ class DivePlanner(
             )
         }
 
-        val decompressionPlanner = DecompressionPlanner(
-            environment = configuration.environment,
-            maxPpO2 = configuration.maxPPO2Deco,
-            maxEquivalentNarcoticDepth = configuration.maxEND,
-            ascentRate = configuration.maxAscentRate,
-            decoStepSize = configuration.decoStepSize,
-            lastDecoStopDepth = configuration.lastDecoStopDepth,
-            forceMinimalDecoStopTime = configuration.forceMinimalDecoStopTime,
-            gasSwitchTime = configuration.gasSwitchTime,
-            model = model
-        )
+        val decompressionPlanner = createDecompressionPlanner(model, configuration)
 
         decompressionPlanner.setDecoGases(decoCylinders)
 
@@ -117,13 +111,14 @@ class DivePlanner(
             plan
         }
 
-        var currentDepth = 0.0
+        var currentPressure = configuration.environment.atmosphericPressure
         effectivePlan.forEach {
-            if (it.depth.toDouble() != currentDepth) {
+            val sectionPressure = metersToAmbientPressure(it.depth.toDouble(), configuration.environment).value
+            if (sectionPressure != currentPressure) {
 
-                val difference = currentDepth - it.depth
+                val pressureDifference = currentPressure - sectionPressure
 
-                if(difference > 0) {
+                if(pressureDifference > 0) {
                     // Ascending
 
                     val runtime = decompressionPlanner.runtime
@@ -138,10 +133,10 @@ class DivePlanner(
                         // Only allow the listed bottom gas to get to this segment
                         // This is similar to what MultiDeco does
                         decompressionPlanner.setDecoGases(listOf(it.cylinder))
-                        decompressionPlanner.calculateDecompression(toDepth = it.depth, breathingMode = breathingMode, setpointSwitch = ascentSwitch)
+                        decompressionPlanner.calculateDecompression(toAmbientPressure = sectionPressure, breathingMode = breathingMode, setpointSwitch = ascentSwitch)
                         decompressionPlanner.setDecoGases(gases)
                     } else {
-                        decompressionPlanner.calculateDecompression(toDepth = it.depth, breathingMode = breathingMode, setpointSwitch = ascentSwitch)
+                        decompressionPlanner.calculateDecompression(toAmbientPressure = sectionPressure, breathingMode = breathingMode, setpointSwitch = ascentSwitch)
                     }
 
                     val timeSpend = decompressionPlanner.runtime - runtime
@@ -152,7 +147,7 @@ class DivePlanner(
                         throw NotEnoughTimeToDecompress()
                     } else if(timeLeftAtPlannedDepth > 0) {
                         decompressionPlanner.addFlat(
-                            it.depth.toDouble(),
+                            sectionPressure,
                             it.cylinder,
                             timeLeftAtPlannedDepth,
                             breathingMode,
@@ -162,7 +157,7 @@ class DivePlanner(
 
                 } else {
                     // Descending
-                    val timeToChange = configuration.travelTime(difference)
+                    val timeToChange = configuration.travelTime(pressureDifference, configuration.environment)
 
                     val timeLeftAtPlannedDepth = it.duration - timeToChange
 
@@ -171,8 +166,8 @@ class DivePlanner(
                     val ascentSwitchForTts = configuration.ascentSetpointSwitch(breathingMode)
 
                     decompressionPlanner.addDepthChange(
-                        currentDepth,
-                        it.depth.toDouble(),
+                        currentPressure,
+                        sectionPressure,
                         it.cylinder,
                         timeToChange,
                         descentBreathingMode,
@@ -184,7 +179,7 @@ class DivePlanner(
                         throw NotEnoughTimeToReachDepth()
                     } else if(timeLeftAtPlannedDepth > 0) {
                         decompressionPlanner.addFlat(
-                            it.depth.toDouble(),
+                            sectionPressure,
                             it.cylinder,
                             timeLeftAtPlannedDepth,
                             breathingMode,
@@ -192,17 +187,17 @@ class DivePlanner(
                     }
                     decompressionPlanner.collectTts(breathingMode, isCcr, ttsBySegmentIndex, ascentSwitchForTts)
                 }
-                currentDepth = it.depth.toDouble()
+                currentPressure = sectionPressure
             } else {
                 decompressionPlanner.addFlat(
-                    it.depth.toDouble(),
+                    sectionPressure,
                     it.cylinder,
                     it.duration,
                     breathingMode,
                 )
                 val ascentSwitchForTts = configuration.ascentSetpointSwitch(breathingMode)
                 decompressionPlanner.collectTts(breathingMode, isCcr, ttsBySegmentIndex, ascentSwitchForTts)
-                currentDepth = it.depth.toDouble()
+                currentPressure = sectionPressure
             }
         }
 
@@ -218,7 +213,7 @@ class DivePlanner(
         } else {
             null
         }
-        decompressionPlanner.calculateDecompression(toDepth = 0, breathingMode = ascentBreathingMode, setpointSwitch = finalAscentSwitch)
+        decompressionPlanner.calculateDecompression(toAmbientPressure = configuration.environment.atmosphericPressure, breathingMode = ascentBreathingMode, setpointSwitch = finalAscentSwitch)
 
         val segments = decompressionPlanner.getSegments().mapIndexed { index, segment ->
             ttsBySegmentIndex[index]?.let {
@@ -231,6 +226,7 @@ class DivePlanner(
             alternativeAccents = decompressionPlanner.getAlternativeAccents(),
             cylinders = cylinders.toPersistentList(),
             configuration = configuration,
+            // TODO should this be part of DivePlan? Or part of DivePlanSet as a OxygenPlan? Like GasPlan?
             totalCns = OxygenToxicityCalculator.calculateCns(segments, configuration.environment),
             totalOtu = OxygenToxicityCalculator.calculateOtu(segments, configuration.environment)
         )
@@ -252,6 +248,33 @@ class DivePlanner(
             environment = configuration.environment,
             gfLow = configuration.gfLow,
             gfHigh = configuration.gfHigh,
+        )
+    }
+
+    private fun createDecompressionPlanner(
+        model: DecompressionModel,
+        configuration: Configuration,
+    ): DecompressionPlanner {
+        val environment = configuration.environment
+        return DecompressionPlanner(
+            surfacePressure = environment.atmosphericPressure,
+            maxPpO2 = configuration.maxPPO2Deco,
+            maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(configuration.maxEND, environment).value,
+            ascentRatePressureDelta = metersToHydrostaticPressure(configuration.maxAscentRate, environment).value,
+            decoStepSizePressureDelta = metersToHydrostaticPressure(configuration.decoStepSize.toDouble(), environment).value,
+            lastDecoStopAmbientPressure = metersToAmbientPressure(configuration.lastDecoStopDepth.toDouble(), environment).value,
+            displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+            forceMinimalDecoStopTime = configuration.forceMinimalDecoStopTime,
+            gasSwitchTime = configuration.gasSwitchTime,
+            model = model,
+            pressureToDepth = { pressure ->
+                // This is not strictly required to make the UI work, since the UI already formats
+                // to zero decimals or 1 maybe 2 decimals at most. However, it makes the current
+                // test assertions easier to read, since these are usually in whole meters, without
+                // this noise normalization tolerance handling at assertion call sites would be
+                // required, or more precise less readable floating point numbers.
+                removeFloatingPointNoise(ambientPressureToMeters(pressure, environment))
+            },
         )
     }
 
@@ -287,3 +310,5 @@ class DivePlanner(
 
     class NotEnoughTimeToDecompress : PlanningException()
 }
+
+

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/ConfigurationTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/ConfigurationTest.kt
@@ -12,6 +12,7 @@
 
 package org.neotech.app.abysner.domain.core.model
 
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -21,6 +22,8 @@ class ConfigurationTest {
         maxAscentRate = 5.0,
         maxDescentRate = 20.0,
     )
+
+    private val environment = configuration.environment
 
     @Test
     fun travelTime_returnsWholeMinutesForEvenDivision() {
@@ -37,5 +40,32 @@ class ConfigurationTest {
     @Test
     fun travelTime_returnsZeroForZeroDistance() {
         assertEquals(0, configuration.travelTime(0.0))
+    }
+
+    @Test
+    fun travelTimePressure_matchesMeterBasedResults() {
+        fun pressureDelta(fromMeters: Double, toMeters: Double): Double =
+            (metersToAmbientPressure(fromMeters, environment) - metersToAmbientPressure(toMeters, environment)).value
+
+        assertEquals(
+            expected = configuration.travelTime(-40.0),
+            actual =   configuration.travelTime(pressureDelta(0.0, 40.0), environment)
+        )
+        assertEquals(
+            expected = configuration.travelTime(-50.0),
+            actual =   configuration.travelTime(pressureDelta(0.0, 50.0), environment)
+        )
+        assertEquals(
+            expected = configuration.travelTime(45.0),
+            actual =   configuration.travelTime(pressureDelta(45.0, 0.0), environment)
+        )
+        assertEquals(
+            expected = configuration.travelTime(8.0),
+            actual =   configuration.travelTime(pressureDelta(8.0, 0.0), environment)
+        )
+        assertEquals(
+            expected = configuration.travelTime(0.0),
+            actual =   configuration.travelTime(0.0, environment)
+        )
     }
 }

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasSelectionTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasSelectionTest.kt
@@ -19,12 +19,6 @@ import kotlin.test.assertNull
 
 class GasSelectionTest {
 
-    private val environment = Environment.Default
-
-    private fun cylinders(vararg gas: Gas) = gas.map { Cylinder.steel12Liter(it) }
-
-    private fun ambient(meters: Double): Double = metersToAmbientPressure(meters, environment).value
-
     @Test
     fun findBestGas_returnsNullWhenAllGasesExceedMaxPPO2() {
         val cylinders = cylinders(Gas.Air, Gas.Nitrox32, Gas.Nitrox50, Gas.Oxygen)
@@ -169,6 +163,36 @@ class GasSelectionTest {
         )
         assertEquals(Gas.Air, result?.gas)
     }
+
+    @Test
+    fun findBestGas_usesExactModWhenToleranceIsZero() {
+        // O2 in fresh water has a MOD of about 5.98 meter at ppO2 1.6.
+        val cylinders = cylinders(Gas.Air, Gas.Oxygen)
+        val result = cylinders.findBestGas(
+            ambientPressure = ambient(meters = 6.0),
+            maxPpO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = END_UNSPECIFIED,
+            modTolerance = 0.0
+        )
+        assertEquals(Gas.Air, result?.gas)
+    }
+
+    @Test
+    fun findBestGas_usesTolerantModByDefault() {
+        // O2 in fresh water has a MOD of about 5.98 meter at ppO2 1.6.
+        val cylinders = cylinders(Gas.Air, Gas.Oxygen)
+        val result = cylinders.findBestGas(
+            ambientPressure = ambient(meters = 6.0),
+            maxPpO2 = 1.6,
+            maxEquivalentNarcoticAmbientPressure = END_UNSPECIFIED
+        )
+        assertEquals(Gas.Oxygen, result?.gas)
+    }
+
+    private fun cylinders(vararg gas: Gas) = gas.map { Cylinder.steel12Liter(it) }
+
+    private fun ambient(meters: Double, environment: Environment = Environment.Default): Double =
+        metersToAmbientPressure(meters, environment).value
 }
 
 private const val END_UNSPECIFIED = Double.MAX_VALUE

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlannerTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.decompression
+
+import org.neotech.app.abysner.domain.core.model.BreathingMode
+import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.Environment
+import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.core.physics.ambientPressureToFeet
+import org.neotech.app.abysner.domain.core.physics.ambientPressureToMeters
+import org.neotech.app.abysner.domain.core.physics.feetToAmbientPressure
+import org.neotech.app.abysner.domain.core.physics.feetToHydrostaticPressure
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
+import org.neotech.app.abysner.domain.core.physics.metersToHydrostaticPressure
+import org.neotech.app.abysner.domain.decompression.algorithm.buhlmann.Buhlmann
+import org.neotech.app.abysner.domain.decompression.model.compactSimilarSegments
+import org.neotech.app.abysner.domain.utilities.removeFloatingPointNoise
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DecompressionPlannerTest {
+
+    private val environment = Environment.SeaLevelFresh
+
+    @Test
+    fun init_rejectsDecoStepNotMultipleOfDisplayUnit() {
+        assertFailsWith<IllegalArgumentException> {
+            buildPlanner(
+                decoStepSizePressureDelta = metersToHydrostaticPressure(2.0, environment).value,
+                displayUnitPressureDelta = metersToHydrostaticPressure(3.0, environment).value,
+                lastDecoStopAmbientPressure = metersToAmbientPressure(2.0, environment).value,
+                pressureToDepth = { ambientPressureToMeters(it, environment) }
+            )
+        }
+    }
+
+    @Test
+    fun init_acceptsDecoStepThatIsMultipleOfDisplayUnit() {
+        buildPlanner(
+            decoStepSizePressureDelta = metersToHydrostaticPressure(3.0, environment).value,
+            displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+            lastDecoStopAmbientPressure = metersToAmbientPressure(3.0, environment).value,
+            pressureToDepth = { ambientPressureToMeters(it, environment) }
+        )
+    }
+
+    @Test
+    fun init_rejectsLastDecoStopNotOnDisplayUnitGrid() {
+        assertFailsWith<IllegalArgumentException> {
+            buildPlanner(
+                decoStepSizePressureDelta = metersToHydrostaticPressure(3.0, environment).value,
+                displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+                lastDecoStopAmbientPressure = metersToAmbientPressure(2.5, environment).value,
+                pressureToDepth = { ambientPressureToMeters(it, environment) }
+            )
+        }
+    }
+
+    @Test
+    fun init_acceptsLastDecoStopOnDisplayUnitGrid() {
+        buildPlanner(
+            decoStepSizePressureDelta = metersToHydrostaticPressure(3.0, environment).value,
+            displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+            lastDecoStopAmbientPressure = metersToAmbientPressure(6.0, environment).value,
+            pressureToDepth = { ambientPressureToMeters(it, environment) }
+        )
+    }
+
+    @Test
+    fun init_acceptsImperialAlignedStepSize() {
+        buildPlanner(
+            decoStepSizePressureDelta = feetToHydrostaticPressure(10.0, environment).value,
+            displayUnitPressureDelta = feetToHydrostaticPressure(1.0, environment).value,
+            lastDecoStopAmbientPressure = feetToAmbientPressure(6.0, environment).value,
+            pressureToDepth = { ambientPressureToFeet(it, environment) }
+        )
+    }
+
+    @Test
+    fun imperialDecoSteps_allSegmentDepthsAlignToTenFootGrid() {
+        val planner = buildPlanner(
+            decoStepSizePressureDelta = feetToHydrostaticPressure(10.0, environment).value,
+            lastDecoStopAmbientPressure = feetToAmbientPressure(10.0, environment).value,
+            displayUnitPressureDelta = feetToHydrostaticPressure(1.0, environment).value,
+            pressureToDepth = { removeFloatingPointNoise(ambientPressureToFeet(it, environment)) },
+        )
+
+        val bottomGas = Cylinder.steel12Liter(Gas.Air)
+
+        // Descend to 100 feet
+        val depthPressure = feetToAmbientPressure(100.0, environment).value
+        planner.addDepthChange(
+            startAmbientPressure = environment.atmosphericPressure,
+            endAmbientPressure = depthPressure,
+            gas = bottomGas,
+            timeInMinutes = 6,
+            breathingMode = BreathingMode.OpenCircuit,
+        )
+
+        // Bottom time
+        planner.addFlat(depthPressure, bottomGas, 30, BreathingMode.OpenCircuit)
+
+        // Ascent and decompress to the surface
+        planner.calculateDecompression(
+            toAmbientPressure = environment.atmosphericPressure,
+            breathingMode = BreathingMode.OpenCircuit,
+        )
+
+        val rawSegments = planner.getSegments()
+
+        // Compacted segments start and end points are expected to be exactly on the display-unit
+        // grid, because the input is aligned for each profile section, and the decompression
+        // planner aligns ascents and stops to the display-unit grid as well.
+        val segments = rawSegments.toMutableList().compactSimilarSegments()
+        segments.forEach {
+            // Due to removeFloatingPointNoise we should be getting exact multiples of 10.0 here.
+            assertEquals(0.0, it.startDepth % 10.0)
+        }
+    }
+
+    private fun buildPlanner(
+        decoStepSizePressureDelta: Double,
+        lastDecoStopAmbientPressure: Double,
+        displayUnitPressureDelta: Double,
+        pressureToDepth: (Double) -> Double,
+    ) = DecompressionPlanner(
+        model = Buhlmann(
+            version = Buhlmann.Version.ZH16C,
+            environment = environment,
+            gfLow = 0.3,
+            gfHigh = 0.7,
+        ),
+        surfacePressure = environment.atmosphericPressure,
+        maxPpO2 = 1.6,
+        maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(30.0, environment).value,
+        ascentRatePressureDelta = metersToHydrostaticPressure(5.0, environment).value,
+        decoStepSizePressureDelta = decoStepSizePressureDelta,
+        lastDecoStopAmbientPressure = lastDecoStopAmbientPressure,
+        displayUnitPressureDelta = displayUnitPressureDelta,
+        forceMinimalDecoStopTime = false,
+        gasSwitchTime = 1,
+        pressureToDepth = pressureToDepth,
+    )
+}

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/model/CompactSimilarSegmentsTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/model/CompactSimilarSegmentsTest.kt
@@ -14,6 +14,7 @@ package org.neotech.app.abysner.domain.decompression.model
 
 import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.diveplanning.assertSegment
 import kotlin.test.Test
@@ -21,6 +22,7 @@ import kotlin.test.assertEquals
 
 class CompactSimilarSegmentsTest {
 
+    private val environment = Environment.Default
     private val airCylinder = Cylinder.steel12Liter(Gas.Air)
     private val nitroxCylinder = Cylinder.aluminium80Cuft(Gas.Nitrox50)
 
@@ -221,7 +223,7 @@ class CompactSimilarSegmentsTest {
         cylinder: Cylinder = airCylinder,
         gfCeilingAtEnd: Double = 0.0,
         breathingMode: BreathingMode = BreathingMode.oc(),
-    ) = DiveSegment(
+    ) = DiveSegment.fromMeters(
         start = start,
         duration = duration,
         startDepth = depth,
@@ -230,6 +232,7 @@ class CompactSimilarSegmentsTest {
         gfCeilingAtEnd = gfCeilingAtEnd,
         type = type,
         breathingMode = breathingMode,
+        environment = environment,
     )
 
     private fun travelSegment(
@@ -239,7 +242,7 @@ class CompactSimilarSegmentsTest {
         duration: Int,
         cylinder: Cylinder = airCylinder,
         breathingMode: BreathingMode = BreathingMode.oc(),
-    ) = DiveSegment(
+    ) = DiveSegment.fromMeters(
         start = start,
         duration = duration,
         startDepth = startDepth,
@@ -252,6 +255,7 @@ class CompactSimilarSegmentsTest {
             DiveSegment.Type.ASCENT
         },
         breathingMode = breathingMode,
+        environment = environment,
     )
 }
 

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
@@ -455,6 +455,63 @@ class DivePlannerTest {
         segments.assertSegment(17, DiveSegment.Type.DECO_STOP, startDepth = 3.0,  endDepth = 3.0,  duration = 13, gas = diluent, breathingMode = high)
         segments.assertSegment(18, DiveSegment.Type.ASCENT,    startDepth = 3.0,  endDepth = 0.0,  duration = 1,  gas = diluent, breathingMode = high)
     }
+
+    /**
+     * Abysner uses very exact calculations, we take into account atmospheric pressures, exact
+     * density values for different types of water. This leads to very exact MOD calculations, which
+     * can be slightly different from commonly accepted gas switch depths. Also gas switches are
+     * usually done at 3 meter of 10 feet steps from the surface. The DecompressionPlanner takes
+     * care of aligning gas switches to those steps. We also use a tiny bit of tolerace on MOD
+     * calculations to make sure that especially in the metric system 100% oxygen at sea-level using
+     * 1.6 as max PPO2 still
+     * allows switching at a depth of 6 meters (while in reality it is probably closer to 5.9
+     * meters), without these tolerances it would clamp to 3 meters which divers don't really expect
+     * nor plan for.
+     *
+     * This test verifies that for very common gas types, the switches are at the expected depths
+     * when diving at sea-level.
+     *
+     * Also see: [Gas.MOD_TOLERANCE].
+     */
+    @Test
+    fun referencePlanGasSwitchDepths_switchesAtCommonlyAcceptedDepths() {
+        val bottomGas = Cylinder.steel12Liter(Gas.Air)
+        val decoGas50 = Cylinder.aluminium80Cuft(Gas.Nitrox50)
+        val decoGas80 = Cylinder.aluminium80Cuft(Gas.Nitrox80)
+        val decoGasO2 = Cylinder.aluminium80Cuft(Gas.Oxygen)
+        val divePlanner = DivePlanner(
+            Configuration(
+                maxAscentRate = 5.0,
+                maxDescentRate = 5.0,
+                gfLow = 0.35,
+                gfHigh = 0.75,
+                salinity = Salinity.WATER_SALT,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                altitude = 0.0,
+                decoStepSize = 3,
+                lastDecoStopDepth = 3,
+                gasSwitchTime = 1
+            )
+        )
+
+        val plannedSections = listOf(DiveProfileSection(duration = 20, 40, bottomGas))
+
+        val divePlan = divePlanner.addDive(
+            plan = plannedSections,
+            cylinders = listOf(decoGas50, decoGas80, decoGasO2).assign()
+        )
+        val plan = divePlan.segmentsCollapsed
+
+        // EAN50 switch at 21m (tolerant MOD ~22.2m, next 3m grid point at 21m)
+        plan.assertSegment(3, DiveSegment.Type.GAS_SWITCH, startDepth = 21.0, endDepth = 21.0, duration = 1, gas = bottomGas)
+        plan.assertSegment(4, DiveSegment.Type.ASCENT,     startDepth = 21.0, endDepth = 9.0,  duration = 3, gas = decoGas50)
+        // EAN80 switch at 9m (tolerant MOD ~10.3m, next 3m grid point at 9m)
+        plan.assertSegment(5, DiveSegment.Type.GAS_SWITCH, startDepth = 9.0,  endDepth = 9.0,  duration = 1, gas = decoGas50)
+        plan.assertSegment(6, DiveSegment.Type.ASCENT,     startDepth = 9.0,  endDepth = 6.0,  duration = 1, gas = decoGas80)
+        // O2 switch at 6m (tolerant MOD ~6.3m, on the 3m grid)
+        plan.assertSegment(7, DiveSegment.Type.GAS_SWITCH, startDepth = 6.0,  endDepth = 6.0,  duration = 1, gas = decoGas80)
+        plan.assertSegment(8, DiveSegment.Type.ASCENT,     startDepth = 6.0,  endDepth = 3.0,  duration = 1, gas = decoGasO2)
+    }
 }
 
 fun List<DiveSegment>.assertSegment(

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculatorTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/OxygenToxicityCalculatorTest.kt
@@ -106,7 +106,7 @@ class OxygenToxicityCalculatorTest {
 
     private fun flatSegment(depth: Double, duration: Int, gas: Gas, breathingMode: BreathingMode) =
         listOf(
-            DiveSegment(
+            DiveSegment.fromMeters(
                 start = 0,
                 duration = duration,
                 startDepth = depth,
@@ -115,6 +115,7 @@ class OxygenToxicityCalculatorTest {
                 gfCeilingAtEnd = 0.0,
                 type = DiveSegment.Type.FLAT,
                 breathingMode = breathingMode,
+                environment = environment,
             )
         )
 }


### PR DESCRIPTION
The `DecompressionPlanner` public API and internals are now all pressure-based. `DivePlanner` is now the conversion boundary, translating user-provided depths (in meters right now) to pressure before passing further down to the `DecompressionPlanner` and `DecompressionModel`. The `DiveSegment` output class now carries both pressure and (display-unit) for each segments start and end depth.

Required for: #49