### PR TITLE
Add: Edit icon and tooltip hint on selected dive button

### DIFF
--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/DiveConfigurationScreenScreenshotTestKt/DiveConfigurationScreenScreenshotTest_d12982c9_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/DiveConfigurationScreenScreenshotTestKt/DiveConfigurationScreenScreenshotTest_d12982c9_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96728edc9408b4a847a5297531d3215758431631f216afc4879b0c9e63149fb9
-size 250054
+oid sha256:10dcc62b67f2bdcde7511fcb7bfdc2943ad56e768de9b800aad6c19ff5797283
+size 249547

--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenFoldableScreenshotTest_2db23271_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenFoldableScreenshotTest_2db23271_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:596b95cac42dd2c8355159722537fc4fcf677da6e1b09093a2d56772fe993b87
-size 70413
+oid sha256:df5f08fcd612cf5d59341392b94373c7854dc47079d7bafc6d082961076eb448
+size 70630

--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenScreenshotTest_d12982c9_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenScreenshotTest_d12982c9_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1c9b3d46c0eb121fd8c120ba5aa2942d865bc1224e8f9b36878e43837df63ad
-size 183015
+oid sha256:263cec4c09269f796c9b5e86a578c9c8a075acca2c83c3126265b9f4eacf1f76
+size 183260

--- a/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenWithWarningsScreenshotTest_d12982c9_0.png
+++ b/androidApp/src/screenshotTestDebug/reference/org/neotech/app/abysner/presentation/screens/planner/PlannerScreenScreenshotTestKt/PlannerScreenWithWarningsScreenshotTest_d12982c9_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9f8eaf44e2b57fafcbc031eed91020cc61fa629dd52fd2776b635580c76ea65
-size 211433
+oid sha256:366813f867d3b1fdec262aae9e5a72099141e23f61c394e84ed2ceb7341d6cdf
+size 211661

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/DefaultTooltip.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/DefaultTooltip.kt
@@ -1,0 +1,50 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.presentation.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.TooltipScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TooltipScope.DefaultTooltip(
+    text: String,
+    modifier: Modifier = Modifier,
+    showCaret: Boolean = true,
+    shadowElevation: Dp = 8.dp,
+) {
+    PlainTooltip(
+        modifier = modifier,
+        caretShape = if (showCaret) {
+            TooltipDefaults.caretShape()
+        } else {
+            null
+        },
+        shadowElevation = shadowElevation,
+    ) {
+        Text(
+            text = text,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/PathwayButtonsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/PathwayButtonsComponent.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -35,7 +36,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -45,19 +45,22 @@ import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun <T : PathwayButtonItem> PathwayButtonsComponent(
     modifier: Modifier = Modifier,
@@ -68,7 +71,7 @@ fun <T : PathwayButtonItem> PathwayButtonsComponent(
     onAddClicked: () -> Unit = {},
     addButtonLabel: String = "Add",
     limit: Int = Int.MAX_VALUE,
-    limitTooltipText: String = "",
+    showEditTooltip: Boolean = false,
 ) {
     val buttonModifier = if (vertical) {
         Modifier.fillMaxWidth()
@@ -86,7 +89,8 @@ fun <T : PathwayButtonItem> PathwayButtonsComponent(
                 buttonModifier = buttonModifier,
                 addButtonLabel = addButtonLabel,
                 limit = limit,
-                limitTooltipText = limitTooltipText,
+                showEditTooltip = showEditTooltip,
+                tooltipAnchorPosition = TooltipAnchorPosition.End,
                 connector = { label, isActive -> VerticalConnector(label, isActive) },
             )
         }
@@ -106,7 +110,8 @@ fun <T : PathwayButtonItem> PathwayButtonsComponent(
                 onAddClicked = onAddClicked,
                 addButtonLabel = addButtonLabel,
                 limit = limit,
-                limitTooltipText = limitTooltipText,
+                showEditTooltip = showEditTooltip,
+                tooltipAnchorPosition = TooltipAnchorPosition.Below,
                 connector = { label, isActive -> HorizontalConnector(label, isActive) },
             )
         }
@@ -123,7 +128,8 @@ private fun <T : PathwayButtonItem> PathwayButtonsList(
     buttonModifier: Modifier = Modifier,
     addButtonLabel: String = "Add",
     limit: Int = Int.MAX_VALUE,
-    limitTooltipText: String = "",
+    showEditTooltip: Boolean = false,
+    tooltipAnchorPosition: TooltipAnchorPosition = TooltipAnchorPosition.Below,
     connector: @Composable (label: String, isActive: Boolean) -> Unit,
 ) {
     buttonLabels.forEachIndexed { index, label ->
@@ -133,6 +139,8 @@ private fun <T : PathwayButtonItem> PathwayButtonsList(
             isSelected = index == selectedButton,
             modifier = buttonModifier,
             onClick = onClick,
+            showEditTooltip = showEditTooltip && index == selectedButton,
+            tooltipAnchorPosition = tooltipAnchorPosition,
         )
         if (index < buttonLabels.size - 1) {
             connector(label.nextConnectorLabel, index == selectedButton - 1)
@@ -147,15 +155,9 @@ private fun <T : PathwayButtonItem> PathwayButtonsList(
 
     TooltipBox(
         modifier = buttonModifier,
-        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Below),
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(tooltipAnchorPosition),
         tooltip = {
-            PlainTooltip {
-                Text(
-                    text = limitTooltipText,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
+            DefaultTooltip(showCaret = false, text = "Easy there, Cousteau!\nPlans are limited to $limit dives.")
         },
         state = tooltipState,
     ) {
@@ -183,6 +185,7 @@ private fun <T : PathwayButtonItem> PathwayButtonsList(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun <T : PathwayButtonItem> SelectableButton(
     index: Int,
@@ -190,15 +193,41 @@ private fun <T : PathwayButtonItem> SelectableButton(
     isSelected: Boolean,
     modifier: Modifier = Modifier,
     onClick: (Int, T) -> Unit,
+    showEditTooltip: Boolean = false,
+    tooltipAnchorPosition: TooltipAnchorPosition = TooltipAnchorPosition.Below,
 ) {
     if (isSelected) {
-        Button(modifier = modifier, onClick = { onClick(index, label) }) {
-            Text(label.buttonLabel)
+        val tooltipState = rememberTooltipState(isPersistent = true)
+
+        LaunchedEffect(showEditTooltip) {
+            if (showEditTooltip) {
+                tooltipState.show()
+            }
+        }
+
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(tooltipAnchorPosition),
+            tooltip = {
+                DefaultTooltip(text = "Looking for dive mode or surface interval?\nTap the selected dive again.")
+            },
+            state = tooltipState,
+        ) {
+            Button(
+                modifier = modifier.semantics { contentDescription = "Edit ${label.buttonLabel}" },
+                onClick = { onClick(index, label) },
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Text(modifier = Modifier.padding(start = ButtonDefaults.IconSpacing), text = label.buttonLabel)
+            }
         }
     } else {
         OutlinedButton(
-            modifier = modifier,
-            onClick = { onClick(index, label) }
+            modifier = modifier.semantics { contentDescription = "View ${label.buttonLabel}" },
+            onClick = { onClick(index, label) },
         ) {
             Text(
                 text = label.buttonLabel,
@@ -328,3 +357,4 @@ private fun VerticalPathwayButtonsComponentPreview() {
         )
     }
 }
+

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/DiveConfigurationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/DiveConfigurationScreen.kt
@@ -92,7 +92,7 @@ fun DiveConfigurationScreen(
             topBar = {
                 Surface(shadowElevation = 8.dp, color = MaterialTheme.colorScheme.background) {
                     TopAppBar(
-                        title = { Text("Dive configuration") },
+                        title = { Text("Plan configuration") },
                         navigationIcon = {
 
                             val currentBackStackEntry by navController.currentBackStackEntryAsState()

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreen.kt
@@ -104,6 +104,7 @@ fun PlannerScreen(
         onUpdateSurfaceInterval = { i, d -> viewModel.updateSurfaceInterval(i, d) },
         onDiveModeChanged = { viewModel.setDiveMode(it) },
         onAvailableForBailoutChanged = { cylinder, value -> viewModel.toggleAvailableForBailout(cylinder, value) },
+        onEditDive = { viewModel.onEditDive() },
     )
 }
 
@@ -126,6 +127,7 @@ fun PlannerScreen(
     onUpdateSurfaceInterval: (Int, Duration) -> Unit = { _, _ -> },
     onDiveModeChanged: (DiveMode) -> Unit = {},
     onAvailableForBailoutChanged: (Cylinder, Boolean) -> Unit = { _, _ -> },
+    onEditDive: () -> Unit = {},
 ) {
     AbysnerTheme {
 
@@ -145,10 +147,13 @@ fun PlannerScreen(
         val onDiveButtonClick: (Int, DefaultPathwayButtonItem) -> Unit = { index, _ ->
             if (index == uiState.selectedDiveIndex) {
                 diveSheet = ModalTarget.Edit(index)
+                onEditDive()
             } else {
                 onSelectDive(index)
             }
         }
+
+        val showEditTooltip = uiState.settingsModel.showDiveEditTooltip
 
         BoxWithConstraints {
             val isWide = maxWidth >= 600.dp
@@ -178,7 +183,7 @@ fun PlannerScreen(
                                 onAddClicked = { diveSheet = ModalTarget.Add },
                                 addButtonLabel = "Add dive",
                                 limit = MAX_DIVES,
-                                limitTooltipText = MAX_DIVES_TOOLTIP,
+                                showEditTooltip = showEditTooltip,
                             )
                         }
                         Box(modifier = Modifier.weight(1f)) {
@@ -231,7 +236,7 @@ fun PlannerScreen(
                                     onAddClicked = { diveSheet = ModalTarget.Add },
                                     addButtonLabel = "Add dive",
                                     limit = MAX_DIVES,
-                                    limitTooltipText = MAX_DIVES_TOOLTIP,
+                                    showEditTooltip = showEditTooltip,
                                 )
                             }
                         }
@@ -293,7 +298,6 @@ fun PlannerScreen(
 }
 
 private const val MAX_DIVES = 10
-private const val MAX_DIVES_TOOLTIP = "Easy there, Cousteau!\nPlans are limited to $MAX_DIVES dives."
 
 @Preview(device = DEVICE_PHONE_MAX_HEIGHT)
 @Composable

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
@@ -57,7 +57,7 @@ import kotlin.time.measureTimedValue
 @Inject
 class PlanScreenViewModel(
     private val planningRepository: PlanningRepository,
-    settingsRepository: SettingsRepository,
+    private val settingsRepository: SettingsRepository,
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     calculationDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
@@ -108,6 +108,12 @@ class PlanScreenViewModel(
     fun setContingency(deeper: Boolean, longer: Boolean, bailout: Boolean) = mutateDive { DiveEditorViewModelDelegate.setContingency(it, deeper, longer, bailout) }
     fun setDiveMode(mode: DiveMode) = mutateDive { DiveEditorViewModelDelegate.setDiveMode(it, mode) }
     fun toggleAvailableForBailout(cylinder: Cylinder, availableForBailout: Boolean) = mutateDive { DiveEditorViewModelDelegate.toggleAvailableForBailout(it, cylinder, availableForBailout) }
+
+    fun onEditDive() {
+        if (settingsRepository.settings.value.showDiveEditTooltip) {
+            settingsRepository.updateSettings { it.copy(showDiveEditTooltip = false) }
+        }
+    }
 
     fun selectDive(index: Int) {
         planInput.update { it.copy(selectedDiveIndex = index) }

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlannerTopAppBar.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlannerTopAppBar.kt
@@ -120,7 +120,7 @@ private fun RowScope.AppBarActions(
     IconButton(onClick = { navController.navigate(Destinations.DIVE_CONFIGURATION.destinationName) }) {
         Icon(
             painter = painterResource(resource = Res.drawable.ic_outline_tune_24),
-            contentDescription = "Dive configuration"
+            contentDescription = "Plan configuration"
         )
     }
 

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/settings/Mappers.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/settings/Mappers.kt
@@ -20,13 +20,15 @@ import org.neotech.app.abysner.domain.settings.model.ThemeMode
 fun SettingsModel.toResource() = SettingsResourceV1(
     showBasicDecoTable = showBasicDecoTable,
     termsAndConditionsAccepted = termsAndConditionsAccepted,
-    themeMode = themeMode.toResource()
+    themeMode = themeMode.toResource(),
+    showDiveEditTooltip = showDiveEditTooltip,
 )
 
 fun SettingsResourceV1.toModel() = SettingsModel(
     showBasicDecoTable = showBasicDecoTable,
     termsAndConditionsAccepted = termsAndConditionsAccepted,
-    themeMode = themeMode.toModel()
+    themeMode = themeMode.toModel(),
+    showDiveEditTooltip = showDiveEditTooltip,
 )
 
 private fun ThemeMode.toResource() = when (this) {

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/settings/resources/SettingsResourceV1.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/settings/resources/SettingsResourceV1.kt
@@ -21,6 +21,7 @@ data class SettingsResourceV1(
     val showBasicDecoTable: Boolean,
     val termsAndConditionsAccepted: Boolean,
     val themeMode: ThemeModeResource = ThemeModeResource.SYSTEM,
+    val showDiveEditTooltip: Boolean = true,
 ): SerializableResource {
 
     @Serializable

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/settings/model/SettingsModel.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/settings/model/SettingsModel.kt
@@ -16,4 +16,5 @@ data class SettingsModel(
     val showBasicDecoTable: Boolean = false,
     val termsAndConditionsAccepted: Boolean = false,
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    val showDiveEditTooltip: Boolean = true,
 )


### PR DESCRIPTION
The selected dive button now shows a small edit icon to signal that tapping it again opens the dive configuration sheet. A tooltip keeps showing until the user opens the dive configuration sheet at least once.