### PR TITLE
Fix: Modal bottom-sheet jitter when dragging to dismiss

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/bottomsheet/ModalBottomSheetScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/org/neotech/app/abysner/presentation/component/bottomsheet/ModalBottomSheetScaffold.kt
@@ -14,12 +14,25 @@ package org.neotech.app.abysner.presentation.component.bottomsheet
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
+/**
+ * Column of [header] plus scrollable [content], capped to leave [topClearance] clear above the
+ * sheet. Content taller than that scrolls instead of growing the sheet further, which keeps a
+ * [androidx.compose.material3.ModalBottomSheet] from wrapping to a height close enough to the
+ * screen's to hunt between wrapping and covering the status bar.
+ */
 @Composable
 fun ModalBottomSheetScaffold(
     modifier: Modifier = Modifier,
@@ -27,10 +40,15 @@ fun ModalBottomSheetScaffold(
     content: @Composable BoxScope.() -> Unit
 ) {
     val scrollState = rememberScrollState()
-    Column(modifier) {
-        header()
-        Box(Modifier.verticalScroll(scrollState)) {
-            content()
+    val topClearance = WindowInsets.safeDrawing.only(WindowInsetsSides.Top)
+        .asPaddingValues()
+        .calculateTopPadding()
+    BoxWithConstraints(modifier) {
+        Column(Modifier.heightIn(max = maxHeight - topClearance)) {
+            header()
+            Box(Modifier.weight(1f, fill = false).verticalScroll(scrollState)) {
+                content()
+            }
         }
     }
 }


### PR DESCRIPTION
When a modal bottom sheet is nearly full screen, dragging downward to dismiss causes layout jitter. Limiting the sheet height to stop below the status bar avoids the issue and keeps taller content normally scrollable/draggable.