### PR TITLE
Fix: Gas fraction validation rejecting valid non-nitrogen (Heliox) mixes

### DIFF
--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/core/model/Gas.kt
@@ -20,8 +20,14 @@ import kotlin.math.round
 data class Gas(val oxygenFraction: Double, val heliumFraction: Double) {
 
     init {
-        if((oxygenFraction + heliumFraction) > 1.0) {
-            error("Oxygen ($oxygenFraction) and helium ($heliumFraction) fraction add up to more then 1.0!")
+        require(oxygenFraction >= 0.0) {
+            "Invalid oxygen fraction `$oxygenFraction`. Must not be negative."
+        }
+        require(heliumFraction >= 0.0) {
+            "Invalid helium fraction `$heliumFraction`. Must not be negative."
+        }
+        require((oxygenFraction + heliumFraction) <= 1.0) {
+            "Invalid gas mix `$oxygenFraction/$heliumFraction`. Oxygen and helium fractions should together not exceed 1.0."
         }
     }
 

--- a/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
+++ b/domain/src/commonMain/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/Buhlmann.kt
@@ -227,10 +227,15 @@ data class TissueCompartment(
             "Invalid duration `$timeInMinutes` for on/off-gassing tissues. The minimum duration must be higher than 0."
         }
 
-        // Calculate nitrogen fraction (by just subtracting oxygen and helium)
-        val fN2 = (1.0 - fO2) - fHe
+        require(fO2 >= 0.0) {
+            "Invalid oxygen fraction `$fO2`. Must not be negative."
+        }
+        require(fHe >= 0.0) {
+            "Invalid helium fraction `$fHe`. Must not be negative."
+        }
+        val fN2 = 1.0 - (fO2 + fHe)
         require(fN2 >= 0.0) {
-            "Invalid gas mix `$fO2/$fHe` for on/off-gassing tissues, oxygen and helium should together never exceed 1.0 (100% of the gas mix)."
+            "Invalid gas mix `$fO2/$fHe`. Oxygen and helium fractions should together not exceed 1.0."
         }
 
         val depthChangeInBarsPerMinute = pressureChangeInBarsPerMinute(startPressure, endPressure, timeInMinutes)

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/core/model/GasTest.kt
@@ -22,10 +22,39 @@ import kotlin.math.floor
 class GasTest {
 
     @Test
-    fun init_rejectsGasWhenCombinedOxygenAndHeliumFractionsExceedOneHundredPercent() {
-        assertFailsWith<IllegalStateException> {
+    fun init_rejectsWhenOxygenAndHeliumSumExceedsOne() {
+        assertFailsWith<IllegalArgumentException> {
             Gas(oxygenFraction = 0.8, heliumFraction = 0.3)
         }
+    }
+
+    @Test
+    fun init_rejectsNegativeOxygenFraction() {
+        assertFailsWith<IllegalArgumentException> {
+            Gas(oxygenFraction = -0.1, heliumFraction = 0.0)
+        }
+    }
+
+    @Test
+    fun init_rejectsNegativeHeliumFraction() {
+        assertFailsWith<IllegalArgumentException> {
+            Gas(oxygenFraction = 0.21, heliumFraction = -0.1)
+        }
+    }
+
+    @Test
+    fun init_acceptsPureOxygen() {
+        Gas(oxygenFraction = 1.0, heliumFraction = 0.0)
+    }
+
+    @Test
+    fun init_acceptsPureHelium() {
+        Gas(oxygenFraction = 0.0, heliumFraction = 1.0)
+    }
+
+    @Test
+    fun init_acceptsGasMixThatSumsToOne() {
+        Gas(oxygenFraction = 0.89, heliumFraction = 0.11)
     }
 
     @Test

--- a/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannTest.kt
+++ b/domain/src/commonTest/kotlin/org/neotech/app/abysner/domain/decompression/algorithm/buhlmann/BuhlmannTest.kt
@@ -20,7 +20,6 @@ class BuhlmannTest {
         // These settings kinda mimic the US Navy/PADI tables. What we use doesn't really matter for
         // this test, but this gives us something to compare against that is relatively well known.
         // There is no real comparing between Buhlmann and Navy tables, but this will make it close.
-        val environment = Environment.SeaLevelSalt
         val model = Buhlmann(
             version = Buhlmann.Version.ZH16C,
             environment = environment,
@@ -53,7 +52,6 @@ class BuhlmannTest {
         // interpolation. Because the ratchet is monotonic and is applied before the return value
         // is computed within the same call, the result must be identical on every subsequent call
         // as long as no tissue loading has changed.
-        val environment = Environment.SeaLevelSalt
         val model = Buhlmann(
             version = Buhlmann.Version.ZH16C,
             environment = environment,
@@ -72,7 +70,6 @@ class BuhlmannTest {
 
     @Test
     fun reset_snapshotIsNotMutatedByLaterTissueLoading() {
-        val environment = Environment.SeaLevelSalt
         val model = Buhlmann(
             version = Buhlmann.Version.ZH16C,
             environment = environment,
@@ -96,7 +93,6 @@ class BuhlmannTest {
 
     @Test
     fun addPressureChange_throwsForZeroDuration() {
-        val environment = Environment.SeaLevelSalt
         val model = Buhlmann(
             version = Buhlmann.Version.ZH16C,
             environment = environment,
@@ -104,10 +100,79 @@ class BuhlmannTest {
             gfHigh = 0.7,
         )
         val depth = metersToAmbientPressure(21.0, environment)
-        assertFailsWith<IllegalArgumentException>(
-            message = "Expected IllegalArgumentException for timeInMinutes=0"
-        ) {
+        assertFailsWith<IllegalArgumentException> {
             model.addPressureChange(depth, depth, Gas.Nitrox50, timeInMinutes = 0)
         }
+    }
+
+    @Test
+    fun addPressureChange_throwsForOxygenFractionAboveOne() {
+        val compartment = TissueCompartment(parameters = compartmentParameters, environment = environment)
+        val depth = metersToAmbientPressure(21.0, environment)
+        assertFailsWith<IllegalArgumentException> {
+            compartment.addPressureChange(depth.value, depth.value, fO2 = 1.1, fHe = 0.0, timeInMinutes = 1.0)
+        }
+    }
+
+    @Test
+    fun addPressureChange_throwsForOxygenFractionBelowZero() {
+        val compartment = TissueCompartment(parameters = compartmentParameters, environment = environment)
+        val depth = metersToAmbientPressure(21.0, environment)
+        assertFailsWith<IllegalArgumentException> {
+            compartment.addPressureChange(depth.value, depth.value, fO2 = -0.01, fHe = 0.0, timeInMinutes = 1.0)
+        }
+    }
+
+    @Test
+    fun addPressureChange_throwsForHeliumFractionAboveOne() {
+        val compartment = TissueCompartment(parameters = compartmentParameters, environment = environment)
+        val depth = metersToAmbientPressure(21.0, environment)
+        assertFailsWith<IllegalArgumentException> {
+            compartment.addPressureChange(depth.value, depth.value, fO2 = 0.0, fHe = 1.1, timeInMinutes = 1.0)
+        }
+    }
+
+    @Test
+    fun addPressureChange_throwsForHeliumFractionBelowZero() {
+        val compartment = TissueCompartment(parameters = compartmentParameters, environment = environment)
+        val depth = metersToAmbientPressure(21.0, environment)
+        assertFailsWith<IllegalArgumentException> {
+            compartment.addPressureChange(depth.value, depth.value, fO2 = 0.0, fHe = -0.01, timeInMinutes = 1.0)
+        }
+    }
+
+    @Test
+    fun addPressureChange_throwsWhenOxygenAndHeliumSumExceedsOne() {
+        val compartment = TissueCompartment(parameters = compartmentParameters, environment = environment)
+        val depth = metersToAmbientPressure(21.0, environment)
+        assertFailsWith<IllegalArgumentException> {
+            compartment.addPressureChange(depth.value, depth.value, fO2 = 0.7, fHe = 0.5, timeInMinutes = 1.0)
+        }
+    }
+
+    @Test
+    fun addPressureChange_acceptsPureOxygen() {
+        val compartment = TissueCompartment(parameters = compartmentParameters, environment = environment)
+        val depth = metersToAmbientPressure(3.0, environment)
+        compartment.addPressureChange(depth.value, depth.value, fO2 = 1.0, fHe = 0.0, timeInMinutes = 1.0)
+    }
+
+    @Test
+    fun addPressureChange_acceptsPureHelium() {
+        val compartment = TissueCompartment(parameters = compartmentParameters, environment = environment)
+        val depth = metersToAmbientPressure(40.0, environment)
+        compartment.addPressureChange(depth.value, depth.value, fO2 = 0.0, fHe = 1.0, timeInMinutes = 1.0)
+    }
+
+    @Test
+    fun addPressureChange_acceptsHeliox() {
+        val compartment = TissueCompartment(parameters = compartmentParameters, environment = environment)
+        val depth = metersToAmbientPressure(3.0, environment)
+        compartment.addPressureChange(depth.value, depth.value, fO2 = 0.89, fHe = 0.11, timeInMinutes = 1.0)
+    }
+
+    companion object {
+        private val compartmentParameters = CompartmentParameters(5.0, 1.1696, 0.5578, 1.88, 1.6189, 0.4770)
+        private val environment = Environment.SeaLevelSalt
     }
 }


### PR DESCRIPTION
`TissueCompartment.addPressureChange` computed the nitrogen fraction in a way that could introduce rounding errors, causing it to reject valid gas mixtures like 89/11. Gas had the same issue and received the same fix. This commit also aligns the boundary checks in both places to behave similarly.