### PR TITLE
Add: Imperial support to `DivePlanner` by passing the `UnitSystem` enum

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Configuration.kt
@@ -152,4 +152,24 @@ data class Configuration(
             max(ceilTolerant(pressureDifference / rate).toInt(), 1)
         }
     }
+
+    /**
+     * Snaps all depth-related configuration values to whole display units for the given
+     * [UnitSystem]. For example a stored value of 3.0 meters would in imperial otherwise become
+     * 9.84251969 feet, while we need to be using exactly 10 feet to align with the display and
+     * diver expectations (align to 10 feet grid). The configuration returned by this method remains
+     * in meters, but the values might be fractions now so that when converted to display-units they
+     * align to the display unit grid.
+     */
+    fun snapToDisplayUnit(unitSystem: UnitSystem): Configuration = copy(
+        decoStepSize = unitSystem.snapMetersToDisplayUnit(decoStepSize),
+        lastDecoStopDepth = unitSystem.snapMetersToDisplayUnit(lastDecoStopDepth),
+        maxAscentRate = unitSystem.snapMetersToDisplayUnit(maxAscentRate),
+        maxDescentRate = unitSystem.snapMetersToDisplayUnit(maxDescentRate),
+        maxEND = unitSystem.snapMetersToDisplayUnit(maxEND),
+        contingencyDeeper = unitSystem.snapMetersToDisplayUnit(contingencyDeeper),
+        altitude = unitSystem.snapMetersToDisplayUnit(altitude),
+        ccrToHighSetpointSwitchDepth = ccrToHighSetpointSwitchDepth?.let { unitSystem.snapMetersToDisplayUnit(it) },
+        ccrToLowSetpointSwitchDepth = ccrToLowSetpointSwitchDepth?.let { unitSystem.snapMetersToDisplayUnit(it) },
+    )
 }

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlanner.kt
@@ -19,7 +19,10 @@ import org.neotech.app.abysner.domain.core.model.BreathingMode
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.SetpointSwitch
+import org.neotech.app.abysner.domain.core.model.UnitSystem
+import org.neotech.app.abysner.domain.core.physics.ambientPressureToFeet
 import org.neotech.app.abysner.domain.core.physics.ambientPressureToMeters
+import org.neotech.app.abysner.domain.core.physics.feetToHydrostaticPressure
 import org.neotech.app.abysner.domain.core.physics.metersToAmbientPressure
 import org.neotech.app.abysner.domain.core.physics.metersToHydrostaticPressure
 import org.neotech.app.abysner.domain.decompression.DecoGrid
@@ -39,10 +42,11 @@ import kotlin.time.Duration
  * adds multi-level dive handling.
  */
 class DivePlanner(
-    configuration: Configuration = Configuration()
+    configuration: Configuration = Configuration(),
+    private val unitSystem: UnitSystem = UnitSystem.METRIC,
 ) {
 
-    var configuration: Configuration = configuration
+    var configuration: Configuration = configuration.snapToDisplayUnit(unitSystem)
         private set
 
     private var model: DecompressionModel = createDecompressionModel()
@@ -53,7 +57,7 @@ class DivePlanner(
      */
     fun updateConfiguration(newConfiguration: Configuration) {
         val snapshot = model.snapshot()
-        configuration = newConfiguration
+        configuration = newConfiguration.snapToDisplayUnit(unitSystem)
         model = createDecompressionModel()
         model.reset(snapshot)
     }
@@ -69,6 +73,7 @@ class DivePlanner(
         cylinders: List<AssignedCylinder>,
         diveMode: DiveMode = DiveMode.OPEN_CIRCUIT,
         bailout: Boolean = false,
+        unitSystem: UnitSystem = UnitSystem.METRIC,
     ): DivePlan {
 
         require(!bailout || diveMode.isCcr) {
@@ -99,7 +104,7 @@ class DivePlanner(
             )
         }
 
-        val decompressionPlanner = createDecompressionPlanner(model, configuration)
+        val decompressionPlanner = createDecompressionPlanner(model, configuration, unitSystem)
 
         decompressionPlanner.setDecoGases(decoCylinders)
 
@@ -255,14 +260,24 @@ class DivePlanner(
     private fun createDecompressionPlanner(
         model: DecompressionModel,
         configuration: Configuration,
+        unitSystem: UnitSystem = UnitSystem.METRIC,
     ): DecompressionPlanner {
         val environment = configuration.environment
         val grid = DecoGrid(
             surfacePressure = environment.atmosphericPressure,
             decoStepSizePressureDelta = metersToHydrostaticPressure(configuration.decoStepSize, environment).value,
             lastDecoStopAmbientPressure = metersToAmbientPressure(configuration.lastDecoStopDepth, environment).value,
-            displayUnitPressureDelta = metersToHydrostaticPressure(1.0, environment).value,
+            displayUnitPressureDelta = when (unitSystem) {
+                UnitSystem.METRIC -> metersToHydrostaticPressure(1.0, environment).value
+                UnitSystem.IMPERIAL -> feetToHydrostaticPressure(1.0, environment).value
+            },
         )
+        // removeFloatingPointNoise makes test assertions easier to read since depths are
+        // usually whole numbers without requiring tolerance handling at every call site.
+        val pressureToDepth: (Double) -> Double = when (unitSystem) {
+            UnitSystem.METRIC -> { pressure -> removeFloatingPointNoise(ambientPressureToMeters(pressure, environment)) }
+            UnitSystem.IMPERIAL -> { pressure -> removeFloatingPointNoise(ambientPressureToFeet(pressure, environment)) }
+        }
         return DecompressionPlanner(
             model = model,
             grid = grid,
@@ -271,14 +286,7 @@ class DivePlanner(
             ascentRatePressureDelta = metersToHydrostaticPressure(configuration.maxAscentRate, environment).value,
             forceMinimalDecoStopTime = configuration.forceMinimalDecoStopTime,
             gasSwitchTime = configuration.gasSwitchTime,
-            pressureToDepth = { pressure ->
-                // This is not strictly required to make the UI work, since the UI already formats
-                // to zero decimals or 1 maybe 2 decimals at most. However, it makes the current
-                // test assertions easier to read, since these are usually in whole meters, without
-                // this noise normalization tolerance handling at assertion call sites would be
-                // required, or more precise less readable floating point numbers.
-                removeFloatingPointNoise(ambientPressureToMeters(pressure, environment))
-            },
+            pressureToDepth = pressureToDepth,
         )
     }
 
@@ -314,5 +322,3 @@ class DivePlanner(
 
     class NotEnoughTimeToDecompress : PlanningException()
 }
-
-

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/diveplanning/DivePlannerTest.kt
@@ -20,6 +20,8 @@ import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.DiveMode
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.core.model.Salinity
+import org.neotech.app.abysner.domain.core.model.UnitSystem
+import org.neotech.app.abysner.domain.core.physics.METERS_PER_FOOT
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
 import org.neotech.app.abysner.domain.diveplanning.model.assign
@@ -511,6 +513,48 @@ class DivePlannerTest {
         // O2 switch at 6m (tolerant MOD ~6.3m, on the 3m grid)
         plan.assertSegment(7, DiveSegment.Type.GAS_SWITCH, startDepth = 6.0,  endDepth = 6.0,  duration = 1, gas = decoGas80)
         plan.assertSegment(8, DiveSegment.Type.ASCENT,     startDepth = 6.0,  endDepth = 3.0,  duration = 1, gas = decoGasO2)
+    }
+
+    @Test
+    fun referencePlanImperial_producesSegmentsInFeetWithTenFootDecoStops() {
+        val divePlanner = DivePlanner(
+            configuration = Configuration(
+                maxAscentRate = 10.0 * METERS_PER_FOOT,
+                maxDescentRate = 20.0 * METERS_PER_FOOT,
+                gfLow = 0.3,
+                gfHigh = 0.7,
+                salinity = Salinity.WATER_SALT,
+                algorithm = Algorithm.BUHLMANN_ZH16C,
+                altitude = 0.0,
+                decoStepSize = 10.0 * METERS_PER_FOOT,
+                lastDecoStopDepth = 10.0 * METERS_PER_FOOT,
+                gasSwitchTime = 1,
+            ),
+            unitSystem = UnitSystem.IMPERIAL,
+        )
+
+        val bottomGas = Cylinder.steel12Liter(Gas.Air)
+
+        val divePlan = divePlanner.addDive(
+            plan = listOf(DiveProfileSection(duration = 25, 100.0 * METERS_PER_FOOT, bottomGas)),
+            cylinders = listOf(bottomGas, Cylinder.aluminium80Cuft(Gas.Nitrox50)).assign(),
+            unitSystem = UnitSystem.IMPERIAL,
+        )
+        val plan = divePlan.segmentsCollapsed
+
+        // Verify the decent and bottom sections are in feet
+        plan.assertSegment(index = 0, type = DiveSegment.Type.DECENT, startDepth = 0.0, endDepth = 100.0, duration = 5, gas = bottomGas)
+        plan.assertSegment(index = 1, type = DiveSegment.Type.FLAT, startDepth = 100.0, endDepth = 100.0, duration = 20, gas = bottomGas)
+
+        // Verify all stop and gas switch depths align to the 10 feet grid
+        plan.filter {
+            it.type == DiveSegment.Type.DECO_STOP || it.type == DiveSegment.Type.GAS_SWITCH
+        }.forEach {
+            assertEquals(0.0, it.endDepth % 10.0)
+        }
+
+        // Verify the dive ends at the surface (0 feet)
+        assertEquals(0.0, plan.last().endDepth)
     }
 }
 


### PR DESCRIPTION
`DivePlanner.addDive()` is now aware of the `UnitSystem`. When `UnitSystem.IMPERIAL` is active, output depths are produced in feet and deco stops align to the 10 feet grid.

Required for: #49