### PR TITLE
Fix: Bailout gas distributed to diluent-only cylinders

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlanner.kt
@@ -18,6 +18,7 @@ import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
 import org.neotech.app.abysner.domain.core.model.Gas
 import org.neotech.app.abysner.domain.decompression.model.DiveSegment
+import org.neotech.app.abysner.domain.diveplanning.model.AssignedCylinder
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlan
 import org.neotech.app.abysner.domain.gasplanning.model.GasPlan
 import org.neotech.app.abysner.domain.gasplanning.model.CylinderGasRequirements
@@ -117,7 +118,7 @@ class GasPlanner {
             }
         }
 
-        return distributeByGas(divePlan, normalByGas, reserveByGas).toImmutableList()
+        return distributeByGas(divePlan.cylinders, normalByGas, reserveByGas).toImmutableList()
     }
 
     private fun calculateCcrGasPlan(
@@ -152,7 +153,8 @@ class GasPlanner {
             }
         }
 
-        val bailoutResult = distributeByGas(divePlan, emptyMap(), reserveByGas)
+        val bailoutCylinders = divePlan.cylinders.filter { it.isAvailableForBailout }
+        val bailoutResult = distributeByGas(bailoutCylinders, emptyMap(), reserveByGas)
 
         val closedCircuitResult = ccrSegments.calculateClosedCircuitGasRequirements(
             cylinders = divePlan.cylinders.map { it.cylinder },
@@ -178,11 +180,11 @@ class GasPlanner {
      * change in the planner, which is now based on 'best-gas' not on 'make it work'.
      */
     private fun distributeByGas(
-        divePlan: DivePlan,
+        cylinders: List<AssignedCylinder>,
         normalByGas: Map<Gas, Double>,
         reserveByGas: Map<Gas, Double>,
     ): List<CylinderGasRequirements> {
-        val cylindersByGas = divePlan.cylinders.groupBy { it.gas }
+        val cylindersByGas = cylinders.groupBy { it.gas }
         return cylindersByGas
             .filter { (gas, _) -> gas in normalByGas || gas in reserveByGas }
             .flatMap { (gas, cylinders) ->

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/gasplanning/GasPlannerTest.kt
@@ -349,6 +349,26 @@ class GasPlannerTest {
         assertEquals(0.0, diluentEntry.extraEmergencyRequirement)
     }
 
+    @Test
+    fun calculateGasPlan_ccrBailoutDistributesOnlyAcrossBailoutEligibleCylinders() {
+        val bailoutCylinder = Cylinder(Gas.Air, pressure = 232.0, waterVolume = 12.0)
+        val divePlan = ccrDivePlan(
+            depth = 40.0,
+            duration = 20,
+            extraCylinders = listOf(bailoutCylinder),
+            bailout = true,
+        )
+        assertEquals(diluentCylinder.gas, bailoutCylinder.gas)
+
+        val gasPlan = GasPlanner().calculateGasPlan(divePlan)
+
+        val diluentEntry = gasPlan.first { it.cylinder == diluentCylinder }
+        assertEquals(0.0, diluentEntry.extraEmergencyRequirement)
+
+        val bailoutEntry = gasPlan.first { it.cylinder == bailoutCylinder }
+        assertTrue(bailoutEntry.extraEmergencyRequirement > 0.0)
+    }
+
     private fun ccrDivePlan(
         depth: Double = 30.0,
         duration: Int = 30,


### PR DESCRIPTION
When a diluent cylinder uses the same gas mix as a bailout cylinder, the bailout gas requirement was incorrectly spread across both. Bailout gas must only be distributed across cylinders eligible for bailout, excluding diluent-only cylinders.