### PR TITLE
Refactor: Move planning input state and storage to PlanningRepository

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/di/AppComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/di/AppComponent.kt
@@ -16,6 +16,8 @@ import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 import org.neotech.app.abysner.data.PersistenceRepositoryImpl
+import org.neotech.app.abysner.data.diveplanning.PlanningDataSource
+import org.neotech.app.abysner.data.diveplanning.PlanningFileDataSource
 import org.neotech.app.abysner.data.diveplanning.PlanningRepositoryImpl
 import org.neotech.app.abysner.data.PlatformFileDataSource
 import org.neotech.app.abysner.data.settings.SettingsRepositoryImpl
@@ -35,6 +37,11 @@ abstract class AppComponent {
     @SingleIn(AppScope::class)
     @Provides
     fun providesPlanningRepository(planningRepository: PlanningRepositoryImpl): PlanningRepository = planningRepository
+
+    @SingleIn(AppScope::class)
+    @Provides
+    fun providesPlanningDataSource(platformFileDataSource: PlatformFileDataSource): PlanningDataSource =
+        PlanningFileDataSource(platformFileDataSource.getPrivateFileStoragePath())
 
     @SingleIn(AppScope::class)
     @Provides

--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModel.kt
@@ -17,20 +17,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import dev.zacsweers.metro.Inject
 import org.neotech.app.abysner.domain.core.model.Configuration
 import org.neotech.app.abysner.domain.core.model.Cylinder
@@ -40,7 +35,6 @@ import org.neotech.app.abysner.domain.diveplanning.PlanningRepository
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanInputModel
 import org.neotech.app.abysner.domain.diveplanning.model.DivePlanSet
 import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
-import org.neotech.app.abysner.domain.diveplanning.model.MultiDivePlanInputModel
 import org.neotech.app.abysner.domain.diveplanning.model.MultiDivePlanSet
 import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
 import org.neotech.app.abysner.domain.diveplanning.model.toggleAvailableForBailout
@@ -50,49 +44,18 @@ import org.neotech.app.abysner.presentation.utilities.combine
 import kotlin.time.Duration
 import kotlin.time.measureTimedValue
 
-@OptIn(FlowPreview::class)
 @Inject
 class PlanScreenViewModel(
     private val planningRepository: PlanningRepository,
     private val settingsRepository: SettingsRepository,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     calculationDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
 
-    private data class PlanInput(
-        val model: MultiDivePlanInputModel = MultiDivePlanInputModel.Default,
-        val selectedDiveIndex: Int = 0,
-    )
-
-    private val planInput = MutableStateFlow(PlanInput())
+    private val selectedDiveIndex = MutableStateFlow(0)
     private val isCalculatingDivePlan = MutableStateFlow(false)
-    private val isLoading = MutableStateFlow(true)
-
-    init {
-        viewModelScope.launch(ioDispatcher) {
-            val loaded = planningRepository.getMultiDivePlanInput() ?: MultiDivePlanInputModel.Default
-            // Recompute cylinder lock state for every dive after loading persisted data.
-            val recomputed = loaded.copy(dives = loaded.dives.map { it.recomputeCylinderState() })
-            planInput.update { it.copy(model = recomputed) }
-            isLoading.value = false
-
-            planInput.map { it.model }
-                .distinctUntilChanged()
-                .debounce(1000)
-                .collectLatest { model ->
-                    runCatching {
-                        planningRepository.setMultiDivePlanInput(model)
-                    }.onFailure {
-                        it.printStackTrace()
-                    }
-                }
-        }
-    }
 
     private fun mutateDive(mutation: DivePlanInputModel.() -> DivePlanInputModel) {
-        planInput.update { state ->
-            state.copy(model = state.model.updateDive(state.selectedDiveIndex, mutation))
-        }
+        planningRepository.updateMultiDivePlanInput { it.updateDive(selectedDiveIndex.value, mutation) }
     }
 
     fun addSegment(section: DiveProfileSection) = mutateDive { addSegment(section) }
@@ -113,43 +76,42 @@ class PlanScreenViewModel(
     }
 
     fun selectDive(index: Int) {
-        planInput.update { it.copy(selectedDiveIndex = index) }
+        selectedDiveIndex.value = index
     }
 
     fun addDive(surfaceInterval: Duration) {
-        planInput.update { state ->
+        planningRepository.updateMultiDivePlanInput {
             val newDive = DivePlanInputModel.Default.copy(surfaceIntervalBefore = surfaceInterval)
-            state.copy(
-                model = state.model.copy(dives = state.model.dives + newDive),
-                // Switch to the newly added dive as the selected dive
-                selectedDiveIndex = state.model.dives.size,
-            )
+            it.copy(dives = it.dives + newDive)
+        }?.let {
+            // Switch to the newly added dive as the selected dive
+            selectedDiveIndex.value = it.dives.lastIndex
         }
     }
 
     fun removeDive(index: Int) {
-        if (planInput.value.model.dives.size <= 1) {
+        val model = planningRepository.multiDivePlanInput.value ?: return
+        if (model.dives.size <= 1) {
             return
         }
-        planInput.update { state ->
-            val newDives = state.model.dives.toMutableList().apply { removeAt(index) }
+        // Keep the selected dive index the same (usually the dive that is selected will be
+        // removed), if that index is no longer valid, we set it to the last dive. This is set
+        // before the model itself shrinks, so the index always remains valid.
+        selectedDiveIndex.value = selectedDiveIndex.value.coerceAtMost(model.dives.size - 2)
+        planningRepository.updateMultiDivePlanInput { state ->
+            val newDives = state.dives.toMutableList().apply { removeAt(index) }
             if (index == 0) {
                 // If the first dive got removed, set the surface interval of the new first dive to null
                 newDives[0] = newDives[0].copy(surfaceIntervalBefore = null)
             }
-            state.copy(
-                model = state.model.copy(dives = newDives),
-                // Keep the selected dive index the same (usually the dive that is selected will be
-                // removed), if that index is no longer valid, we set it to the last dive.
-                selectedDiveIndex = state.selectedDiveIndex.coerceAtMost(newDives.lastIndex),
-            )
+            state.copy(dives = newDives)
         }
     }
 
     fun updateSurfaceInterval(index: Int, duration: Duration) {
         require(index >= 1) { "The first dive cannot have a surface interval before it." }
-        planInput.update { state ->
-            state.copy(model = state.model.updateDive(index) { copy(surfaceIntervalBefore = duration) })
+        planningRepository.updateMultiDivePlanInput { state ->
+            state.updateDive(index) { copy(surfaceIntervalBefore = duration) }
         }
     }
 
@@ -158,13 +120,13 @@ class PlanScreenViewModel(
      * does not retrigger a potentially expensive recalculation.
      */
     private val divePlanSet: StateFlow<Result<MultiDivePlanSet?>> = combine(
-        planInput.map { it.model }.distinctUntilChanged(),
+        planningRepository.multiDivePlanInput.filterNotNull().distinctUntilChanged(),
         planningRepository.configuration,
         settingsRepository.settings.map { it.unitSystem }.distinctUntilChanged(),
-    ) { model, config, unitSystem ->
+    ) { model, configuration, unitSystem ->
         isCalculatingDivePlan.value = true
         val result = measureTimedValue {
-            runCatching { MultiDivePlanner(config, unitSystem).plan(model) }
+            runCatching { MultiDivePlanner(configuration, unitSystem).plan(model) }
                 .onFailure { it.printStackTrace() }
         }.also { isCalculatingDivePlan.value = false }
         println("Duration: Calculating dive plan took ${result.duration}")
@@ -181,25 +143,28 @@ class PlanScreenViewModel(
     )
 
     val uiState: StateFlow<UiState> = combine(
-        planInput,
+        planningRepository.multiDivePlanInput,
+        selectedDiveIndex,
         divePlanSet,
-        isLoading,
         isCalculatingDivePlan,
         settingsRepository.settings,
         // In theory, we can read this directly from the repository, since divePlanSet which this combine depends on already observes it.
         planningRepository.configuration,
-    ) { input, plan, loading, isCalc, settings, configuration ->
-        val selectedDive = input.model.dives[input.selectedDiveIndex]
+    ) { input, selectedIndex, plan, isCalc, settings, configuration ->
+        if (input == null) {
+            return@combine UiState(isLoading = true)
+        }
+        val selectedDive = input.dives[selectedIndex]
         UiState(
-            selectedDiveIndex = input.selectedDiveIndex,
-            dives = input.model.dives,
+            selectedDiveIndex = selectedIndex,
+            dives = input.dives,
             segments = selectedDive.plannedProfile,
             availableGas = selectedDive.cylinders,
             diveMode = selectedDive.diveMode,
             isCalculatingDivePlan = isCalc,
             multiDivePlanSet = plan,
-            selectedDivePlanSet = plan.map { it?.divePlanSets?.getOrNull(input.selectedDiveIndex) },
-            isLoading = loading,
+            selectedDivePlanSet = plan.map { it?.divePlanSets?.getOrNull(selectedIndex) },
+            isLoading = false,
             settingsModel = settings,
             configuration = configuration,
         )

--- a/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/neotech/app/abysner/presentation/screens/planner/PlanScreenViewModelTest.kt
@@ -36,6 +36,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -162,20 +163,43 @@ class PlanScreenViewModelTest {
         assertFalse(calculationTriggered)
         assertEquals(0, viewModel.uiState.value.selectedDiveIndex)
     }
+
+    @Test
+    fun uiState_isLoadingWhileInputIsNotYetLoaded() = runTest {
+        val planningRepo = FakePlanningRepository(loaded = false)
+        val viewModel = createViewModel(planningRepository = planningRepo)
+
+        collectForTest(viewModel.uiState)
+
+        assertTrue(viewModel.uiState.value.isLoading)
+    }
 }
 
 private class FakePlanningRepository(
     initialConfig: Configuration = Configuration(),
+    loaded: Boolean = true,
 ) : PlanningRepository {
     override val configuration = MutableStateFlow(initialConfig)
+    override val multiDivePlanInput = MutableStateFlow(
+        if (loaded) {
+            MultiDivePlanInputModel.Default
+        } else {
+            null
+        }
+    )
 
-    override fun updateConfiguration(updateBlock: (Configuration) -> Configuration) {
-        configuration.value = updateBlock(configuration.value)
+    override fun updateConfiguration(updateBlock: (Configuration) -> Configuration): Configuration {
+        val updated = updateBlock(configuration.value)
+        configuration.value = updated
+        return updated
     }
 
-    override fun setMultiDivePlanInput(model: MultiDivePlanInputModel) {}
-
-    override suspend fun getMultiDivePlanInput(): MultiDivePlanInputModel? = null
+    override fun updateMultiDivePlanInput(updateBlock: (MultiDivePlanInputModel) -> MultiDivePlanInputModel): MultiDivePlanInputModel? {
+        val current = multiDivePlanInput.value ?: return null
+        val updated = updateBlock(current)
+        multiDivePlanInput.value = updated
+        return updated
+    }
 }
 
 private class FakeSettingsRepository : SettingsRepository {
@@ -195,7 +219,6 @@ private fun TestScope.createViewModel(
 ) = PlanScreenViewModel(
     planningRepository = planningRepository,
     settingsRepository = settingsRepository,
-    ioDispatcher = UnconfinedTestDispatcher(testScheduler),
     calculationDispatcher = UnconfinedTestDispatcher(testScheduler),
 )
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -66,6 +66,7 @@ kotlin {
     sourceSets {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
 
         commonMain.dependencies {
@@ -73,6 +74,7 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.androidx.datastore.preferences)
             implementation(libs.kotlinx.serialization)
+            implementation(libs.okio)
         }
     }
 }

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningDataSource.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningDataSource.kt
@@ -1,0 +1,28 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.data.diveplanning
+
+import org.neotech.app.abysner.data.diveplanning.resources.ConfigurationResourceV1
+import org.neotech.app.abysner.data.diveplanning.resources.MultiDivePlanInputResourceV1
+
+interface PlanningDataSource {
+
+    suspend fun loadConfiguration(): ConfigurationResourceV1?
+
+    suspend fun saveConfiguration(configuration: ConfigurationResourceV1)
+
+    suspend fun loadPlan(): MultiDivePlanInputResourceV1?
+
+    suspend fun savePlan(plan: MultiDivePlanInputResourceV1)
+}
+

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningFileDataSource.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningFileDataSource.kt
@@ -1,0 +1,76 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.data.diveplanning
+
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import okio.SYSTEM
+import org.neotech.app.abysner.data.diveplanning.resources.ConfigurationResourceV1
+import org.neotech.app.abysner.data.diveplanning.resources.MultiDivePlanInputResourceV1
+
+class PlanningFileDataSource(
+    baseDirectory: Path,
+    private val fileSystem: FileSystem = FileSystem.SYSTEM,
+) : PlanningDataSource {
+
+    private val rootDirectory = baseDirectory.resolve("planning")
+    private val planFile = rootDirectory.resolve("plan.json")
+    private val configurationFile = rootDirectory.resolve("configuration.json")
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+    }
+
+    override suspend fun loadConfiguration(): ConfigurationResourceV1? {
+        return readJsonFile<ConfigurationResourceV1>(configurationFile)
+    }
+
+    override suspend fun saveConfiguration(configuration: ConfigurationResourceV1) {
+        writeJsonFile(configurationFile, configuration)
+    }
+
+    override suspend fun loadPlan(): MultiDivePlanInputResourceV1? {
+        return readJsonFile<MultiDivePlanInputResourceV1>(planFile)
+    }
+
+    override suspend fun savePlan(plan: MultiDivePlanInputResourceV1) {
+        writeJsonFile(planFile, plan)
+    }
+
+    private inline fun <reified T> readJsonFile(path: Path): T? {
+        return try {
+            val content = fileSystem.read(path) { readUtf8() }
+            json.decodeFromString<T>(content)
+        } catch (exception: Exception) {
+            exception.printStackTrace()
+            null
+        }
+    }
+
+    private inline fun <reified T> writeJsonFile(path: Path, value: T) {
+        val content = json.encodeToString(value)
+        updateFile(path, content)
+    }
+
+    private fun updateFile(path: Path, content: String) {
+        val parent = path.parent ?: error("Path '$path' has no parent directory!")
+        fileSystem.createDirectories(parent)
+        val temporaryPath = parent.resolve("${path.name}.tmp")
+        fileSystem.write(temporaryPath) {
+            writeUtf8(content)
+        }
+        fileSystem.atomicMove(temporaryPath, path)
+    }
+}

--- a/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningRepositoryImpl.kt
@@ -12,189 +12,110 @@
 
 package org.neotech.app.abysner.data.diveplanning
 
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.doublePreferencesKey
-import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import dev.zacsweers.metro.Inject
 import org.neotech.app.abysner.data.diveplanning.resources.ConfigurationResourceV1
-import org.neotech.app.abysner.data.diveplanning.resources.DivePlanInputResourceV1
 import org.neotech.app.abysner.data.diveplanning.resources.MultiDivePlanInputResourceV1
 import org.neotech.app.abysner.data.getJson
-import org.neotech.app.abysner.data.setJson
 import org.neotech.app.abysner.domain.core.model.Configuration
-import org.neotech.app.abysner.domain.core.model.Salinity
 import org.neotech.app.abysner.domain.diveplanning.PlanningRepository
 import org.neotech.app.abysner.domain.diveplanning.model.MultiDivePlanInputModel
 import org.neotech.app.abysner.domain.persistence.PersistenceRepository
-import org.neotech.app.abysner.domain.persistence.get
+import kotlin.time.Duration.Companion.milliseconds
 
-@Inject
-class PlanningRepositoryImpl(
+@OptIn(FlowPreview::class)
+class PlanningRepositoryImpl @Inject constructor(
+    private val dataSource: PlanningDataSource,
     private val persistenceRepository: PersistenceRepository,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : PlanningRepository {
 
     override val configuration: MutableStateFlow<Configuration> = MutableStateFlow(Configuration())
 
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    override val multiDivePlanInput = MutableStateFlow<MultiDivePlanInputModel?>(null)
+
+    private val scope = CoroutineScope(dispatcher + SupervisorJob())
 
     init {
         scope.launch {
-            persistenceRepository.getPreferences().collect { preferences ->
-                @Suppress("DEPRECATION")
-                if (preferences.contains(PREFERENCE_KEY_ALGORITHM_TYPE)) {
-                    preferences.migrateConfigurationFromBuild9AndBefore()
+            loadInitialState()
+        }
+
+        scope.launch {
+            configuration
+                .debounce(PERSIST_DEBOUNCE_MILLIS.milliseconds)
+                .collectLatest { config ->
+                    runCatching {
+                        dataSource.saveConfiguration(config.toResource())
+                    }.onFailure { it.printStackTrace() }
                 }
-                @Suppress("DEPRECATION")
-                if (preferences.contains(PREFERENCE_KEY_INPUT_DIVE_PLAN)) {
-                    preferences.migrateConfigurationFromBuild10()
+        }
+
+        scope.launch {
+            multiDivePlanInput.filterNotNull()
+                .distinctUntilChanged()
+                .debounce(PERSIST_DEBOUNCE_MILLIS.milliseconds)
+                .collectLatest { model ->
+                    runCatching {
+                        dataSource.savePlan(model.toResource())
+                    }.onFailure { it.printStackTrace() }
                 }
-                configuration.emit(preferences.getJson<ConfigurationResourceV1>(PREFERENCE_KEY_GLOBAL_CONFIGURATION)?.toModel() ?: Configuration())
-            }
         }
     }
 
-    @Suppress("DEPRECATION")
-    private suspend fun Preferences.migrateConfigurationFromBuild9AndBefore() {
-        // Step 1: read old configuration
-        val oldConfiguration = ConfigurationResourceV1(
-            sacRate = get(PREFERENCE_KEY_DIVER_NORMAL_SAC, 20.0),
-            sacRateStress = get(PREFERENCE_KEY_DIVER_OUT_OF_AIR_SAC, 40.0),
-            maxPPO2Deco = get(PREFERENCE_KEY_MAX_PPO2_DECO, 1.6),
-            maxPPO2 = get(PREFERENCE_KEY_MAX_PPO2, 1.4),
-            maxAscentRate = get(PREFERENCE_KEY_DIVER_SPEED_ASCENT, 5.0),
-            maxDescentRate = get(PREFERENCE_KEY_DIVER_SPEED_DESCENT, 20.0),
-            gfLow = get(PREFERENCE_KEY_ALGORITHM_GF_LOW, 0.6),
-            gfHigh = get(PREFERENCE_KEY_ALGORITHM_GF_HIGH, 0.7),
-            forceMinimalDecoStopTime = get(PREFERENCE_KEY_FORCE_MINIMAL_STOP_TIME, true),
-            useDecoGasBetweenSections = get(PREFERENCE_KEY_USE_DECO_GAS_BETWEEN_SECTIONS, false),
-            decoStepSize = get(PREFERENCE_KEY_DECO_STEP_SIZE, 3).toDouble(),
-            lastDecoStopDepth = get(PREFERENCE_KEY_LAST_DECO_STOP, 3).toDouble(),
-            salinity = get(PREFERENCE_KEY_ENVIRONMENT_SALINITY, Salinity.WATER_FRESH).preferenceValue,
-            algorithm = get(PREFERENCE_KEY_ALGORITHM_TYPE, Configuration.Algorithm.BUHLMANN_ZH16C).preferenceValue,
-            contingencyDeeper = get(PREFERENCE_KEY_CONTINGENCY_DEEPER, 3).toDouble(),
-            contingencyLonger = get(PREFERENCE_KEY_CONTINGENCY_LONGER, 3),
-            maxEND = 30.0,
-            altitude = 0.0
-        )
+    private suspend fun loadInitialState() {
+        val loadedConfiguration = dataSource.loadConfiguration() ?: migrateConfigurationFromPreferences()
+        configuration.value = loadedConfiguration?.toModel() ?: Configuration()
 
-        persistenceRepository.updatePreferences {
-
-            // Step 2: update new configuration
-            it.setJson(PREFERENCE_KEY_GLOBAL_CONFIGURATION, oldConfiguration)
-
-            // Step 3: remove old key configuration
-            it.remove(PREFERENCE_KEY_ALGORITHM_TYPE)
-            it.remove(PREFERENCE_KEY_ALGORITHM_GF_LOW)
-            it.remove(PREFERENCE_KEY_ALGORITHM_GF_HIGH)
-            it.remove(PREFERENCE_KEY_ENVIRONMENT_SALINITY)
-            it.remove(PREFERENCE_KEY_DIVER_SPEED_ASCENT)
-            it.remove(PREFERENCE_KEY_DIVER_SPEED_DESCENT)
-            it.remove(PREFERENCE_KEY_DIVER_NORMAL_SAC)
-            it.remove(PREFERENCE_KEY_DIVER_OUT_OF_AIR_SAC)
-            it.remove(PREFERENCE_KEY_FORCE_MINIMAL_STOP_TIME)
-            it.remove(PREFERENCE_KEY_DECO_STEP_SIZE)
-            it.remove(PREFERENCE_KEY_LAST_DECO_STOP)
-            it.remove(PREFERENCE_KEY_MAX_PPO2_DECO)
-            it.remove(PREFERENCE_KEY_MAX_PPO2)
-            it.remove(PREFERENCE_KEY_USE_DECO_GAS_BETWEEN_SECTIONS)
-            it.remove(PREFERENCE_KEY_CONTINGENCY_DEEPER)
-            it.remove(PREFERENCE_KEY_CONTINGENCY_LONGER)
-        }
+        val loadedPlan = dataSource.loadPlan() ?: migrateActivePlanFromPreferences()
+        val model = loadedPlan?.toModel() ?: MultiDivePlanInputModel.Default
+        multiDivePlanInput.value = model.copy(dives = model.dives.map { it.recomputeCylinderState() })
     }
 
-    @Suppress("DEPRECATION")
-    private suspend fun Preferences.migrateConfigurationFromBuild10() {
-        // Step 1: read old configuration
-        val singleDive = getJson<DivePlanInputResourceV1>(PREFERENCE_KEY_INPUT_DIVE_PLAN)
-        persistenceRepository.updatePreferences {
-
-            // Step 2: update new configuration
-            if (singleDive != null) {
-                it.setJson(PREFERENCE_KEY_INPUT_MULTI_DIVE_PLAN, MultiDivePlanInputResourceV1(dives = listOf(singleDive)))
-            }
-
-            // Step 3: remove old key configuration
-            it.remove(PREFERENCE_KEY_INPUT_DIVE_PLAN)
-        }
+    private suspend fun migrateConfigurationFromPreferences(): ConfigurationResourceV1? {
+        val preferences = persistenceRepository.getPreferences().firstOrNull() ?: return null
+        val legacy = preferences.getJson<ConfigurationResourceV1>(PREFERENCE_KEY_GLOBAL_CONFIGURATION) ?: return null
+        dataSource.saveConfiguration(legacy)
+        persistenceRepository.updatePreferences { it.remove(PREFERENCE_KEY_GLOBAL_CONFIGURATION) }
+        return legacy
     }
 
-    override fun updateConfiguration(updateBlock: (Configuration) -> Configuration) {
+    private suspend fun migrateActivePlanFromPreferences(): MultiDivePlanInputResourceV1? {
+        val preferences = persistenceRepository.getPreferences().firstOrNull() ?: return null
+        val legacy = preferences.getJson<MultiDivePlanInputResourceV1>(PREFERENCE_KEY_INPUT_MULTI_DIVE_PLAN) ?: return null
+        dataSource.savePlan(legacy)
+        persistenceRepository.updatePreferences { it.remove(PREFERENCE_KEY_INPUT_MULTI_DIVE_PLAN) }
+        return legacy
+    }
+
+    override fun updateConfiguration(updateBlock: (Configuration) -> Configuration): Configuration {
         val newConfiguration = updateBlock(configuration.value)
-        configuration.update {
-            newConfiguration
-        }
-        scope.launch {
-            persistenceRepository.updatePreferences {
-                it.setJson(PREFERENCE_KEY_GLOBAL_CONFIGURATION, newConfiguration.toResource())
-            }
-        }
+        configuration.value = newConfiguration
+        return newConfiguration
     }
 
-    override fun setMultiDivePlanInput(model: MultiDivePlanInputModel) {
-        scope.launch {
-            persistenceRepository.updatePreferences {
-                it.setJson(PREFERENCE_KEY_INPUT_MULTI_DIVE_PLAN, model.toResource())
-            }
-        }
+    override fun updateMultiDivePlanInput(updateBlock: (MultiDivePlanInputModel) -> MultiDivePlanInputModel): MultiDivePlanInputModel? {
+        val current = multiDivePlanInput.value ?: return null
+        val updated = updateBlock(current)
+        multiDivePlanInput.value = updated
+        return updated
     }
-
-    override suspend fun getMultiDivePlanInput(): MultiDivePlanInputModel? =
-        persistenceRepository.getPreferences().first().getJson<MultiDivePlanInputResourceV1>(PREFERENCE_KEY_INPUT_MULTI_DIVE_PLAN)?.toModel()
 }
 
 private val PREFERENCE_KEY_GLOBAL_CONFIGURATION = stringPreferencesKey("global.configuration")
 private val PREFERENCE_KEY_INPUT_MULTI_DIVE_PLAN = stringPreferencesKey("input.diveplan.multi.v1")
 
-@Deprecated("Will be removed in future version when most users have migrated to the multi-dive format.")
-private val PREFERENCE_KEY_INPUT_DIVE_PLAN = stringPreferencesKey("input.diveplan")
-
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_ALGORITHM_TYPE = stringPreferencesKey("algorithm.type")
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_ALGORITHM_GF_LOW = doublePreferencesKey("algorithm.buhlmann.gradientFactor.low")
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_ALGORITHM_GF_HIGH = doublePreferencesKey("algorithm.buhlmann.gradientFactor.high")
-
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_ENVIRONMENT_SALINITY = stringPreferencesKey("environment.salinity")
-
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_DIVER_SPEED_ASCENT = doublePreferencesKey("diver.speed.ascent")
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_DIVER_SPEED_DESCENT = doublePreferencesKey("diver.speed.descent")
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_DIVER_NORMAL_SAC = doublePreferencesKey("diver.sac.normal")
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_DIVER_OUT_OF_AIR_SAC = doublePreferencesKey("diver.sac.outOfAir")
-
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_FORCE_MINIMAL_STOP_TIME = booleanPreferencesKey("deco.minimalStopTime")
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_LAST_DECO_STOP = intPreferencesKey("deco.lastStop")
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_DECO_STEP_SIZE = intPreferencesKey("deco.stepSize")
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_MAX_PPO2 = doublePreferencesKey("deco.ppo2.normal")
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_MAX_PPO2_DECO = doublePreferencesKey("deco.ppo2.deco")
-
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_CONTINGENCY_DEEPER = intPreferencesKey("contingency.deeper")
-
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_CONTINGENCY_LONGER = intPreferencesKey("contingency.longer")
-
-@Deprecated(PREFERENCE_DEPRECATION_WARNING)
-private val PREFERENCE_KEY_USE_DECO_GAS_BETWEEN_SECTIONS = booleanPreferencesKey("multiLevel.useDecoGasBetweenSections")
-
-private const val PREFERENCE_DEPRECATION_WARNING = "Will be removed in future version when most users have migrated to the JSON format stored configuration."
+private const val PERSIST_DEBOUNCE_MILLIS = 1000L

--- a/data/src/commonTest/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningFileDataSourceTest.kt
+++ b/data/src/commonTest/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningFileDataSourceTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Abysner - Dive planner
+ * Copyright (C) 2026 Neotech
+ *
+ * Abysner is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+package org.neotech.app.abysner.data.diveplanning
+
+import kotlinx.coroutines.runBlocking
+import okio.FileSystem
+import okio.SYSTEM
+import org.neotech.app.abysner.domain.core.model.Configuration
+import org.neotech.app.abysner.domain.diveplanning.model.DivePlanInputModel
+import org.neotech.app.abysner.domain.diveplanning.model.MultiDivePlanInputModel
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PlanningFileDataSourceTest {
+
+    private val fileSystem = FileSystem.SYSTEM
+    private val testDirectory = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "planning_test"
+    private val planningDirectory = testDirectory / "planning"
+    private lateinit var dataSource: PlanningFileDataSource
+
+    @BeforeTest
+    fun setUp() {
+        fileSystem.deleteRecursively(testDirectory)
+        fileSystem.createDirectories(testDirectory)
+        dataSource = PlanningFileDataSource(baseDirectory = testDirectory, fileSystem = fileSystem)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        fileSystem.deleteRecursively(testDirectory)
+    }
+
+    @Test
+    fun loadPlan_returnsNullWhenFileDoesNotExist() = runBlocking {
+        assertNull(dataSource.loadPlan())
+    }
+
+    @Test
+    fun loadPlan_returnsNullWhenFileContainsInvalidJson() = runBlocking {
+        fileSystem.createDirectories(planningDirectory)
+        fileSystem.write(planningDirectory / "plan.json") {
+            writeUtf8("{ invalid json content }")
+        }
+
+        assertNull(dataSource.loadPlan())
+    }
+
+    @Test
+    fun savePlan_persistsPlan() = runBlocking {
+        val initialPlan = createPlan(deeper = false)
+        val updatedPlan = createPlan(deeper = true)
+
+        dataSource.savePlan(initialPlan)
+        dataSource.savePlan(updatedPlan)
+
+        val loaded = dataSource.loadPlan()
+        assertEquals(updatedPlan, loaded)
+    }
+
+    @Test
+    fun loadConfiguration_returnsNullWhenFileDoesNotExist() = runBlocking {
+        assertNull(dataSource.loadConfiguration())
+    }
+
+    @Test
+    fun loadConfiguration_returnsNullWhenFileContainsInvalidJson() = runBlocking {
+        fileSystem.createDirectories(planningDirectory)
+        fileSystem.write(planningDirectory / "configuration.json") {
+            writeUtf8("{ invalid json content }")
+        }
+
+        assertNull(dataSource.loadConfiguration())
+    }
+
+    @Test
+    fun saveConfiguration_persistsConfiguration() = runBlocking {
+        val configuration = createConfiguration()
+
+        dataSource.saveConfiguration(configuration)
+        val loaded = dataSource.loadConfiguration()
+
+        assertEquals(configuration, loaded)
+    }
+
+    private fun createPlan(deeper: Boolean = false) = MultiDivePlanInputModel.Default.copy(
+        dives = listOf(DivePlanInputModel.Default.copy(deeper = deeper))
+    ).toResource()
+
+    private fun createConfiguration() = Configuration().toResource()
+}

--- a/data/src/commonTest/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningRepositoryImplTest.kt
+++ b/data/src/commonTest/kotlin/org/neotech/app/abysner/data/diveplanning/PlanningRepositoryImplTest.kt
@@ -16,78 +16,205 @@ import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
-import org.neotech.app.abysner.data.diveplanning.resources.DivePlanInputResourceV1
+import org.neotech.app.abysner.data.diveplanning.resources.ConfigurationResourceV1
 import org.neotech.app.abysner.data.diveplanning.resources.MultiDivePlanInputResourceV1
 import org.neotech.app.abysner.data.getJson
 import org.neotech.app.abysner.data.setJson
+import org.neotech.app.abysner.domain.core.model.Configuration
+import org.neotech.app.abysner.domain.core.model.Cylinder
+import org.neotech.app.abysner.domain.core.model.DiveMode
+import org.neotech.app.abysner.domain.core.model.Gas
+import org.neotech.app.abysner.domain.diveplanning.model.DivePlanInputModel
+import org.neotech.app.abysner.domain.diveplanning.model.DiveProfileSection
+import org.neotech.app.abysner.domain.diveplanning.model.MultiDivePlanInputModel
+import org.neotech.app.abysner.domain.diveplanning.model.PlannedCylinderModel
 import org.neotech.app.abysner.domain.persistence.PersistenceRepository
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
+import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class PlanningRepositoryImplTest {
 
     @Test
-    fun init_migratesOldDivePlanToMultiDivePlan() = runBlocking {
-        val inMemoryPersistenceRepository = InMemoryPersistenceRepository()
+    fun init_loadsMultiDivePlanInputFromStorage() = runTest {
+        val dataSource = InMemoryPlanningDataSource()
+        // Create a non-default dive plan to later verify against.
+        val storedPlan = MultiDivePlanInputModel.Default.copy(
+            dives = listOf(DivePlanInputModel.Default, DivePlanInputModel.Default)
+        ).toResource()
+        dataSource.savePlan(storedPlan)
 
-        // Prepare in-memory old data state
-        val singleDive = DivePlanInputResourceV1(deeper = false, longer = false, cylinders = emptyList(), profile = emptyList())
-        inMemoryPersistenceRepository.updatePreferences { it.setJson(KEY_OLD, singleDive) }
+        val repository = PlanningRepositoryImpl(dataSource, InMemoryPersistenceRepository(), StandardTestDispatcher(testScheduler))
 
-        // Create the planning repository, this will trigger migration
-        PlanningRepositoryImpl(inMemoryPersistenceRepository)
+        val loaded = withTimeout(1.seconds) { repository.multiDivePlanInput.filterNotNull().first() }
 
-        // Wait for migration to finish (at most 1 second, there is no real IO)
-        val updatedPrefs = withTimeout(1_000) {
-            inMemoryPersistenceRepository.prefsFlow.first { !it.contains(KEY_OLD) }
-        }
-
-        // Check if new key exists, and if old key got removed
-        assertNotNull(updatedPrefs.getJson<MultiDivePlanInputResourceV1>(KEY_NEW))
-        assertFalse(updatedPrefs.contains(KEY_OLD))
+        assertEquals(storedPlan, loaded.toResource())
     }
 
     @Test
-    fun init_withCorruptOldDivePlan_removesOldKeyWithoutMigrating() = runBlocking {
-        val inMemoryPersistenceRepository = InMemoryPersistenceRepository()
+    fun init_loadsConfigurationFromStorage() = runTest {
+        val dataSource = InMemoryPlanningDataSource()
+        // Create a non-default configuration to later verify against.
+        val storedConfiguration = Configuration(altitude = 500.0).toResource()
+        dataSource.saveConfiguration(storedConfiguration)
 
-        // Prepare in-memory old data state (with corrupt JSON value)
-        inMemoryPersistenceRepository.updatePreferences { it[KEY_OLD] = "NOT_VALID_JSON" }
+        val repository = PlanningRepositoryImpl(dataSource, InMemoryPersistenceRepository(), StandardTestDispatcher(testScheduler))
 
-        // Create the planning repository, this will trigger migration
-        PlanningRepositoryImpl(inMemoryPersistenceRepository)
+        withTimeout(1.seconds) { repository.multiDivePlanInput.filterNotNull().first() }
 
-        // Wait for migration to finish (at most 1 second, there is no real IO)
-        val updatedPrefs = withTimeout(1_000) {
-            inMemoryPersistenceRepository.prefsFlow.first { !it.contains(KEY_OLD) }
+        assertEquals(storedConfiguration.toModel(), repository.configuration.value)
+    }
+
+    @Test
+    fun init_loadsDefaultPlanWhenNoStoredInput() = runTest {
+        val dataSource = InMemoryPlanningDataSource()
+        val repository = PlanningRepositoryImpl(dataSource, InMemoryPersistenceRepository(), StandardTestDispatcher(testScheduler))
+
+        val loaded = withTimeout(1.seconds) { repository.multiDivePlanInput.filterNotNull().first() }
+
+        assertEquals(MultiDivePlanInputModel.Default, loaded)
+    }
+
+    @Test
+    fun init_migratesPlanFromPreferencesWhenNoStoredInput() = runTest {
+        val dataSource = InMemoryPlanningDataSource()
+        val persistenceRepository = InMemoryPersistenceRepository()
+        val storedPlan = MultiDivePlanInputModel.Default.copy(
+            dives = listOf(DivePlanInputModel.Default, DivePlanInputModel.Default)
+        ).toResource()
+        persistenceRepository.updatePreferences {
+            it.setJson(PREFERENCE_KEY_LEGACY_PLAN, storedPlan)
         }
 
-        // Check that old key is removed and no new key was written
-        assertFalse(updatedPrefs.contains(KEY_OLD))
-        assertNull(updatedPrefs.getJson<MultiDivePlanInputResourceV1>(KEY_NEW))
+        val repository = PlanningRepositoryImpl(dataSource, persistenceRepository, StandardTestDispatcher(testScheduler))
+
+        val loaded = withTimeout(1.seconds) { repository.multiDivePlanInput.filterNotNull().first() }
+
+        assertEquals(storedPlan, loaded.toResource())
+        assertEquals(storedPlan, dataSource.loadPlan())
+        assertNull(persistenceRepository.preferencesFlow.value.getJson<MultiDivePlanInputResourceV1>(PREFERENCE_KEY_LEGACY_PLAN))
+    }
+
+    @Test
+    fun init_migratesConfigurationFromPreferences() = runTest {
+        val dataSource = InMemoryPlanningDataSource()
+        val persistenceRepository = InMemoryPersistenceRepository()
+        val legacyConfiguration = Configuration(altitude = 1000.0).toResource()
+        persistenceRepository.updatePreferences {
+            it.setJson<ConfigurationResourceV1>(PREFERENCE_KEY_LEGACY_CONFIGURATION, legacyConfiguration)
+        }
+
+        val repository = PlanningRepositoryImpl(dataSource, persistenceRepository, StandardTestDispatcher(testScheduler))
+
+        withTimeout(1.seconds) { repository.multiDivePlanInput.filterNotNull().first() }
+
+        assertEquals(legacyConfiguration.toModel(), repository.configuration.value)
+        assertEquals(legacyConfiguration, dataSource.loadConfiguration())
+        assertNull(persistenceRepository.preferencesFlow.value.getJson<ConfigurationResourceV1>(PREFERENCE_KEY_LEGACY_CONFIGURATION))
+    }
+
+    @Test
+    fun init_recomputesCylinderStateOnLoadedInput() = runTest {
+        val dataSource = InMemoryPlanningDataSource()
+        val cylinder = Cylinder.steel12Liter(gas = Gas.Air)
+        val storedPlan = MultiDivePlanInputModel(
+            dives = listOf(
+                DivePlanInputModel(
+                    diveMode = DiveMode.OPEN_CIRCUIT,
+                    deeper = false,
+                    longer = false,
+                    bailout = false,
+                    plannedProfile = listOf(DiveProfileSection(duration = 10, depthInMeters = 20.0, cylinder = cylinder)),
+                    // This is the only cylinder in the plan, so it should be marked as checked and locked when active in use.
+                    cylinders = listOf(PlannedCylinderModel(cylinder = cylinder, isChecked = false, isLocked = false)),
+                    surfaceIntervalBefore = null,
+                )
+            )
+        ).toResource()
+        dataSource.savePlan(storedPlan)
+
+        val repository = PlanningRepositoryImpl(dataSource, InMemoryPersistenceRepository(), StandardTestDispatcher(testScheduler))
+
+        val loaded = withTimeout(1.seconds) { repository.multiDivePlanInput.filterNotNull().first() }
+
+        val loadedCylinder = loaded.dives.first().cylinders.first()
+        assertTrue(loadedCylinder.isChecked)
+        assertTrue(loadedCylinder.isLocked)
+    }
+
+    @Test
+    fun updateMultiDivePlanInput_persistsToStorage() = runTest {
+        val dataSource = InMemoryPlanningDataSource()
+        val repository = PlanningRepositoryImpl(dataSource, InMemoryPersistenceRepository(), StandardTestDispatcher(testScheduler))
+        withTimeout(1.seconds) { repository.multiDivePlanInput.filterNotNull().first() }
+
+        repository.updateMultiDivePlanInput { it.updateDive(0) { copy(deeper = true) } }
+
+        advanceTimeBy(1001.milliseconds)
+        testScheduler.runCurrent()
+
+        assertEquals(true, dataSource.planFlow.value?.dives?.first()?.deeper)
+    }
+
+    @Test
+    fun updateConfiguration_persistsToStorage() = runTest {
+        val dataSource = InMemoryPlanningDataSource()
+        val repository = PlanningRepositoryImpl(dataSource, InMemoryPersistenceRepository(), StandardTestDispatcher(testScheduler))
+        withTimeout(1.seconds) { repository.multiDivePlanInput.filterNotNull().first() }
+
+        repository.updateConfiguration { it.copy(altitude = 500.0) }
+
+        advanceTimeBy(1001.milliseconds)
+        testScheduler.runCurrent()
+
+        assertEquals(500.0, dataSource.configurationFlow.value?.altitude)
     }
 }
 
-private val KEY_OLD = stringPreferencesKey("input.diveplan")
-private val KEY_NEW  = stringPreferencesKey("input.diveplan.multi.v1")
+private val PREFERENCE_KEY_LEGACY_CONFIGURATION = stringPreferencesKey("global.configuration")
+private val PREFERENCE_KEY_LEGACY_PLAN = stringPreferencesKey("input.diveplan.multi.v1")
+
+
+private class InMemoryPlanningDataSource : PlanningDataSource {
+
+    val configurationFlow = MutableStateFlow<ConfigurationResourceV1?>(null)
+    val planFlow = MutableStateFlow<MultiDivePlanInputResourceV1?>(null)
+
+    override suspend fun loadConfiguration(): ConfigurationResourceV1? = configurationFlow.value
+
+    override suspend fun saveConfiguration(configuration: ConfigurationResourceV1) {
+        configurationFlow.value = configuration
+    }
+
+    override suspend fun loadPlan(): MultiDivePlanInputResourceV1? = planFlow.value
+
+    override suspend fun savePlan(plan: MultiDivePlanInputResourceV1) {
+        planFlow.value = plan
+    }
+}
 
 private class InMemoryPersistenceRepository : PersistenceRepository {
 
-    val prefsFlow = MutableStateFlow(emptyPreferences())
+    val preferencesFlow = MutableStateFlow(emptyPreferences())
 
-    override fun getPreferences(): Flow<Preferences> = prefsFlow
+    override fun getPreferences(): Flow<Preferences> = preferencesFlow
 
     override suspend fun updatePreferences(update: (MutablePreferences) -> Unit) {
-        val mutable = prefsFlow.value.toMutablePreferences()
+        val mutable = preferencesFlow.value.toMutablePreferences()
         update(mutable)
-        prefsFlow.value = mutable
+        preferencesFlow.value = mutable
     }
 }
-

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/PlanningRepository.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/diveplanning/PlanningRepository.kt
@@ -20,9 +20,9 @@ interface PlanningRepository {
 
     val configuration: StateFlow<Configuration>
 
-    fun updateConfiguration(updateBlock: (Configuration) -> Configuration)
+    fun updateConfiguration(updateBlock: (Configuration) -> Configuration): Configuration
 
-    fun setMultiDivePlanInput(model: MultiDivePlanInputModel)
+    val multiDivePlanInput: StateFlow<MultiDivePlanInputModel?>
 
-    suspend fun getMultiDivePlanInput(): MultiDivePlanInputModel?
+    fun updateMultiDivePlanInput(updateBlock: (MultiDivePlanInputModel) -> MultiDivePlanInputModel): MultiDivePlanInputModel?
 }


### PR DESCRIPTION
Moves the dive planning input state from PlanScreenViewModel into PlanningRepository. Also migrates away from DataStore preferences into dedicated JSON files via PlanningFileDataSource, preventing unrelated preference changes from interfering with planning input flows.