### PR TITLE
Refactor: Extract grid logic out of `DecompressionPlanner`

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecoGrid.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecoGrid.kt
@@ -1,0 +1,148 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.decompression
+
+import org.neotech.app.abysner.domain.utilities.ceilTolerant
+import org.neotech.app.abysner.domain.utilities.equalsTolerant
+import org.neotech.app.abysner.domain.utilities.greaterThanTolerant
+import org.neotech.app.abysner.domain.utilities.lessThanOrEqualTolerant
+import org.neotech.app.abysner.domain.utilities.lessThanTolerant
+import kotlin.math.floor
+import kotlin.math.round
+
+/**
+ * While the decompression algorithm calculates the required deco stops and gas switches at any
+ * arbitrary pressure, divers plan and work in whole meters or feet, and for gas switches and
+ * decompression stops in steps of 3 meter or 10 feet.
+ *
+ * The DecoGrid encapsulates this grid-thinking logic, and allows configuring a grid for different
+ * display units (meters, feet or anything custom).
+ */
+class DecoGrid(
+    val surfacePressure: Double,
+    /**
+     * The deco step size in pressure (for example about 0.3 bar for 3m steps) used to determine at
+     * which pressures deco stops are required. Must be an exact multiple of
+     * [displayUnitPressureDelta].
+     */
+    val decoStepSizePressureDelta: Double,
+    /**
+     * The ambient pressure of the last allowed deco stop, must fall on a
+     * [displayUnitPressureDelta] grid point relative to [surfacePressure].
+     */
+    val lastDecoStopAmbientPressure: Double,
+    /**
+     * The pressure delta that corresponds to the smallest display unit step (for example about
+     * 0.1 bar for steps of 1 meter).
+     */
+    val displayUnitPressureDelta: Double,
+) {
+
+    init {
+        // Both decoStepSizePressureDelta and lastDecoStopAmbientPressure must align to
+        // displayUnitPressureDelta so that deco stops always land on whole display units (e.g.
+        // 3, 6 or 9 meter instead of 2.9, 5.8 or 8.7 meter).
+        val decoStepInDisplayUnits = decoStepSizePressureDelta / displayUnitPressureDelta
+        require(decoStepInDisplayUnits.equalsTolerant(round(decoStepInDisplayUnits))) {
+            "decoStepSizePressureDelta ($decoStepSizePressureDelta) must be an exact multiple of displayUnitPressureDelta ($displayUnitPressureDelta)."
+        }
+        val lastDecoStopDepthPressure = lastDecoStopAmbientPressure - surfacePressure
+        val lastDecoStopInDisplayUnits = lastDecoStopDepthPressure / displayUnitPressureDelta
+        require(lastDecoStopInDisplayUnits.equalsTolerant(round(lastDecoStopInDisplayUnits))) {
+            "lastDecoStopAmbientPressure ($lastDecoStopAmbientPressure) must fall on a display unit grid point relative to surfacePressure ($surfacePressure)."
+        }
+    }
+
+    /**
+     * Snaps a raw ceiling pressure to the nearest deeper deco stop pressure on the grid, clamping
+     * to [lastDecoStopAmbientPressure] if the result falls between [surfacePressure] and the last
+     * allowed stop. Returns [surfacePressure] when the ceiling is at or above the surface.
+     */
+    fun snapCeilingToDecoGrid(rawCeilingPressure: Double): Double {
+        if (rawCeilingPressure.lessThanOrEqualTolerant(surfacePressure)) {
+            return surfacePressure
+        }
+
+        val depthPressure = rawCeilingPressure - surfacePressure
+
+        // Snap (ceil) to the deco grid (e.g. 3 meter or 10 feet increments). Because
+        // decoStepSizePressureDelta is guaranteed to be an exact multiple of
+        // displayUnitPressureDelta, this always lands on a display-unit boundary too.
+        val decoGridSteps = ceilTolerant(depthPressure / decoStepSizePressureDelta).toInt()
+        if (decoGridSteps <= 0) {
+            return surfacePressure
+        }
+        val snappedPressure = surfacePressure + decoGridSteps * decoStepSizePressureDelta
+
+        // If the deco stop falls between surface and the last allowed deco stop depth, clamp to
+        // the last allowed deco stop.
+        return if (snappedPressure.lessThanTolerant(lastDecoStopAmbientPressure) && snappedPressure.greaterThanTolerant(surfacePressure)) {
+            lastDecoStopAmbientPressure
+        } else {
+            snappedPressure
+        }
+    }
+
+    /**
+     * Returns the next shallower deco stop pressure that is shallower than [fromAmbientPressure].
+     * If the given ambient pressure is already on a deco stop pressure, returns one step shallower.
+     * Returns [surfacePressure] when the next shallower deco stop would fall between
+     * [surfacePressure] and [lastDecoStopAmbientPressure].
+     */
+    fun findNextDecoStopPressure(fromAmbientPressure: Double): Double {
+        val depthPressure = fromAmbientPressure - surfacePressure
+        if (depthPressure.lessThanOrEqualTolerant(0.0)) {
+            return surfacePressure
+        }
+
+        val steps = depthPressure / decoStepSizePressureDelta
+        val nearestWholeStep = round(steps)
+        val isOnGrid = steps.equalsTolerant(nearestWholeStep)
+
+        // If exactly on a deco-grid point, go one step shallower, so we select the next stop. If
+        // not, we are in between deco-grid points. In that case the next stop is the nearest
+        // shallower one, so use floor to find it.
+        val nextStep = if (isOnGrid) {
+            nearestWholeStep.toInt() - 1
+        } else {
+            // No need for tolerance, if there was any floating-point noise the isOnGrid check would have caught it
+            floor(steps).toInt()
+        }
+        if (nextStep <= 0) {
+            // No more deco stops, next step on the grid is surface, return early and exactly
+            return surfacePressure
+        }
+
+        val nextPressure = surfacePressure + nextStep * decoStepSizePressureDelta
+
+        // If the next stop falls between surface and the configured last deco stop depth, skip to
+        // surface (the dive was configured to not stop in between the surface and
+        // lastDecoStopAmbientPressure).
+        return if (nextPressure.lessThanTolerant(lastDecoStopAmbientPressure)) {
+            surfacePressure
+        } else {
+            nextPressure
+        }
+    }
+
+    /**
+     * Returns true if [ambientPressure] falls on a deco stop level.
+     */
+    fun isAtDecoStop(ambientPressure: Double): Boolean {
+        val steps = (ambientPressure - surfacePressure) / decoStepSizePressureDelta
+        val nearestWholeStep = round(steps)
+        // If nearest whole step is within tolerance to the actual step we are at, the diver is on a
+        // deco grid point.
+        return steps.equalsTolerant(nearestWholeStep)
+    }
+}

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlanner.kt
@@ -25,15 +25,12 @@ import org.neotech.app.abysner.domain.core.physics.Pressure
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
 import org.neotech.app.abysner.domain.diveplanning.DivePlanner
 import org.neotech.app.abysner.domain.utilities.ceilTolerant
-import org.neotech.app.abysner.domain.utilities.equalsTolerant
-import kotlin.math.floor
 import org.neotech.app.abysner.domain.utilities.greaterThanOrEqualTolerant
 import org.neotech.app.abysner.domain.utilities.greaterThanTolerant
 import org.neotech.app.abysner.domain.utilities.lessThanOrEqualTolerant
 import org.neotech.app.abysner.domain.utilities.lessThanTolerant
 import kotlin.math.abs
 import kotlin.math.max
-import kotlin.math.round
 
 /**
  * The decompression planner makes use of a decompression model and adds algorithms to figure out
@@ -46,44 +43,14 @@ import kotlin.math.round
  */
 class DecompressionPlanner(
     val model: DecompressionModel,
-    val surfacePressure: Double,
+    val grid: DecoGrid,
     val maxPpO2: Double,
     val maxEquivalentNarcoticAmbientPressure: Double,
     val ascentRatePressureDelta: Double,
-    /**
-     * The deco step size in pressure (for example about 0.3 bar for 3m steps) used to determine at
-     * which pressures deco stops are required. Must be an exact multiple of
-     * [displayUnitPressureDelta].
-     */
-    val decoStepSizePressureDelta: Double,
-    /**
-     * The ambient pressure of the last allowed deco stop, must be aligned to the deco step size.
-     */
-    val lastDecoStopAmbientPressure: Double,
-    /**
-     * The pressure delta that corresponds to the smallest display unit step (for example about
-     * 0.1 bar for steps of 1 meter).
-     */
-    val displayUnitPressureDelta: Double,
     val forceMinimalDecoStopTime: Boolean,
     val gasSwitchTime: Int,
     val pressureToDepth: (Double) -> Double,
 ) {
-
-    init {
-        // Both decoStepSizePressureDelta and lastDecoStopAmbientPressure must align to
-        // displayUnitPressureDelta so that deco stops always land on whole display units (e.g.
-        // 3, 6 or 9 meter instead of 2.9, 5.8 or 8.7 meter).
-        val decoStepInDisplayUnits = decoStepSizePressureDelta / displayUnitPressureDelta
-        require(decoStepInDisplayUnits.equalsTolerant(round(decoStepInDisplayUnits))) {
-            "decoStepSizePressureDelta ($decoStepSizePressureDelta) must be an exact multiple of displayUnitPressureDelta ($displayUnitPressureDelta)."
-        }
-        val lastDecoStopDepthPressure = lastDecoStopAmbientPressure - surfacePressure
-        val lastDecoStopInDisplayUnits = lastDecoStopDepthPressure / displayUnitPressureDelta
-        require(lastDecoStopInDisplayUnits.equalsTolerant(round(lastDecoStopInDisplayUnits))) {
-            "lastDecoStopAmbientPressure ($lastDecoStopAmbientPressure) must fall on a display unit grid point relative to surfacePressure ($surfacePressure)."
-        }
-    }
 
     private var isLookahead = false
 
@@ -96,7 +63,7 @@ class DecompressionPlanner(
     /**
      * Current dive depth in ambient pressure (bar).
      */
-    var ambientPressure: Double = surfacePressure
+    var ambientPressure: Double = grid.surfacePressure
         private set
 
     private val decoGases = mutableListOf<Cylinder>()
@@ -230,7 +197,7 @@ class DecompressionPlanner(
             return 0
         }
         val decoSegments = lookahead {
-            calculateDecompression(toAmbientPressure = surfacePressure, breathingMode = breathingMode, setpointSwitch = setpointSwitch).toList()
+            calculateDecompression(toAmbientPressure = grid.surfacePressure, breathingMode = breathingMode, setpointSwitch = setpointSwitch).toList()
         }
         alternativeAccents[runtime] = decoSegments
         return decoSegments.sumOf { it.duration }
@@ -260,7 +227,7 @@ class DecompressionPlanner(
                 // Check if there is a better gas to breathe at the current pressure
                 val betterDecoGas = findBetterGas(currentCylinder = gas, pressure = currentPressure)
                 // Only start using the better gas when we reach a deco increment point
-                if (betterDecoGas != null && betterDecoGas.gas != gas.gas && isAtDecoIncrement(currentPressure)) {
+                if (betterDecoGas != null && betterDecoGas.gas != gas.gas && grid.isAtDecoStop(currentPressure)) {
                     // Gas switch time is spent on the old gas: the diver is still breathing the
                     // previous gas while preparing to switch (grabbing regulator, purging, etc.).
                     // The actual switch to the new gas happens after the gas switch time.
@@ -277,7 +244,7 @@ class DecompressionPlanner(
                 // Figure out if before we reach the targetPressure gas switches are required at any
                 // of the deco increments between currentPressure and targetPressure (gas switches
                 // are aligned to the decompression stops).
-                var nextPressure = findNextDecoStopPressure(currentPressure)
+                var nextPressure = grid.findNextDecoStopPressure(currentPressure)
                 var nextDecoGas: Cylinder?
                 while(nextPressure.greaterThanOrEqualTolerant(targetPressure)) {
                     nextDecoGas = findBetterGas(currentCylinder = gas, pressure = nextPressure)
@@ -285,7 +252,7 @@ class DecompressionPlanner(
                         targetPressure = nextPressure
                         break
                     }
-                    nextPressure -= decoStepSizePressureDelta
+                    nextPressure -= grid.decoStepSizePressureDelta
                 }
             }
 
@@ -313,7 +280,7 @@ class DecompressionPlanner(
 
         if (!isCcr) {
             val betterDecoGas = findBetterGas(currentCylinder = gas, pressure = currentPressure)
-            if (betterDecoGas != null && betterDecoGas.gas != gas.gas && isAtDecoIncrement(currentPressure)) {
+            if (betterDecoGas != null && betterDecoGas.gas != gas.gas && grid.isAtDecoStop(currentPressure)) {
                 // Gas switch time on the old gas before switching
                 addGasSwitch(currentPressure, gas, gasSwitchTime, effectiveBreathingMode)
                 gas = betterDecoGas
@@ -419,7 +386,7 @@ class DecompressionPlanner(
         }
 
         // Keep making deco stops until the deco ceiling is at or above the surface
-        while (ceiling.greaterThanTolerant(surfacePressure)) {
+        while (ceiling.greaterThanTolerant(grid.surfacePressure)) {
 
             val currentPressure = ceiling
             if(currentPressure.lessThanOrEqualTolerant(toAmbientPressure)) {
@@ -432,7 +399,7 @@ class DecompressionPlanner(
             }
 
             // Check the new ceiling
-            ceiling = max(this.getDecoCeiling(), toAmbientPressure)
+            ceiling = max(this.getGridDecoCeiling(), toAmbientPressure)
 
             // Don't allow ceiling below start depth
             // TODO this check feels a bit weird, shouldn't we just throw if this happens?
@@ -450,9 +417,9 @@ class DecompressionPlanner(
 
                 // If minimal deco step times are required, force stops to also be symmetric!
                 val nextDecoPressure = if(forceMinimalDecoStopTime) {
-                    max(findNextDecoStopPressure(currentPressure), toAmbientPressure)
+                    max(grid.findNextDecoStopPressure(currentPressure), toAmbientPressure)
                 } else {
-                    max(findNextDecoStopPressure(ceiling), toAmbientPressure)
+                    max(grid.findNextDecoStopPressure(ceiling), toAmbientPressure)
                 }
 
                 // Stop at the current deco stop until we can safely ascend to the next deco stop.
@@ -462,7 +429,7 @@ class DecompressionPlanner(
                     this.addDecoStop(currentPressure, gas, 1, effectiveBreathingMode)
                     stopTime++
 
-                    ceiling = max(this.getDecoCeiling(), toAmbientPressure)
+                    ceiling = max(this.getGridDecoCeiling(), toAmbientPressure)
                     if(ceiling.lessThanTolerant(nextDecoPressure) && forceMinimalDecoStopTime) {
                         // Ceiling is skipping a deco step, force the ceiling to be deeper to avoid skipping
                         ceiling = nextDecoPressure
@@ -503,7 +470,7 @@ class DecompressionPlanner(
         breathingMode: BreathingMode,
     ): Double {
 
-        var ceiling: Double = getDecoCeiling()
+        var ceiling: Double = getGridDecoCeiling()
         var nextCeiling = ceiling
         do {
 
@@ -511,8 +478,8 @@ class DecompressionPlanner(
 
             nextCeiling = lookahead {
 
-                if (ceiling.lessThanOrEqualTolerant(surfacePressure)) {
-                    return@lookahead surfacePressure
+                if (ceiling.lessThanOrEqualTolerant(grid.surfacePressure)) {
+                    return@lookahead grid.surfacePressure
                 }
 
                 // Move diver up
@@ -527,14 +494,14 @@ class DecompressionPlanner(
                 )
 
                 // Check new ceiling (could already be higher)
-                getDecoCeiling()
+                getGridDecoCeiling()
             }
         } while(ceiling.greaterThanTolerant(nextCeiling))
 
         // Check if off-gassing during the ascent to the next shallower deco stop clears the
         // ceiling, allowing the current stop to be skipped entirely.
-        val nextDecoPressure = findNextDecoStopPressure(nextCeiling)
-        if (nextCeiling.greaterThanTolerant(surfacePressure) && nextDecoPressure.greaterThanOrEqualTolerant(surfacePressure)) {
+        val nextDecoPressure = grid.findNextDecoStopPressure(nextCeiling)
+        if (nextCeiling.greaterThanTolerant(grid.surfacePressure) && nextDecoPressure.greaterThanOrEqualTolerant(grid.surfacePressure)) {
             if (isCeilingClearedDuringAscent(fromPressure, nextDecoPressure, gas, breathingMode)) {
                 return nextDecoPressure
             }
@@ -558,13 +525,13 @@ class DecompressionPlanner(
         breathingMode: BreathingMode,
         setpointSwitch: SetpointSwitch? = null,
     ): Boolean {
-        if (targetDecoAmbientPressure.lessThanTolerant(surfacePressure)) {
+        if (targetDecoAmbientPressure.lessThanTolerant(grid.surfacePressure)) {
             return false
         }
         val ceilingAfterAscent = lookahead {
             addDecoDepthChange(
                 fromAmbientPressure,
-                targetDecoAmbientPressure.coerceAtLeast(surfacePressure),
+                targetDecoAmbientPressure.coerceAtLeast(grid.surfacePressure),
                 maxPpO2,
                 maxEquivalentNarcoticAmbientPressure,
                 gas,
@@ -572,80 +539,12 @@ class DecompressionPlanner(
                 breathingMode,
                 setpointSwitch
             )
-            getDecoCeiling()
+            getGridDecoCeiling()
         }
         return ceilingAfterAscent.lessThanOrEqualTolerant(targetDecoAmbientPressure)
     }
 
-    private fun getDecoCeiling(): Double {
-        val rawCeiling = model.getCeiling().value
-        if (rawCeiling.lessThanOrEqualTolerant(surfacePressure)) {
-            return surfacePressure
-        }
-
-        val depthPressure = rawCeiling - surfacePressure
-
-        // Snap (ceil) to the deco grid (e.g. 3 meter or 10 feet increments). Because
-        // decoStepSizePressureDelta is guaranteed to be an exact multiple of
-        // displayUnitPressureDelta, this always lands on a display-unit boundary too.
-        val decoGridSteps = ceilTolerant(depthPressure / decoStepSizePressureDelta).toInt()
-        if (decoGridSteps <= 0) {
-            return surfacePressure
-        }
-        val snappedPressure = surfacePressure + decoGridSteps * decoStepSizePressureDelta
-
-        // If the deco stop falls between surface and the last allowed deco stop depth, clamp to
-        // the last allowed deco stop.
-        return if (snappedPressure.lessThanTolerant(lastDecoStopAmbientPressure) && snappedPressure.greaterThanTolerant(surfacePressure)) {
-            lastDecoStopAmbientPressure
-        } else {
-            snappedPressure
-        }
-    }
-
-    private fun findNextDecoStopPressure(fromAmbientPressure: Double): Double {
-        val depthPressure = fromAmbientPressure - surfacePressure
-        if (depthPressure.lessThanOrEqualTolerant(0.0)) {
-            return surfacePressure
-        }
-
-        val steps = depthPressure / decoStepSizePressureDelta
-        val nearestWholeStep = round(steps)
-        val isOnGrid = steps.equalsTolerant(nearestWholeStep)
-
-        // If exactly on a deco-grid point, go one step shallower, so we select the next stop. If
-        // not, we are in between deco-grid points. In that case the next stop is the nearest
-        // shallower one, so use floor to find it.
-        val nextStep = if (isOnGrid) {
-            nearestWholeStep.toInt() - 1
-        } else {
-            // No need for tolerance, if there was any floating-point noise the isOnGrid check would have caught it
-            floor(steps).toInt()
-        }
-        if (nextStep <= 0) {
-            // No more deco stops, next step on the grid is surface, return early and exactly
-            return surfacePressure
-        }
-
-        val nextPressure = surfacePressure + nextStep * decoStepSizePressureDelta
-
-        // If the next stop falls between surface and the configured last deco stop depth, skip to
-        // surface (the dive was configured to not stop in between the surface and
-        // lastDecoStopAmbientPressure).
-        return if (nextPressure.lessThanTolerant(lastDecoStopAmbientPressure)) {
-            surfacePressure
-        } else {
-            nextPressure
-        }
-    }
-
-    private fun isAtDecoIncrement(pressure: Double): Boolean {
-        val steps = (pressure - surfacePressure) / decoStepSizePressureDelta
-        val nearestWholeStep = round(steps)
-        // If nearest whole step is within tolerance to the actual step we are at, the diver is on a
-        // deco grid point.
-        return steps.equalsTolerant(nearestWholeStep)
-    }
+    private fun getGridDecoCeiling(): Double = grid.snapCeilingToDecoGrid(model.getCeiling().value)
 
     private fun <T> lookahead(block: () -> T): T {
         val savedRuntime = runtime
@@ -679,4 +578,3 @@ class DecompressionPlanner(
         return segments.toPersistentList()
     }
 }
-

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
@@ -22,6 +22,7 @@ import org.neotech.app.abysner.domain.core.model.SetpointSwitch
 import org.neotech.app.abysner.domain.core.physics.ambientPressureToMeters
 import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.core.physics.metersToHydrostaticPressure
+import org.neotech.app.abysner.domain.decompression.DecoGrid
 import org.neotech.app.abysner.domain.decompression.DecompressionPlanner
 import org.neotech.app.abysner.domain.decompression.algorithm.DecompressionModel
 import org.neotech.app.abysner.domain.decompression.algorithm.buhlmann.Buhlmann
@@ -256,17 +257,20 @@ class DivePlanner(
         configuration: Configuration,
     ): DecompressionPlanner {
         val environment = configuration.environment
-        return DecompressionPlanner(
+        val grid = DecoGrid(
             surfacePressure = environment.atmosphericPressure,
-            maxPpO2 = configuration.maxPPO2Deco,
-            maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(configuration.maxEND, environment).value,
-            ascentRatePressureDelta = metersToHydrostaticPressure(configuration.maxAscentRate, environment).value,
             decoStepSizePressureDelta = metersToHydrostaticPressure(configuration.decoStepSize.toDouble(), environment).value,
             lastDecoStopAmbientPressure = metersToAmbientPressure(configuration.lastDecoStopDepth.toDouble(), environment).value,
             displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+        )
+        return DecompressionPlanner(
+            model = model,
+            grid = grid,
+            maxPpO2 = configuration.maxPPO2Deco,
+            maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(configuration.maxEND, environment).value,
+            ascentRatePressureDelta = metersToHydrostaticPressure(configuration.maxAscentRate, environment).value,
             forceMinimalDecoStopTime = configuration.forceMinimalDecoStopTime,
             gasSwitchTime = configuration.gasSwitchTime,
-            model = model,
             pressureToDepth = { pressure ->
                 // This is not strictly required to make the UI work, since the UI already formats
                 // to zero decimals or 1 maybe 2 decimals at most. However, it makes the current

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/DecoGridTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/DecoGridTest.kt
@@ -1,0 +1,180 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.domain.decompression
+
+import org.neotech.app.abysner.domain.core.model.Environment
+import org.neotech.app.abysner.domain.core.physics.feetToAmbientPressure
+import org.neotech.app.abysner.domain.core.physics.feetToHydrostaticPressure
+import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
+import org.neotech.app.abysner.domain.core.physics.metersToHydrostaticPressure
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DecoGridTest {
+
+    private val environment = Environment.SeaLevelFresh
+    private val surfacePressure = environment.atmosphericPressure
+
+    @Test
+    fun init_rejectsDecoStepNotMultipleOfDisplayUnit() {
+        assertFailsWith<IllegalArgumentException> {
+            DecoGrid(
+                surfacePressure = surfacePressure,
+                decoStepSizePressureDelta = metersToHydrostaticPressure(2.0, environment).value,
+                displayUnitPressureDelta = metersToHydrostaticPressure(3.0, environment).value,
+                lastDecoStopAmbientPressure = metersToAmbientPressure(2.0, environment).value,
+            )
+        }
+    }
+
+    @Test
+    fun init_acceptsDecoStepThatIsMultipleOfDisplayUnit() {
+        DecoGrid(
+            surfacePressure = surfacePressure,
+            decoStepSizePressureDelta = metersToHydrostaticPressure(3.0, environment).value,
+            displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+            lastDecoStopAmbientPressure = metersToAmbientPressure(3.0, environment).value,
+        )
+    }
+
+    @Test
+    fun init_rejectsLastDecoStopNotOnDisplayUnitGrid() {
+        assertFailsWith<IllegalArgumentException> {
+            DecoGrid(
+                surfacePressure = surfacePressure,
+                decoStepSizePressureDelta = metersToHydrostaticPressure(3.0, environment).value,
+                displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+                lastDecoStopAmbientPressure = metersToAmbientPressure(2.5, environment).value,
+            )
+        }
+    }
+
+    @Test
+    fun init_acceptsLastDecoStopOnDisplayUnitGrid() {
+        DecoGrid(
+            surfacePressure = surfacePressure,
+            decoStepSizePressureDelta = metersToHydrostaticPressure(3.0, environment).value,
+            displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+            lastDecoStopAmbientPressure = metersToAmbientPressure(6.0, environment).value,
+        )
+    }
+
+    @Test
+    fun init_acceptsImperialAlignedStepSize() {
+        DecoGrid(
+            surfacePressure = surfacePressure,
+            decoStepSizePressureDelta = feetToHydrostaticPressure(10.0, environment).value,
+            displayUnitPressureDelta = feetToHydrostaticPressure(1.0, environment).value,
+            lastDecoStopAmbientPressure = feetToAmbientPressure(20.0, environment).value,
+        )
+    }
+
+    @Test
+    fun snapCeilingToDecoGrid_returnsSurfaceWhenCeilingAtOrAboveSurface() {
+        val grid = metricGrid()
+        assertEquals(surfacePressure, grid.snapCeilingToDecoGrid(surfacePressure))
+        assertEquals(surfacePressure, grid.snapCeilingToDecoGrid(surfacePressure - 0.1))
+    }
+
+    @Test
+    fun snapCeilingToDecoGrid_snapsUpToNearestGridPoint() {
+        val grid = metricGrid()
+        val rawCeiling = metersToAmbientPressure(4.0, environment).value
+        val expectedGridCeiling = metersToAmbientPressure(6.0, environment).value
+        assertEquals(expectedGridCeiling, grid.snapCeilingToDecoGrid(rawCeiling))
+    }
+
+    @Test
+    fun snapCeilingToDecoGrid_clampsToLastDecoStop() {
+        val grid = metricGrid(decoStepMeters = 3.0, lastDecoStopMeters = 6.0)
+        val rawCeiling = metersToAmbientPressure(2.0, environment).value
+        val expectedGridCeiling = metersToAmbientPressure(6.0, environment).value
+        assertEquals(expectedGridCeiling, grid.snapCeilingToDecoGrid(rawCeiling))
+    }
+
+    @Test
+    fun findNextDecoStopPressure_returnsSurfaceFromLastDecoStop() {
+        val grid = metricGrid()
+        val currentStop = metersToAmbientPressure(3.0, environment).value
+        assertEquals(surfacePressure, grid.findNextDecoStopPressure(currentStop))
+    }
+
+    @Test
+    fun findNextDecoStopPressure_returnsNextShallowerGridPoint() {
+        val grid = metricGrid()
+        val currentStop = metersToAmbientPressure(9.0, environment).value
+        val expectedNextStop = metersToAmbientPressure(6.0, environment).value
+        assertEquals(expectedNextStop, grid.findNextDecoStopPressure(currentStop))
+    }
+
+    @Test
+    fun findNextDecoStopPressure_betweenGridPointsReturnsShallowerGridPoint() {
+        val grid = metricGrid()
+        // This is a bit of a weird stop location (should in production code not happen, but the
+        // grid code should be able to handle it). Let's just pretend the diver is at 7 meter, then
+        // the next shallower stop to reach should be at 6 meters if we want to get back on the
+        // grid.
+        val currentStop = metersToAmbientPressure(7.0, environment).value
+        val expectedNextStop = metersToAmbientPressure(6.0, environment).value
+        assertEquals(expectedNextStop, grid.findNextDecoStopPressure(currentStop))
+    }
+
+    @Test
+    fun findNextDecoStopPressure_returnsSurfaceWhenNextStopShallowerThanLastDecoStop() {
+        val grid = metricGrid(decoStepMeters = 3.0, lastDecoStopMeters = 6.0)
+        val currentStop = metersToAmbientPressure(6.0, environment).value
+        assertEquals(surfacePressure, grid.findNextDecoStopPressure(currentStop))
+    }
+
+    @Test
+    fun findNextDecoStopPressure_returnsSurfaceAtSurface() {
+        val grid = metricGrid()
+        assertEquals(surfacePressure, grid.findNextDecoStopPressure(surfacePressure))
+    }
+
+    @Test
+    fun isAtDecoStop_returnsTrueForGridPoint() {
+        val grid = metricGrid()
+        val pointOnGrid = metersToAmbientPressure(6.0, environment).value
+        assertTrue(grid.isAtDecoStop(pointOnGrid))
+    }
+
+    @Test
+    fun isAtDecoStop_returnsFalseForNonGridPoint() {
+        val grid = metricGrid()
+        val pointNotOnGrid = metersToAmbientPressure(5.0, environment).value
+        assertFalse(grid.isAtDecoStop(pointNotOnGrid))
+    }
+
+    @Test
+    fun isAtDecoStop_returnsTrueAtSurface() {
+        val grid = metricGrid()
+        assertTrue(grid.isAtDecoStop(surfacePressure))
+    }
+
+    private fun metricGrid(
+        decoStepMeters: Double = 3.0,
+        lastDecoStopMeters: Double = 3.0,
+    ) = DecoGrid(
+        surfacePressure = surfacePressure,
+        decoStepSizePressureDelta = metersToHydrostaticPressure(decoStepMeters, environment).value,
+        lastDecoStopAmbientPressure = metersToAmbientPressure(
+            lastDecoStopMeters,
+            environment
+        ).value,
+        displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+    )
+}

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/DecompressionPlannerTest.kt
@@ -17,7 +17,6 @@ import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Environment
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.core.physics.ambientPressureToFeet
-import org.neotech.app.abysner.domain.core.physics.ambientPressureToMeters
 import org.neotech.app.abysner.domain.core.physics.feetToAmbientPressure
 import org.neotech.app.abysner.domain.core.physics.feetToHydrostaticPressure
 import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
@@ -27,65 +26,10 @@ import org.neotech.app.abysner.domain.decompression.model.compactSimilarSegments
 import org.neotech.app.abysner.domain.utilities.removeFloatingPointNoise
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 class DecompressionPlannerTest {
 
     private val environment = Environment.SeaLevelFresh
-
-    @Test
-    fun init_rejectsDecoStepNotMultipleOfDisplayUnit() {
-        assertFailsWith<IllegalArgumentException> {
-            buildPlanner(
-                decoStepSizePressureDelta = metersToHydrostaticPressure(2.0, environment).value,
-                displayUnitPressureDelta = metersToHydrostaticPressure(3.0, environment).value,
-                lastDecoStopAmbientPressure = metersToAmbientPressure(2.0, environment).value,
-                pressureToDepth = { ambientPressureToMeters(it, environment) }
-            )
-        }
-    }
-
-    @Test
-    fun init_acceptsDecoStepThatIsMultipleOfDisplayUnit() {
-        buildPlanner(
-            decoStepSizePressureDelta = metersToHydrostaticPressure(3.0, environment).value,
-            displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
-            lastDecoStopAmbientPressure = metersToAmbientPressure(3.0, environment).value,
-            pressureToDepth = { ambientPressureToMeters(it, environment) }
-        )
-    }
-
-    @Test
-    fun init_rejectsLastDecoStopNotOnDisplayUnitGrid() {
-        assertFailsWith<IllegalArgumentException> {
-            buildPlanner(
-                decoStepSizePressureDelta = metersToHydrostaticPressure(3.0, environment).value,
-                displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
-                lastDecoStopAmbientPressure = metersToAmbientPressure(2.5, environment).value,
-                pressureToDepth = { ambientPressureToMeters(it, environment) }
-            )
-        }
-    }
-
-    @Test
-    fun init_acceptsLastDecoStopOnDisplayUnitGrid() {
-        buildPlanner(
-            decoStepSizePressureDelta = metersToHydrostaticPressure(3.0, environment).value,
-            displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
-            lastDecoStopAmbientPressure = metersToAmbientPressure(6.0, environment).value,
-            pressureToDepth = { ambientPressureToMeters(it, environment) }
-        )
-    }
-
-    @Test
-    fun init_acceptsImperialAlignedStepSize() {
-        buildPlanner(
-            decoStepSizePressureDelta = feetToHydrostaticPressure(10.0, environment).value,
-            displayUnitPressureDelta = feetToHydrostaticPressure(1.0, environment).value,
-            lastDecoStopAmbientPressure = feetToAmbientPressure(6.0, environment).value,
-            pressureToDepth = { ambientPressureToFeet(it, environment) }
-        )
-    }
 
     @Test
     fun imperialDecoSteps_allSegmentDepthsAlignToTenFootGrid() {
@@ -141,13 +85,15 @@ class DecompressionPlannerTest {
             gfLow = 0.3,
             gfHigh = 0.7,
         ),
-        surfacePressure = environment.atmosphericPressure,
+        grid = DecoGrid(
+            surfacePressure = environment.atmosphericPressure,
+            decoStepSizePressureDelta = decoStepSizePressureDelta,
+            lastDecoStopAmbientPressure = lastDecoStopAmbientPressure,
+            displayUnitPressureDelta = displayUnitPressureDelta,
+        ),
         maxPpO2 = 1.6,
         maxEquivalentNarcoticAmbientPressure = metersToAmbientPressure(30.0, environment).value,
         ascentRatePressureDelta = metersToHydrostaticPressure(5.0, environment).value,
-        decoStepSizePressureDelta = decoStepSizePressureDelta,
-        lastDecoStopAmbientPressure = lastDecoStopAmbientPressure,
-        displayUnitPressureDelta = displayUnitPressureDelta,
         forceMinimalDecoStopTime = false,
         gasSwitchTime = 1,
         pressureToDepth = pressureToDepth,


### PR DESCRIPTION
Moved grid-related state and methods into a standalone `DecoGrid` class. `DecompressionPlanner` now accepts a `DecoGrid` instance and delegates grid operations to it.